### PR TITLE
add Linux `file` utility to read magic bytes and determine file type

### DIFF
--- a/packages/file.vm/file.vm.nuspec
+++ b/packages/file.vm/file.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>file.vm</id>
+    <version>0.0.0.20170108</version>
+    <description>A Windows port of the Linux `file` utility for checking header magics</description>
+    <authors>Nolen Scaiffe</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/file.vm/tools/chocolateyinstall.ps1
+++ b/packages/file.vm/tools/chocolateyinstall.ps1
@@ -9,7 +9,6 @@ try {
     $zipSha256 = "963147318f96d9345471e1a9a3943def4d95fcb3c1fe020e465ab910d0cda4a3"
 
     $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true)[-1]
-    
     $executableDir = Split-Path -Path $executablePath
     $scriptPath = Join-Path $executableDir "leave_file_open.bat"
     [IO.File]::WriteAllLines($scriptPath, $("`"$executablePath`" %1", "PAUSE"))

--- a/packages/file.vm/tools/chocolateyinstall.ps1
+++ b/packages/file.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'file'
+    $category = 'Utilities'
+
+    $zipUrl = "https://github.com/nscaife/file-windows/releases/download/20170108/file-windows-20170108.zip"
+    $zipSha256 = "963147318f96d9345471e1a9a3943def4d95fcb3c1fe020e465ab910d0cda4a3"
+
+    $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true)[-1]
+    
+    $executableDir = Split-Path -Path $executablePath
+    $scriptPath = Join-Path $executableDir "leave_file_open.bat"
+    [IO.File]::WriteAllLines($scriptPath, $("`"$executablePath`" %1", "PAUSE"))
+
+    VM-Add-To-Right-Click-Menu $toolName "file type" "`"$scriptPath`" `"%1`"" "file"
+} catch {
+    VM-Write-Log-Exception $_
+}

--- a/packages/file.vm/tools/chocolateyuninstall.ps1
+++ b/packages/file.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'file'
+$category = 'Utilities'
+
+VM-Uninstall $toolName $category
+VM-Remove-From-Right-Click-Menu $toolName "file"


### PR DESCRIPTION
Also add a right-click shortcut to quickly run it on any file. I find this useful when downloading a bunch of files by hash that are missing extensions and you don't even know what they are.