### PR TITLE
Feat/add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/packages"
     schedule:
       interval: "daily"
-    reviewers:
-      - "malwaremechanic"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/packages"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "malwaremechanic"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/packages"
     schedule:
       interval: "daily"
+    target-branch: "feat/add-dependabot"


### PR DESCRIPTION
Seems like dependabot can auto-update our nuget dependencies for us. Not sure how to test this before a commit to main, so if anyone know please let me know. I've briefly read up on dependabot on https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates