### PR TITLE
Add Notepad++ & ComparePlus plugin

### DIFF
--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -693,7 +693,7 @@ function VM-Add-To-Right-Click-Menu {
     }
     Set-ItemProperty -LiteralPath "HKCR:\$key\shell\$menuKey\command" -Name '(Default)' -Value $command -Type String
   } catch {
-    FE-Write-Log "ERROR" "Failed to add $menuKey to right-click menu"
+    VM-Write-Log "ERROR" "Failed to add $menuKey to right-click menu"
   }
 }
 
@@ -724,6 +724,6 @@ function VM-Remove-From-Right-Click-Menu {
       Remove-Item -LiteralPath "HKCR:\$key\shell\$menuKey" -Recurse
     }
   } catch {
-    FE-Write-Log "ERROR" "Failed to remove $menuKey from right-click menu"
+    VM-Write-Log "ERROR" "Failed to remove $menuKey from right-click menu"
   }
 }

--- a/packages/notepadpp.plugin.compare.vm/notepadplusplus.vm.nuspec
+++ b/packages/notepadpp.plugin.compare.vm/notepadplusplus.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>notepadpp.plugin.compare.vm</id>
+    <version>2.0.1</version>
+    <description>ComparePlus plugin for Notepad++</description>
+    <authors>Pavel Nedev</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="notepadpp.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/notepadpp.plugin.compare.vm/tools/chocolateyinstall.ps1
+++ b/packages/notepadpp.plugin.compare.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = "ComparePlugin"
+  $pluginsDir= Join-Path ${Env:ProgramFiles} "Notepad++\plugins" -Resolve
+  $toolDir = New-Item (Join-Path $pluginsDir $toolName) -itemtype directory
+  VM-Assert-Path $toolDir
+
+  $zipUrl= "https://github.com/pnedev/compare-plugin/releases/download/v2.0.1/ComparePlugin_v2.0.1_x86.zip"
+  $zipSha256 ="07972c1c7e3012a46ac6ef133a6500ca851bddc9c83471df2f118519a0241ed5"
+  $zipUrl_64 = "https://github.com/pnedev/compare-plugin/releases/download/v2.0.1/ComparePlugin_v2.0.1_X64.zip"
+  $zipSha256_64 ="77dedf98ea2280528d726c0053db2001e90da7588e14ee01a98933f121bb15cb"
+
+  # Download and unzip
+  $packageArgs = @{
+    packageName    = ${Env:ChocolateyPackageName}
+    unzipLocation  = $toolDir
+    url            = $zipUrl
+    checksum       = $zipSha256
+    checksumType   = 'sha256'
+    url64bit       = $zipUrl_64
+    checksum64     = $zipSha256_64
+  }
+  Install-ChocolateyZipPackage @packageArgs
+  VM-Assert-Path (Join-Path $toolDir "$toolName.dll")
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/notepadpp.plugin.compare.vm/tools/chocolateyuninstall.ps1
+++ b/packages/notepadpp.plugin.compare.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Continue'
+
+$toolDir = Join-Path ${Env:ProgramFiles} "Notepad++\plugins\ComparePlugin"
+Remove-Item $toolDir -Recurse -Force -ea 0

--- a/packages/notepadpp.vm/notepadplusplus.vm.nuspec
+++ b/packages/notepadpp.vm/notepadplusplus.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>notepadpp.vm</id>
+    <version>8.1.9.3</version>
+    <description>Wrapper for Notepad++</description>
+    <authors>Don Ho</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="notepadplusplus" version="[8.1.9.3]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/notepadpp.vm/tools/chocolateyinstall.ps1
+++ b/packages/notepadpp.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  # Path to Notepad++'s configuration file
+  $configFile = Join-Path ${Env:APPDATA} "Notepad++\config.xml"
+
+  if (-Not (Test-Path -Path $configFile)) {
+    # Launch Notepad++
+    Start-Process "notepad++"
+    Start-Sleep -Seconds 2
+
+    # Try to gracefully close it so that it can create it's config.xml
+    # Give it a little time in case it's slow
+    foreach ($item in "0", "1") {
+      $notepad = Get-Process -Name "notepad++" -ErrorAction SilentlyContinue
+      if ($notepad -ne $null) {
+        $notepad | ForEach-Object {$_.CloseMainWindow() | Out-Null}
+      }
+      Start-Sleep -Seconds 2
+    }
+  }
+
+  if (-Not (Test-Path -Path $configFile)) {
+    VM-Write-Log "WARN" "Can't find config.xml to modify"
+  } else {
+    # Update the config file and disable auto-updates
+    (Get-Content -Path $configFile) -Replace '("noUpdate".*?">)no', '$1yes' | Set-Content -Path $configFile -Force | Out-Null
+  }
+} catch {
+  VM-Write-Log-Exception $_
+}


### PR DESCRIPTION
`notepadplusplus.vm` is a wrapper for the community package `notepadplusplus` that updates the config file and disable auto-updates. The original package I have migrated had an uninstaller that reenabled the updates. But we can't really know if they were enabled before installing the package (in case Notepad++ was already installed) and we keep Notepad++ that may not have been installed (as it is installed by the dependency). So I would suggest to keep things simple and do not provide an uninstaller in this case. Any concerns with this?

I have also added a `notepadplusplus-compare.vm` package to install the ComparePlus plugin for Notepad++ that I like to use.