### PR TITLE
Add LECmd by Eric Zimmerman

### DIFF
--- a/packages/lecmd.vm/lecmd.vm.nuspec
+++ b/packages/lecmd.vm/lecmd.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>lecmd.vm</id>
+    <version>1.5.0.0</version>
+    <description>LECmd: parse Windows shortcut files with LNK Explorer Command Line edition</description>
+    <authors>Eric Zimmerman</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/lecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/lecmd.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'LECmd'
+$category = 'Utilities'
+
+$zipUrl = "https://f001.backblazeb2.com/file/EricZimmermanTools/LECmd.zip"
+$zipSha256 = "a7f694d3aeb958cf18efba2e32c3e590fbd6a8e358d0117f66294f36d5425203"
+
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true
+

--- a/packages/lecmd.vm/tools/chocolateyuninstall.ps1
+++ b/packages/lecmd.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'LECmd'
+$category = 'Utilities'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
This tool parses Windows shortcut files (LNK), which can do all kinds of stuff besides simply point to local disk files.

This version requires .NET version 4, which is apparently already installed in FLARE VM. (there's also a version for .NET 6 which did not work for me in the VM). I'm not sure if there's a way to declare that dependency, or if we can just assume it's there.