### PR TITLE
handle utf-8 and ignore case when searching dependency

### DIFF
--- a/packages/pebear.vm/pebear.vm.nuspec
+++ b/packages/pebear.vm/pebear.vm.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pebear.vm</id>
-    <version>0.6.1</version>
+    <version>0.6.1.20230131</version>
     <authors>hasherezade</authors>
-    <description>Delivers fast and flexible “first view” for malware analysts</description>
+    <description>Delivers fast and flexible "first view" for malware analysts</description>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="pebear" version="[0.6.1]" />

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -96,7 +96,7 @@ def update_github_url(package):
 # Metapackages have only one dependency and same name (adding `.vm`)  and version as the dependency
 def update_dependencies(package):
     nuspec_path = f"packages/{package}/{package}.nuspec"
-    with open(nuspec_path, "r") as file:
+    with open(nuspec_path, "r", encoding="utf-8") as file:
         content = file.read()
     matches = re.findall(
         f'<dependency id=["\'](?P<dependency>[^"\']+)["\'] version="\[(?P<version>[^"\']+)\]" */>',
@@ -108,7 +108,8 @@ def update_dependencies(package):
     for dependency, version in matches:
         stream = os.popen(f"powershell.exe choco find -er {dependency}")
         output = stream.read()
-        m = re.search(f"^{dependency}\|(?P<version>.+)", output, re.M)
+        # ignore case to also find dependencies like GoogleChrome
+        m = re.search(f"^{dependency}\|(?P<version>.+)", output, re.M | re.I)
         if m:
             latest_version = m.group("version")
             if latest_version != version:


### PR DESCRIPTION
This should improve automatic updates for cyberchef (googlechrome vs. GoogleChrome) and other such cases.