### PR TITLE
Fix daily run

### DIFF
--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -26,7 +26,7 @@ $built_pkgs_dir = New-Item -ItemType Directory -Force $built_pkgs_dir_name
 if ($package_names) {
     $packages = $package_names.Split(" ")
 } else {
-    $packages = Get-ChildItem -Path $packages_dir_name | Select-Object Name
+    $packages = Get-ChildItem -Path $packages_dir_name | Select-Object -ExpandProperty Name
 }
 
 foreach ($package in $packages) {


### PR DESCRIPTION
Fixes errors like
```
Cannot find path 'D:\a\VM-Packages\VM-Packages\packages\@{Name=010editor.vm}' because it does not
     | exist.
```