### PR TITLE
Remove annoying download progress percentages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
           choco install common.vm -s .
           foreach ($package in $built_pkgs) {
-              choco install $package -s "'.;https://community.chocolatey.org/api/v2/'"
+              choco install $package -s "'.;https://community.chocolatey.org/api/v2/'" --no-progress
               if ($validExitCodes -notcontains $LASTEXITCODE) { Exit 1 } # Abort with the first failing install
           }
           Exit 0


### PR DESCRIPTION
Remove annoying download progress percentages from GH actions log.

![Screenshot 2021-12-20 at 20 57 37](https://user-images.githubusercontent.com/16052290/146825204-413619ec-ff1e-4af0-a2cd-fd6b180ca68b.png)