### PR TITLE
Upload Chocolatey logs in daily run

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -41,3 +41,12 @@ jobs:
               if ($validExitCodes -notcontains $LASTEXITCODE) { Exit 1 } # Abort with the first failing install
           }
           Exit 0
+      - name: Upload chocolatey logs to artifacts
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: logs-${{ matrix.os }}.zip
+          path: |
+            C:\ProgramData\chocolatey\logs\chocolatey.log
+            C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt
+            C:\ProgramData\_VM\log.txt


### PR DESCRIPTION
Upload the Chocolatey logs as artifacts in the daily run. I forgot this on https://github.com/mandiant/VM-Packages/pull/22.

This may help with https://github.com/mandiant/VM-Packages/issues/41.

I don't like the duplication in both actions, but I can't come up with a better way to do this. We could move the log paths to a file if we find ourselves modifying this often, but by now let's leave like it is.