### PR TITLE
Fix daily run

### DIFF
--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -26,7 +26,7 @@ $built_pkgs_dir = New-Item -ItemType Directory -Force $built_pkgs_dir_name
 if ($package_names) {
     $packages = $package_names.Split(" ")
 } else {
-    $packages = Get-ChildItem -Path $packages_dir_name
+    $packages = Get-ChildItem -Path $packages_dir_name | Select-Object Name
 }
 
 foreach ($package in $packages) {


### PR DESCRIPTION
We are constructing paths like the following because we assign the variable `$packages` paths instead of names:
`'D:\a\VM-Packages\VM-Packages\packages\D:\a\VM-Packages\VM-Packages\packages\010editor.vm'`

Note this doesn't fail in the CI run because we provide a list of names.