### PR TITLE
Display Failures in daily run

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Build and test all modified packages
         id: test
         run: scripts/test/test_install.ps1 -all
+      - name: Display Failures context
+        run: Select-String "Failures" -Context 0,1 C:\ProgramData\chocolatey\logs\chocolatey.log
       - name: Upload chocolatey logs to artifacts
         uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
Example output:

```cmd
$ Select-String "Failures" -Context 0,1 .\chocolatey.log
> chocolatey.log:64081:2022-11-28 03:53:17,123 2916 [ERROR] - Failures
  chocolatey.log:64082:2022-11-28 03:53:17,123 2916 [ERROR] -  - notepadpp.plugin.compare.vm (exited 1) -
notepadpp.plugin.compare.vm not installed. An error occurred during installation:
> chocolatey.log:69998:2022-11-28 03:56:38,391 4216 [ERROR] - Failures
  chocolatey.log:69999:2022-11-28 03:56:38,391 4216 [ERROR] -  - python2.vm (exited -1) - Error while running
'C:\ProgramData\chocolatey\lib\python2.vm\tools\chocolateyinstall.ps1'.
> chocolatey.log:78824:2022-11-28 03:59:09,324 6592 [ERROR] - Failures
  chocolatey.log:78825:2022-11-28 03:59:09,324 6592 [ERROR] -  - wireshark (exited -1) - Error while running
'C:\ProgramData\chocolatey\lib\wireshark\tools\chocolateyInstall.ps1'.
```