### PR TITLE
linter: fix version checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           # fetch all history for all branches
           fetch-depth: 0
-      - name: Run lint.ps1
-        run: scripts/test/lint.ps1
       - name: Run lint.py
         run: python scripts/test/lint.py packages
+      - name: Run lint.ps1
+        run: scripts/test/lint.ps1
 
   test_upload:
     runs-on: ${{ matrix.os }}

--- a/packages/010editor.vm/tools/chocolateyinstall.ps1
+++ b/packages/010editor.vm/tools/chocolateyinstall.ps1
@@ -1,6 +1,8 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
+# a change here, should be yelled at by the linter
+
 try {
   $toolName = '010Editor'
   $category = 'Hex Editors'

--- a/packages/010editor.vm/tools/chocolateyinstall.ps1
+++ b/packages/010editor.vm/tools/chocolateyinstall.ps1
@@ -1,8 +1,6 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-# a change here, should be yelled at by the linter
-
 try {
   $toolName = '010Editor'
   $category = 'Hex Editors'

--- a/packages/exiftool.vm/exiftool.vm.nuspec
+++ b/packages/exiftool.vm/exiftool.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exiftool.vm</id>
-    <version>12.55</version>
+    <version>12.55.0</version>
     <authors>Phil Harvey</authors>
     <description>A tool for reeding and writing file metadata</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="exiftool" version="[12.55]" />
+      <dependency id="exiftool" version="[12.55.0.20230121]" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/wireshark.vm/wireshark.vm.nuspec
+++ b/packages/wireshark.vm/wireshark.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wireshark.vm</id>
-    <version>4.0.2.20221221</version>
+    <version>4.0.3</version>
     <description>Wireshark lets you capture and interactively browse the traffic running on a computer network.</description>
     <authors>Gerald Combs, Wireshark team</authors>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="npcap.vm" />
-      <dependency id="wireshark" version="[4.0.2]" />
+      <dependency id="wireshark" version="[4.0.3]" />
     </dependencies>
   </metadata>
 </package>

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -26,7 +26,7 @@ from xml.dom import minidom
 GIT_EXE = "git"
 
 # set log level for debugging here script-wide
-LOG_LEVEL = logging.DEBUG
+LOG_LEVEL = logging.INFO
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger("lint")
 

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -136,7 +136,8 @@ class VersionFormatIncorrect(Lint):
 
         # for metapackage that just installs/configures a specific tool (with locked dependency version)
         deps = dom.getElementsByTagName("dependency")
-        if len(deps) == 1:
+        # common.vm and one locked dependency
+        if len(deps) <= 2:
             for d in deps:
                 if d.getAttribute("version"):
                     dep_version = d.getAttribute("version")
@@ -144,7 +145,10 @@ class VersionFormatIncorrect(Lint):
                         dep_version = dep_version[1:-1].split(".")
                         if len(dep_version) == 4:
                             if dep_version[:3] != version[:3]:
-                                print(f"{path} package version should be {'.'.join(dep_version[:3])}")
+                                print(f"{path} package version should start with {'.'.join(dep_version[:3])}")
+                                return True
+                            if len(version) != 4:
+                                print(f"{path} package version should use current date (YYYYMMDD) in the 4th segment")
                                 return True
                         elif dep_version != version:
                             # when change is made to a metapackage, use the current date in the 4th segment

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -220,7 +220,8 @@ class VersionNotUpdated(Lint):
         for part in path.parts:
             if part.endswith(".vm"):
                 # only check exact package path, i.e., `/<package>/`
-                package_path = f"{os.sep}{part}{os.sep}"
+                # git appears to return slash (/) separated paths here on Windows and Linux
+                package_path = f"/{part}/"
                 break
 
         if package_path is None:

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -216,13 +216,21 @@ class VersionNotUpdated(Lint):
     logger.debug("others: %s", others)
 
     def check(self, path):
+        package_path = None
         for part in path.parts:
             if part.endswith(".vm"):
                 # only check exact package path, i.e., `/<package>/`
                 package_path = f"{os.sep}{part}{os.sep}"
+                break
+
+        if package_path is None:
+            logger.error("could not find package path <package.vm> in %s", path)
+            return True
 
         # has any file in this package, including nuspec files, been updated?
+        logger.debug("package path '%s' in part of changed files (%s)?", package_path, self.changed_files)
         if not any([package_path in cfile for cfile in self.changed_files]):
+            logger.debug(" computer says no")
             return False
 
         # look for version string in git diff

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -138,7 +138,11 @@ class VersionFormatIncorrect(Lint):
         deps = dom.getElementsByTagName("dependency")
         # common.vm and one locked dependency
         if len(deps) <= 2:
+            pkg_id = metadata.getElementsByTagName("id")[0].firstChild.data.replace("vm", "")
             for d in deps:
+                if d.getAttribute("id") != pkg_id:
+                    continue
+
                 if d.getAttribute("version"):
                     dep_version = d.getAttribute("version")
                     if dep_version.startswith("[") and dep_version.endswith("]"):

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -26,7 +26,7 @@ from xml.dom import minidom
 GIT_EXE = "git"
 
 # set log level for debugging here script-wide
-LOG_LEVEL = logging.INFO
+LOG_LEVEL = logging.DEBUG
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger("lint")
 


### PR DESCRIPTION
Closes #212 and enforces the meta package versioning per the Wiki (including the updates from #221).