### PR TITLE
Do no create file in new_package workflow

### DIFF
--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -25,8 +25,7 @@ jobs:
           # The Python script prints the package name so that we can easily
           # echo it to $GITHUB_ENV. Alternatively we could parse if with a
           # regular string from the JSON string
-          echo '${{ steps.issue-parser.outputs.jsonString }}' > pkg.json
-          pkg_name=$(./scripts/utils/create_package_template_from_json.py --json_file pkg.json)
+          pkg_name=$(./scripts/utils/create_package_template_from_json.py '${{ steps.issue-parser.outputs.jsonString }}')
           echo "pkg_name=$pkg_name" >> $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
Restoring change introduced in https://github.com/mandiant/VM-Packages/pull/69 as the generated file gets added to the commit and this file is not needed. The code also doesn't fix https://github.com/mandiant/VM-Packages/issues/67, see https://github.com/mandiant/VM-Packages/issues/67#issuecomment-1243838565. 