### PR TITLE
Test all packages in daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and test all modified packages
         id: test
-        run: scripts/test/test_install.ps1
+        run: scripts/test/test_install.ps1 -all
       - name: Upload chocolatey logs to artifacts
         uses: actions/upload-artifact@v3
         if: always()

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -32,7 +32,7 @@ if ($package_names) {
 
 foreach ($package in $packages) {
     Set-Location "$root\$packages_dir_name\$package"
-    choco pack -out $built_pkgs_dir
+    choco pack -y -out $built_pkgs_dir
     if ($LASTEXITCODE -ne 0) { Exit 1 } # Abort with the first failing build
 }
 


### PR DESCRIPTION
Test all packages in daily so that we now all packages that fail. 😄 

Reduce the chocolatey output with the `-r` option to make it easier to read the now longer output. Also make it easier to download the log with failing packages.

Unrelated to CI: Do not ask for confirmation to build packages. It annoyed me during manual testing. :wink: