### PR TITLE
Add Mozilla Thunderbird

### DIFF
--- a/packages/thunderbird.vm/thunderbird.vm.nuspec
+++ b/packages/thunderbird.vm/thunderbird.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>thunderbird.vm</id>
+    <version>102.7.2</version>
+    <authors>MZLA Technologies Corporation (Mozilla)</authors>
+    <description>Thunderbird is an open-source email client that can open saved email messages such as .eml files</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="thunderbird" version="[102.7.2]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/thunderbird.vm/tools/chocolateyinstall.ps1
+++ b/packages/thunderbird.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'Thunderbird'
+  $category = 'Email'
+  $executablePath = 'C:\Program Files\Mozilla Thunderbird\thunderbird.exe'
+
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
+  VM-Assert-Path $shortcut
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/thunderbird.vm/tools/chocolateyuninstall.ps1
+++ b/packages/thunderbird.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'Thunderbird'
+$category = 'Email'
+
+VM-Remove-Tool-Shortcut $toolName $category


### PR DESCRIPTION
Thunderbird is useful for viewing malicious emails (and their attachments) exported from the mail server, e.g. as .eml files. Built in Windows Mail requires you to add an account even before opening local files.