### PR TITLE
Do not check hash for updates with same URL

### DIFF
--- a/packages/bloodhound.vm/bloodhound.vm.nuspec
+++ b/packages/bloodhound.vm/bloodhound.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound.vm</id>
-    <version>3.0.2.0</version>
+    <version>3.0.2.20220113</version>
     <description>BloodHound uses graph theory to reveal the hidden and often unintended relationships within an Active Directory environment.</description>
     <authors>Andrew Robbins, Rohan Vazarkar, Will Schroeder</authors>
     <dependencies>

--- a/packages/bloodhound.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Information Gathering'
 $zipUrl = "https://github.com/BloodHoundAD/BloodHound/releases/download/3.0.2/BloodHound-win32-ia32.zip"
 $zipSha256 = "F80352D7F6C1EAAC75EA3D252605A5B5E193683FBF743B40694A2D65E4A80537"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true

--- a/packages/capa.vm/capa.vm.nuspec
+++ b/packages/capa.vm/capa.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>capa.vm</id>
-    <version>1.6.3</version>
+    <version>1.6.3.20220113</version>
     <description>capa detects capabilities in executable files. You run it against a PE file or shellcode and it tells you what it thinks the program can do.</description>
     <authors>@williballenthin, @mr-tz, @Ana06, @mike-hunhoff, @mwilliams31, @MalwareMechanic</authors>
     <dependencies>

