### PR TITLE
Add Azure-CLI

### DIFF
--- a/packages/azure-cli.vm/azure-cli.vm.nuspec
+++ b/packages/azure-cli.vm/azure-cli.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>azure-cli.vm</id>
+    <version>2.46.0</version>
+    <authors>Microsoft</authors>
+    <description>Azure CLI is a command-line tool for managing and automating Microsoft Azure cloud services, enabling users to create, manage, and deploy resources through scripts or direct commands.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="azure-cli" version="[2.46.0]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/azure-cli.vm/tools/chocolateyinstall.ps1
+++ b/packages/azure-cli.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'Azure-CLI'
+  $category = 'Cloud'
+
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+  $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
+  $executableArgs = "/K az --help"
+  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executableCmd -Arguments $executableArgs -RunAsAdmin
+  VM-Assert-Path $shortcut
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/azure-cli.vm/tools/chocolateyuninstall.ps1
+++ b/packages/azure-cli.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'Azure-CLI'
+$category = 'Cloud'
+
+VM-Remove-Tool-Shortcut $toolName $category


### PR DESCRIPTION
added a tool to manage azure resources from command-line.

this metapackage doesn't have a shim, so the shortcut calls cmd.exe with `az --help` instead.

this PR is blocked until #269 is merged