### PR TITLE
Upload Chocolatey logs as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,12 @@ jobs:
           foreach ($package in $built_pkgs) {
               cpush -s "https://www.myget.org/F/vm-packages/api/v2" -k ${{ secrets.MYGET_TOKEN }} $package
           }
+      - name: Upload chocolatey logs to artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: logs-${{ matrix.os }}.zip
+          path: |
+            C:\ProgramData\chocolatey\logs\chocolatey.log
+            C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt
+            C:\ProgramData\_VM\log.txt


### PR DESCRIPTION
Upload the Chocolatey logs as they can be useful to debug errors.
![Screen Shot 2022-02-21 at 18 44 58](https://user-images.githubusercontent.com/16052290/155004897-0bfaaa31-0454-4b7c-8185-e412fbfbb9cf.png)

