### PR TITLE
daily: Update badges if tests fail

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,7 +24,7 @@ jobs:
         if: always()
         run: if (Test-Path -Path C:\ProgramData\_VM\log.txt ) { Select-String "ERR|WARN" -CaseSensitive -Context 0,5 C:\ProgramData\_VM\log.txt }
       - name: Update badges in README
-        if: matrix.os == 'windows-2022'
+        if: always() && matrix.os == 'windows-2022'
         run: |
           # test_install.ps1 writes success_failure.json with contents: `{success: n, failure: m}`
           $succ = (Get-Content "success_failure.json" | ConvertFrom-Json).success
@@ -33,14 +33,14 @@ jobs:
           # URL format: `https://img.shields.io/badge/pkgs--install--pass-1337-green.svg`
           (Get-Content README.md) -replace 'pkgs--install--pass-(\d{1,})-', "pkgs--install--pass-$succ-" -replace 'pkgs--install--fail-(\d{1,})-', "pkgs--install--fail-$fail-" -replace 'packages-(\d{1,})-blue', "packages-$total-blue" | Out-File README.md
       - name: Commit changes
-        if: matrix.os == 'windows-2022'
+        if: always() && matrix.os == 'windows-2022'
         run: |
           git config user.email 'vm-packages@mandiant.com'
           git config user.name 'vm-packages'
           git add README.md
           git commit -m 'Update daily success/failure badges'
       - name: Push changes
-        if: matrix.os == 'windows-2022'
+        if: always() && matrix.os == 'windows-2022'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
We had only tested the daily with successful testing. We need to also update the badges if there are failures.

Note that if updating the badges in README fails, we don't want to commit. But I think using `always()` is ok as there won't be anything to commit. It is similar with pushing, as there won't be anything to push.