### PR TITLE
Automatic package updates

### DIFF
--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -1,0 +1,63 @@
+name: Update package
+
+on:
+  schedule:
+    # Runs Wednesdays and Sundays at a weird time (22:21 UTC) to avoid
+    # delays during periods of high loads of GitHub Actions workflow runs.
+    - cron: '21 22 * * 0,3'
+
+jobs:
+  update:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install python dependency 'requests'
+        run: pip install requests
+      - name: Set git up
+        run: |
+          git config user.email 'vm-packages@mandiant.com'
+          git config user.name 'vm-packages'
+      - name: Update packages
+        run: |
+          $root = pwd
+          New-Item test_logs -itemType Directory | Out-Null
+          foreach ($packagePath in (Get-ChildItem packages)){
+            $package = $packagePath.Name
+            $version = python scripts\utils\update_package.py $package
+            $updated = $?
+            echo "$package $version"
+            if ($updated -and $version) {
+              # Test package before committing
+              scripts\test\test_install.ps1 $package *>> "test_logs/$package.txt"
+              $tested = $?
+              cd $root
+              if ($tested) {
+                git add "packages/$package/"
+                git commit -m "Update $package to $version"
+              } else {
+                echo "$package $version FAILED"
+              }
+            }
+            # Clean changes and built packages
+            git restore .
+            Remove-Item built_pkgs -Recurse -ErrorAction Ignore
+          }
+          Exit(0)
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: ':robot: Package update'
+          body: 'Automated package update'
+          branch: package-update
+          author: vm-packages <vm-packages@mandiant.com>
+          # GH actions can not trigger other GH actions,
+          # use a Personal Access Token to trigger the CI workflow in the created PR
+          token: ${{ secrets.REPO_TOKEN }}
+      - name: Upload test output to assets
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test_logs
+          path: test_logs/
+

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ env.bak/
 venv.bak/
 .envrc
 .tool-versions
+
+# Test logs for Update package workflow
+test_logs/

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -21,6 +21,13 @@ def get_sha256(url):
 
 
 def format_version(version):
+    # Get first three segments of version (which can be preceded by `v`)
+    # For example:
+    # v1.2.3 -> 1.2.3
+    # 1.2.3-p353 -> 1.2.3
+    # 1.2.3.4 -> 1.2.3
+    # v1.2 -> 1.2
+    # 1 -> 1
     match = re.match("v?(?P<version>\d+(.\d+){0,2})", version)
     if not match:
         print("has wrong version")
@@ -32,7 +39,8 @@ def update(package):
     chocolateyinstall_path = f"packages/{package}/tools/chocolateyinstall.ps1"
     with open(chocolateyinstall_path, "r") as file:
         content = file.read()
-        # Some packages have two urls (for 32 and 64 bits), we need to update both
+        # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
+        # Match urls like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
         matches = re.findall(
             "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/(?P<version>[^/]+)/[^\"']+)[\"']",
             content,
@@ -64,6 +72,7 @@ def update(package):
     nuspec_path = f"packages/{package}/{package}.nuspec"
     with open(nuspec_path, "r") as file:
         content = file.read()
+    # Replace version in nuspec, for example `<version>1.6.3</version>`
     content = re.sub("<version>[^<]+</version>", f"<version>{format_version(latest_version)}</version>", content)
     with open(nuspec_path, "w") as file:
         file.write(content)

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -1,0 +1,73 @@
+import hashlib
+import re
+import requests
+import sys
+
+
+def get_latest_version(org, project, version):
+    response = requests.get(f"https://api.github.com/repos/{org}/{project}/releases/latest")
+    if not response.ok:
+        print(response)
+        exit(1)
+    latest_version = response.json()["tag_name"]
+    if latest_version == version:
+        print("it is up-to-date")
+        exit(2)
+    return latest_version
+
+
+def get_sha256(url):
+    return hashlib.sha256(requests.get(url).content).hexdigest()
+
+
+def format_version(version):
+    match = re.match("v?(?P<version>\d+(.\d+){0,2})", version)
+    if not match:
+        print("has wrong version")
+        exit(3)
+    return match.group("version")
+
+
+def update(package):
+    chocolateyinstall_path = f"packages/{package}/tools/chocolateyinstall.ps1"
+    with open(chocolateyinstall_path, "r") as file:
+        content = file.read()
+        # Some packages have two urls (for 32 and 64 bits), we need to update both
+        matches = re.findall(
+            "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/(?P<version>[^/]+)/[^\"']+)[\"']",
+            content,
+        )
+
+    if not matches:
+        print("it is not a GitHub release")
+        exit(4)
+
+    latest_version = None
+    for url, org, project, version in matches:
+        latest_version_match = get_latest_version(org, project, version)
+        # The version of the 32 and 64 bit downloads need to be the same, we only have one nuspec
+        if latest_version and latest_version_match != latest_version:
+            print("has several versions")
+            exit(5)
+        latest_version = latest_version_match
+        latest_url = url.replace(version, latest_version)
+        sha256 = get_sha256(url)
+        latest_sha256 = get_sha256(latest_url)
+        # Hash can be uppercase or downcase
+        content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
+
+    content = content.replace(version, latest_version)
+    print(latest_version)
+    with open(chocolateyinstall_path, "w") as file:
+        file.write(content)
+
+    nuspec_path = f"packages/{package}/{package}.nuspec"
+    with open(nuspec_path, "r") as file:
+        content = file.read()
+    content = re.sub("<version>[^<]+</version>", f"<version>{format_version(latest_version)}</version>", content)
+    with open(nuspec_path, "w") as file:
+        file.write(content)
+
+
+if __name__ == "__main__":
+    update(sys.argv[1])


### PR DESCRIPTION
Add workflow that runs `scripts/utils/update_package.py` for every package. `scripts/utils/update_package.py` identifies packages downloaded from a GitHub release URL, queries the latest version and updates:
- The version in `tools/chocolateyinstall.ps1`, including the download URL.
- The SHA256 hashes in `tools/chocolateyinstall.ps1`
- The version in the nuspec

The workflow is run twice a week and creates a PR with a commit for every package.


See example run here: https://github.com/Ana06/VM-Packages/actions/runs/3297886819
See PR example here: https://github.com/Ana06/VM-Packages/pull/17

![Screen Shot 2022-10-21 at 15 50 05](https://user-images.githubusercontent.com/16052290/197211677-5843d91b-3c91-4f04-aa33-08d46142fc19.png)

The workflow tests changes before committing. The workflow logs packages that failed to update, but the action still succeeds and sends a PR.
![Screen Shot 2022-10-21 at 15 49 37](https://user-images.githubusercontent.com/16052290/197211577-27454c41-4655-4651-ba23-675429caf43a.png)

The workflow uploads the output of testing every package to the assets.
![Screen Shot 2022-10-21 at 15 51 06](https://user-images.githubusercontent.com/16052290/197211865-f9a4ca53-4db6-4f51-8418-addb9997a527.png)


