### PR TITLE
Improve libraries.python packages and fix test suite 🎉 

### DIFF
--- a/packages/libraries.python2.vm/libraries.python2.vm.nuspec
+++ b/packages/libraries.python2.vm/libraries.python2.vm.nuspec
@@ -6,14 +6,12 @@
     <description>Metapackage that requires the dependencies below:
 - vcbuildtools.vm
 - python2
-- python3
 </description>
     <authors>Mandiant, Microsoft, Python Software Foundation</authors>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="vcbuildtools.vm" />
       <dependency id="python2" />
-      <dependency id="python3" version="[3.7.0, 3.8.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/libraries.python2.vm/libraries.python2.vm.nuspec
+++ b/packages/libraries.python2.vm/libraries.python2.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python2.vm</id>
-    <version>0.0.0.20210603</version>
+    <version>0.0.0.20220221</version>
     <description>Metapackage that requires the dependencies below:
 - vcbuildtools.vm
 - python2

--- a/packages/libraries.python2.vm/tools/packages.json
+++ b/packages/libraries.python2.vm/tools/packages.json
@@ -1,22 +1,23 @@
 {
   "packages": [
-    {"name": "hexdump"},
-    {"name": "pefile"},
-    {"name": "winappdbg"},
-    {"name": "pycryptodome"},
     {"name": "capstone-windows"},
-    {"name": "unicorn"},
-    {"name": "oletools"},
-    {"name": "olefile"}, 
-    {"name": "unpy2exe"},
-    {"name": "pyftpdlib"},
-    {"name": "pyasn1"},
-    {"name": "pyOpenSSL"},
+    {"name": "hexdump"},
     {"name": "ldapdomaindump"},
+    {"name": "msoffcrypto-tool"},
+    {"name": "olefile"},
+    {"name": "oletools"},
+    {"name": "pefile"},
+    {"name": "pyasn1"},
+    {"name": "pycryptodome"},
+    {"name": "pyftpdlib"},
     {"name": "pyreadline"},
-    {"name": "flask"},
-    {"name": "networkx"},
+    {"name": "pyOpenSSL"},
     {"name": "requests"},
-    {"name": "msoffcrypto-tool"}
+    {"name": "uncompyle6"},
+    {"name": "unpy2exe"},
+    {"name": "unicorn"},
+    {"name": "vivisect"},
+    {"name": "winappdbg"}
   ]
 }
+

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -5,14 +5,12 @@
     <version>0.0.0.20210603</version>
     <description>Metapackage that requires the dependencies below:
 - vcbuildtools.vm
-- python2
 - python3
 </description>
     <authors>Mandiant, Microsoft, Python Software Foundation</authors>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="vcbuildtools.vm" />
-      <dependency id="python2" />
       <dependency id="python3" version="[3.7.0, 3.8.0)" />
     </dependencies>
   </metadata>

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20210603</version>
+    <version>0.0.0.20220221</version>
     <description>Metapackage that requires the dependencies below:
 - vcbuildtools.vm
 - python3

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -11,7 +11,7 @@
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="vcbuildtools.vm" />
-      <dependency id="python3" version="[3.7.0, 3.8.0)" />
+      <dependency id="python3" version="[3.9.0, 3.10.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -19,7 +19,7 @@ function InstallOneModule {
   } else {
     $url = $module.url
   }
-  iex "py -3 -m pip install $url 2>&1 >> $outputFile"
+  iex "py -3.9 -m pip install $url 2>&1 >> $outputFile"
   return $LastExitCode
 }
 
@@ -37,7 +37,7 @@ try {
   $outputFile = VM-New-Install-Log $toolDir
 
   # upgrade pip
-  iex "py -3 -m pip install --no-cache-dir --upgrade pip 2>&1 >> $outputFile"
+  iex "py -3.9 -m pip install --no-cache-dir --upgrade pip 2>&1 >> $outputFile"
 
   $packages = $json.packages
   $success = $true

--- a/packages/libraries.python3.vm/tools/packages.json
+++ b/packages/libraries.python3.vm/tools/packages.json
@@ -16,10 +16,7 @@
       "name": "binwalk",
       "url": "https://github.com/ReFirmLabs/binwalk/archive/master.zip"
     },
-    {
-      "name":"vivisect",
-      "url": "https://github.com/williballenthin/vivisect/zipball/master"
-    },
+    {"name": "vivisect"},
     {"name": "unicorn"},
     {"name": "requests"},
     {"name": "yara-python"},

--- a/packages/libraries.python3.vm/tools/packages.json
+++ b/packages/libraries.python3.vm/tools/packages.json
@@ -1,25 +1,29 @@
 {
   "packages": [
-    {"name": "hexdump"},
-    {"name": "pycryptodome"},
-    {"name": "oletools"},
-    {"name": "olefile"},
-    {"name": "msoffcrypto-tool"},
-    {"name": "unpy2exe"},
-    {"name": "uncompyle6"},
-    {"name": "pyftpdlib"},
-    {"name": "pyasn1"},
-    {"name": "pyOpenSSL"},
     {"name": "acefile"},
-    {"name": "stringsifter"},
     {
       "name": "binwalk",
       "url": "https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"
     },
-    {"name": "vivisect"},
-    {"name": "unicorn"},
+    {"name": "capstone-windows"},
+    {"name": "hexdump"},
+    {"name": "ldapdomaindump"},
+    {"name": "mkyara"},
+    {"name": "msoffcrypto-tool"},
+    {"name": "olefile"},
+    {"name": "oletools"},
+    {"name": "pefile"},
+    {"name": "pyasn1"},
+    {"name": "pycryptodome"},
+    {"name": "pyftpdlib"},
+    {"name": "pyreadline"},
+    {"name": "pyOpenSSL"},
     {"name": "requests"},
-    {"name": "yara-python"},
-    {"name": "mkyara"}
+    {"name": "stringsifter"},
+    {"name": "uncompyle6"},
+    {"name": "unpy2exe"},
+    {"name": "unicorn"},
+    {"name": "vivisect"},
+    {"name": "yara-python"}
   ]
 }

--- a/packages/libraries.python3.vm/tools/packages.json
+++ b/packages/libraries.python3.vm/tools/packages.json
@@ -14,7 +14,7 @@
     {"name": "stringsifter"},
     {
       "name": "binwalk",
-      "url": "https://github.com/ReFirmLabs/binwalk/archive/master.zip"
+      "url": "https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"
     },
     {"name": "vivisect"},
     {"name": "unicorn"},


### PR DESCRIPTION
Currently the test suite is broken because a version higher than Python 3.9 was already installed (GH actions include several versions of Python in the tools cache directory including Python 3.10.1) and stringsifter doesn't work in Python > 3.9 (as current last version of scikit-learn doesn't support Python 10). Ensure pip uses the correct Python version to fix this problem.

In addition, the following improvements are included in this PR:
- Do not install Python 3 in the Python 2 libraries package and vice versa
- Use library from pip when possible
- Use a fixed version when getting library from GitHub
- Sort Python libraries alphabetically and try to install same packages in
Python 2 and 3.
- Remove flask and networkx as they don't seem to be malware analysis related. Please speak up if you disagree.

Closes https://github.com/mandiant/VM-Packages/issues/1