### PR TITLE
ci: update actions to avoid Node.js deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         os: [windows-2019, windows-2022]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get changed files
         id: files
         uses: Ana06/get-changed-files@v2.0.0
@@ -54,7 +54,7 @@ jobs:
               cpush -s "https://www.myget.org/F/vm-packages/api/v2" -k ${{ secrets.MYGET_TOKEN }} $package
           }
       - name: Upload chocolatey logs to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs-${{ matrix.os }}.zip

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -15,12 +15,12 @@ jobs:
         os: [windows-2019, windows-2022]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and test all modified packages
         id: test
         run: scripts/test/test_install.ps1
       - name: Upload chocolatey logs to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: logs-${{ matrix.os }}.zip

--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           labels: send PR
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Parse issue
         uses: stefanbuck/github-issue-parser@v2
         id: issue-parser


### PR DESCRIPTION
See warnings in recent Actions outputs

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2