### PR TITLE
Add Dissect Python3 package

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20221203</version>
+    <version>0.0.0.20230118</version>
     <description>Metapackage to install common Python3 libraries</description>
     <authors>Mandiant, Microsoft, Python Software Foundation</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -3,6 +3,7 @@
     <module name="acefile"/>
     <module name="binwalk" url="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"/>
     <module name="capstone-windows"/>
+    <module name="dissect"/>
     <module name="hexdump"/>
     <module name="ldapdomaindump"/>
     <module name="mkyara"/>


### PR DESCRIPTION
This change adds the Dissect Python package. Dissect is a framework consisting of multiple libraries and tools to interact with things like disk images and virtual machine disks.

More information:
https://docs.dissect.tools/en/latest/
https://github.com/fox-it/dissect