### PR TITLE
Add host survey to installer and bump versions

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20221115</version>
+    <version>0.0.0.20221121</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
+++ b/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>flarevm.installer.vm</id>
-    <version>0.0.0.20221117</version>
+    <version>0.0.0.20221121</version>
     <title>FLARE VM Installer</title>
     <authors>FLARE</authors>
     <description>Generic installer for Mandiant's custom virtual machines. Originally created by FLARE for FLARE VM, a malware analysis environment.</description>

--- a/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
@@ -15,6 +15,9 @@ function Get-InstalledPackages {
 }
 
 try {
+    # Log basic system information to assist with troubleshooting
+    VM-Get-Host-Info
+
     # Gather packages to install
     $installedPackages = (Get-InstalledPackages).Name
     $configPath = Join-Path ${Env:VM_COMMON_DIR} "config.xml" -Resolve


### PR DESCRIPTION
Supports #49 

Example output:
```
2022/11/21 07:27:49 test.ps1 [+] INFO : Host Information

VM OS version and Service Pack
-----


Version                 : 10.0.17763
BuildNumber             : 17763
OSArchitecture          : 64-bit
ServicePackMajorVersion : 0
Caption                 : Microsoft Windows 10 Enterprise Evaluation





VM OS RAM (MB)
-----
4096


VM OS HDD Space / Usage
-----

DeviceID DriveType ProviderName VolumeName Size        FreeSpace  
-------- --------- ------------ ---------- ----        ---------  
C:       3                      Windows 10 42947571712 27111321600
D:       5                                                        




VM AV Details
-----
DisplayName: Windows Defender
ProductOwner: Microsoft
ProductState: Snoozed
SignatureStatus: UpToDate

VM PowerShell Version
-----
5.1.17763.316

VM Chocolatey Version
-----
0.10.13

VM Boxstarter Version
-----

Boxstarter 3.0.0
Boxstarter.Bootstrapper 3.0.0
Boxstarter.Chocolatey 3.0.0
Boxstarter.Common 3.0.0
Boxstarter.HyperV 3.0.0
Boxstarter.WinConfig 3.0.0
```