--- a/packages/capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/capa.vm/tools/chocolateyinstall.ps1
@@ -7,5 +7,5 @@ $category = 'Utilities'
 $zipUrl = "https://github.com/mandiant/capa/releases/download/v1.6.3/capa-v1.6.3-windows.zip"
 $zipSha256 = "00e8d32941b3a1a58a164efc38826099fd70856156762647c4bbd9e946e41606"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -consoleApp $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true
 

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>3.0.1</version>
+    <version>0.0.0.20220113</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -482,11 +482,11 @@ function VM-Install-From-Zip {
     [string] $category,
     [Parameter(Mandatory=$true, Position=2)]
     [string] $zipUrl,
-    [Parameter(Mandatory=$true, Position=3)]
+    [Parameter(Mandatory=$false)]
     [string] $zipSha256,
-    [Parameter(Mandatory=$false, Position=4)]
+    [Parameter(Mandatory=$false)]
     [string] $zipUrl_64,
-    [Parameter(Mandatory=$false, Position=5)]
+    [Parameter(Mandatory=$false)]
     [string] $zipSha256_64,
     [Parameter(Mandatory=$false)]
     [bool] $consoleApp=$false,

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.02</version>
+    <version>3.02.20220113</version>
     <authors>Hellsp@wn, horsicq</authors>
     <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
     <dependencies>

--- a/packages/die.vm/tools/chocolateyinstall.ps1
+++ b/packages/die.vm/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ try {
   $zipUrl_64 = 'https://github.com/horsicq/DIE-engine/releases/download/3.02/die_win64_portable_3.02.zip'
   $zipSha256_64 = '1ffd192e0f8120691e5c2c018c05245c6761d8aa01695807257044c82a676f27'
 
-  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 $zipUrl_64 $zipSha256_64 -innerFolder $true)[-1]
+  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -zipUrl_64 $zipUrl_64 -zipSha256_64 $zipSha256_64 -innerFolder $true)[-1]
   VM-Add-To-Right-Click-Menu $toolName "detect it easy (DIE)" "`"$executablePath`" `"%1`"" "file"
 } catch {
   VM-Write-Log-Exception $_

--- a/packages/explorersuite.vm/explorersuite.vm.nuspec
+++ b/packages/explorersuite.vm/explorersuite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>explorersuite.vm</id>
-    <version>0.0.0.20211118</version>
+    <version>0.0.0.20220113</version>
     <authors>Erik Pistelli</authors>
     <description>A suite of tools including CFF Explorer and a process viewer.</description>
     <dependencies>

--- a/packages/explorersuite.vm/tools/chocolateyinstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,6 @@ try {
   $category = 'Utilities'
 
   $url = "https://ntcore.com/files/ExplorerSuite.exe"
-  $checksum = "94f4348ec573b05990b1e19542986e46dc30a87870739f5d5430b60072d5144d"
 
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} 'Explorer Suite'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
@@ -14,8 +13,6 @@ try {
     packageName   = ${Env:ChocolateyPackageName}
     fileType      = 'EXE'
     url           = $url
-    checksum      = $checksum
-    checksumType  = 'sha256'
     silentArgs    = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR=`"$toolDir`""
   }
   Install-ChocolateyPackage @packageArgs

--- a/packages/flare-floss.vm/flare-floss.vm.nuspec
+++ b/packages/flare-floss.vm/flare-floss.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>floss.vm</id>
-    <version>1.7.0</version>
+    <version>1.7.0.20220113</version>
     <description>FLOSS uses advanced static analysis techniques to automatically deobfuscate strings from malware binaries. You can use it just like strings.exe to enhance basic static analysis of unknown binaries.</description>
     <authors>@williballenthin, @mr-tz</authors>
     <dependencies>

--- a/packages/flare-floss.vm/tools/chocolateyinstall.ps1
+++ b/packages/flare-floss.vm/tools/chocolateyinstall.ps1
@@ -7,5 +7,5 @@ $category = 'Utilities'
 $zipUrl = "https://github.com/mandiant/flare-floss/releases/download/v1.7.0/floss-v1.7.0-windows.zip"
 $zipSha256 = "9b433a949b210bb8a856de2546cb075c349e0c2582ee9bf6b5fe51d9f95e7690"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -consoleApp $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true
 

--- a/packages/gobuster.vm/gobuster.vm.nuspec
+++ b/packages/gobuster.vm/gobuster.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gobuster.vm</id>
-    <version>3.0.1</version>
+    <version>3.0.1.20220113</version>
     <description>Directory/file and DNS busting tool written in Go</description>
     <authors>OJ Reeves</authors>
     <dependencies>

--- a/packages/gobuster.vm/tools/chocolateyinstall.ps1
+++ b/packages/gobuster.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Information Gathering'
 $zipUrl = "https://github.com/OJ/gobuster/releases/download/v3.0.1/gobuster-windows-386.7z"
 $zipSha256 = "824D8B306FA7D7C40CF1C131F4749024D855EC85DB96D914D4EF8EDB5B0F5DCF"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -consoleApp $true -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>2.42</version>
+    <version>0.0.0.20220113</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>

--- a/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
@@ -6,11 +6,9 @@ try {
   $category = 'Utilities'
 
   $zipUrl = "https://www.nirsoft.net/utils/hashmyfiles.zip"
-  $zipSha256 = "89db49ec6a3e50f1d76da97ac1289272d1b09b9a330d36f65fdbe1f010f1ae8b"
   $zipUrl_64 = "https://www.nirsoft.net/utils/hashmyfiles-x64.zip"
-  $zipSha256_64 = "be2dc5b9613b72ca44e60b7a1b5332593a868079638ded37cc3ad120e7182b0b"
 
-  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 $zipUrl_64 $zipSha256_64)[-1]
+  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipUrl_64 $zipUrl_64)[-1]
   VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "file"
   VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "directory"
 } catch {

--- a/packages/peid.vm/peid.vm.nuspec
+++ b/packages/peid.vm/peid.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>peid.vm</id>
-    <version>0.95.0.20081103</version>
+    <version>0.95.0.20220113</version>
     <description>PEiD detects most common packers, cryptors and compilers for PE files.</description>
     <authors>snaker, Qwerton, Jibz, xineohP</authors>
     <dependencies>

--- a/packages/peid.vm/tools/chocolateyinstall.ps1
+++ b/packages/peid.vm/tools/chocolateyinstall.ps1
@@ -7,5 +7,5 @@ $category = 'Utilities'
 $zipUrl = "https://codeload.github.com/wolfram77web/app-peid/zip/91b0057697fb143205a6071a4482e7ad1ff37e12"
 $zipSha256 = "04cec2d03338a52f540b88b9fe4dff5922888beb9a3eea4a23308850400c9ee5"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true
 

--- a/packages/uniextract2.vm/tools/chocolateyinstall.ps1
+++ b/packages/uniextract2.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Utilities'
 $zipUrl = "https://github.com/Bioruebe/UniExtract2/releases/download/v2.0.0-rc.3/UniExtractRC3.zip"
 $zipSha256 = "03170680b80f2afdf824f4d700c11b8e2dac805a4d9bd3d24f53e43bd7131c3a"
 
-VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true

--- a/packages/uniextract2.vm/uniextract2.vm.nuspec
+++ b/packages/uniextract2.vm/uniextract2.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>uniextract2.vm</id>
-    <version>2.0.0.5</version>
+    <version>2.0.0.20220113</version>
     <description>Universal Extractor 2 is an unofficial updated and extended version of the original UniExtract by Jared Breland.</description>
     <authors>William Engelmann (Bioruebe)</authors>
     <dependencies>


### PR DESCRIPTION
Some projects use the same download URL for all versions of the package. This causes that the hash changes and the package breaks. Ignore checksums for these packages.

Note we are already not checking hashes for all installed software. We currently do something similar for some Python libraries. We should make clear in the project documentation that there is no guarantee the packages are benign. These packages are intended to be used to analyze malware that may be inherently dangerous.