### PR TITLE
Add Teamfiltration

### DIFF
--- a/packages/teamfiltration.vm/teamfiltration.vm.nuspec
+++ b/packages/teamfiltration.vm/teamfiltration.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>teamfiltration.vm</id>
+    <version>3.5.0</version>
+    <authors>Flangvik</authors>
+    <description>TeamFiltration is a cross-platform framework for enumerating, spraying, exfiltrating, and backdooring O365 AAD accounts.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/teamfiltration.vm/tools/chocolateyinstall.ps1
+++ b/packages/teamfiltration.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'TeamFiltration'
+$category = 'Cloud'
+
+$zipUrl = 'https://github.com/Flangvik/TeamFiltration/releases/download/v3.5.0/TeamFiltration-Win-v3.5.0.zip'
+$zipSha256 = 'c91362172789aa47f45200fac925c5c8ade35cd9a8863f154d27dc5e0a2ed916'
+
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256

--- a/packages/teamfiltration.vm/tools/chocolateyuninstall.ps1
+++ b/packages/teamfiltration.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'TeamFiltration'
+$category = 'Cloud'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
TeamFiltration is a cross-platform framework for enumerating, spraying, exfiltrating, and backdooring O365 AAD accounts.

This PR is blocked until #269 is resolved.