### PR TITLE
Add Azure PowerShell 

### DIFF
--- a/packages/azure-powershell.vm/azure-powershell.vm.nuspec
+++ b/packages/azure-powershell.vm/azure-powershell.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>azure-powershell.vm</id>
+    <version>9.5.0</version>
+    <authors>Microsoft</authors>
+    <description>Azure PowerShell is a module that provides cmdlets for managing and automating Microsoft Azure cloud services, allowing users to create, manage, and deploy resources.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="az.powershell" version="[9.5.0]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/azure-powershell.vm/tools/chocolateyinstall.ps1
+++ b/packages/azure-powershell.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'Azure PowerShell'
+  $category = 'Cloud'
+
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+  $executablePwsh  = Join-Path ${Env:WinDir} "System32\WindowsPowerShell\v1.0\powershell.exe" -Resolve
+  $executableArgs = "-NoExit -Command Get-AzContext -ListAvailable"
+  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePwsh -Arguments $executableArgs -RunAsAdmin
+  VM-Assert-Path $shortcut
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/azure-powershell.vm/tools/chocolateyuninstall.ps1
+++ b/packages/azure-powershell.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'Azure PowerShell'
+$category = 'Cloud'
+
+VM-Remove-Tool-Shortcut $toolName $category


### PR DESCRIPTION
Added the Azure PowerShell module.

The metapackage doesn't have a shim, therefore we are calling PowerShell and listing the current available Azure contexts.

This PR is blocked until #269 is resolved.