### PR TITLE
Remove windows-2016 from GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -16,7 +16,7 @@ jobs:
         run: scripts/lint.ps1
 
   check_nuspec:
-    runs-on: windows-2016
+    runs-on: windows-2019
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019, windows-2022]
+        os: [windows-2019, windows-2022]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, windows-2019, windows-2022]
+        os: [windows-2019, windows-2022]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The Windows 2016 runner image will be removed from GitHub-hosted runners
on March 15, 2022:
https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022