### PR TITLE
Fix renamed packages not being pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,15 @@ jobs:
         uses: actions/checkout@v3
       - name: Get changed files
         id: files
-        uses: Ana06/get-changed-files@v2.0.0
+        uses: Ana06/get-changed-files@v2.2.0
         with:
           filter: '*.nuspec'
       - name: Build and test all modified packages
         id: test
         # It runs only if there are modified files
-        if: steps.files.outputs.added_modified != ''
+        if: steps.files.outputs.added_modified_renamed != ''
         run: |
-          $packages = "${{ steps.files.outputs.added_modified }}".Split(" ") | Foreach-Object { (Get-Item $_).Directory.Name }
+          $packages = "${{ steps.files.outputs.added_modified_renamed }}".Split(" ") | Foreach-Object { (Get-Item $_).Directory.Name }
           scripts/test/test_install.ps1 "common.vm $packages"
       - name: Push all built packages to MyGet
         # Only push packages on master if they were built (not if testing was skipped) and


### PR DESCRIPTION
Some packages (such as `notepadplusplus.vm` renamed in https://github.com/mandiant/VM-Packages/pull/98) haven't been pushed to myget because our action only checks modified nuspec files and not renamed ones. Note that in a package change of name, the version is not modified.

I have released a new version of [Ana06/get-changed-files](https://github.com/Ana06/get-changed-files/releases/tag/v2.2.0) which includes `added_modified_renamed` to allows us to easily fix this. This new version also removes the node12 deprecation warnings.

Partially addresses https://github.com/mandiant/VM-Packages/issues/128