### PR TITLE
Lint categories

### DIFF
--- a/categories.txt
+++ b/categories.txt
@@ -1,0 +1,28 @@
+Android
+Cloud
+Debuggers
+Delphi
+Disassemblers
+dotNet
+Forensic
+Hex Editors
+Java
+Javascript
+Networking
+Office
+PDF
+PE
+PowerShell
+Python
+Text Editors
+Utilities
+VB
+Active Directory
+Command & Control
+Evasion
+Exploitation
+Information Gathering
+Password Attacks
+Vulnerability Analysis
+Web Application
+Wordlists

--- a/packages/cmder.vm/cmder.vm.nuspec
+++ b/packages/cmder.vm/cmder.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cmder.vm</id>
-    <version>1.3.20.20221201</version>
+    <version>1.3.20.20230418</version>
     <description>Metapackage for cmder</description>
     <authors>Mandiant, Samuel Vasko</authors>
     <dependencies>

--- a/packages/cmder.vm/tools/chocolateyinstall.ps1
+++ b/packages/cmder.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,8 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'cmder'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Utilities'
+  $category = 'Utilities'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName -Resolve
 

--- a/packages/cmder.vm/tools/chocolateyuninstall.ps1
+++ b/packages/cmder.vm/tools/chocolateyuninstall.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = 'Continue'
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Utilities'
+$category = 'Utilities'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir 'cmder.lnk'
 Remove-Item $shortcut -Force -ea 0 | Out-Null

--- a/packages/cyberchef.vm/cyberchef.vm.nuspec
+++ b/packages/cyberchef.vm/cyberchef.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cyberchef.vm</id>
-    <version>10.4.0</version>
+    <version>10.4.0.20230418</version>
     <authors>GCHQ</authors>
     <description>The Cyber Swiss Army Knife - a web app for encryption, encoding, compression, data analysis, and more.</description>
     <dependencies>

--- a/packages/cyberchef.vm/tools/chocolateyinstall.ps1
+++ b/packages/cyberchef.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,8 @@ Import-Module vm.common -Force -DisableNameChecking
 try {
   VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Utilities'
+  $category = 'Utilities'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} 'cyberchef'
 
   $packageArgs = @{

--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>1.4.11.20221115</version>
+    <version>1.4.11.20230418</version>
     <description>FakeNet-NG is a next generation dynamic network analysis tool for malware analysts and penetration testers.</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,8 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'FakeNet-NG'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Networking'
+  $category = 'Networking'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
   # Remove files from previous zips for upgrade

--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>7.6</version>
+    <version>7.6.20230418</version>
     <authors>hex-rays</authors>
     <description>Free version of IDA, a powerful Interactive DisAssembler and debugger</description>
     <dependencies>

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,8 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'idafree'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Disassemblers'
+  $category = 'Disassemblers'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $packageArgs = @{
     packageName  = ${Env:ChocolateyPackageName}

--- a/packages/nmap.vm/nmap.vm.nuspec
+++ b/packages/nmap.vm/nmap.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nmap.vm</id>
-    <version>7.93.20230301</version>
+    <version>7.93.20230418</version>
     <authors>Fyodor, Nmap Project</authors>
     <description>Port scanning utility and nc replacement with extended features</description>
     <dependencies>

--- a/packages/nmap.vm/tools/chocolateyinstall.ps1
+++ b/packages/nmap.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,8 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'nmap'
-    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Networking'
+    $category = 'Networking'
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
     $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
     $exeUrl = 'https://nmap.org/dist/nmap-7.93-setup.exe'

--- a/packages/ollydbg.vm/ollydbg.vm.nuspec
+++ b/packages/ollydbg.vm/ollydbg.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg.vm</id>
-    <version>1.10.0.20220908</version>
+    <version>1.10.0.20230418</version>
     <description>OllyDbg is a 32-bit assembler level analysing debugger for Windows. Emphasis on binary code analysis makes it particularly useful in cases where source is unavailable.</description>
     <authors>Oleh Yuschuk</authors>
     <dependencies>

--- a/packages/ollydbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/ollydbg.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,8 @@ try {
   VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
   $toolName = 'OllyDbg'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+  $category = 'Debuggers'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
   $packageArgs = @{

--- a/packages/ollydbg.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ollydbg.vm/tools/chocolateyuninstall.ps1
@@ -1,10 +1,13 @@
 $ErrorActionPreference = 'Continue'
 
 $toolName = 'OllyDbg'
+$category = 'Debuggers'
+
 $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
 
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir "$toolName.lnk"
 Remove-Item $shortcut -Force -ea 0 | Out-Null
+
 Uninstall-BinFile -Name 'ollydbg'

--- a/packages/ollydbg2.vm/ollydbg2.vm.nuspec
+++ b/packages/ollydbg2.vm/ollydbg2.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.vm</id>
-    <version>2.01</version>
+    <version>2.01.0.20230418</version>
     <description>OllyDbg2 is a 32-bit assembler level analysing debugger for Windows. Emphasis on binary code analysis makes it particularly useful in cases where source is unavailable.</description>
     <authors>Oleh Yuschuk</authors>
     <dependencies>

--- a/packages/ollydbg2.vm/tools/chocolateyinstall.ps1
+++ b/packages/ollydbg2.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,8 @@ try {
   VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
   $toolName = 'OllyDbg2'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+  $category = 'Debuggers'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
   $packageArgs = @{

--- a/packages/ollydbg2.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ollydbg2.vm/tools/chocolateyuninstall.ps1
@@ -4,7 +4,8 @@ $toolName = 'OllyDbg2'
 $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
 
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+$category = 'Debuggers'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir "$toolName.lnk"
 Remove-Item $shortcut -Force -ea 0 | Out-Null
 Uninstall-BinFile -Name 'ollydbg2'

--- a/packages/vcbuildtools.vm/tools/chocolateyinstall.ps1
+++ b/packages/vcbuildtools.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Utilities'
+  $category = 'Utilities'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $programFiles = ${Env:ProgramFiles(x86)}
   if (-Not ($programFiles)) {

--- a/packages/vcbuildtools.vm/tools/chocolateyuninstall.ps1
+++ b/packages/vcbuildtools.vm/tools/chocolateyuninstall.ps1
@@ -1,4 +1,5 @@
 ﻿$ErrorActionPreference = 'Continue'
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Utilities'
+$category = 'Utilities'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir 'Microsoft Visual C++ Build Tools.lnk'
 Remove-Item $shortcut -Force -ea 0 | Out-Null

--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20230322</version>
+    <version>0.0.0.20230418</version>
     <description>Metapackage that requires the dependencies below:
 - visualstudio2017buildtools
 - visualstudio2017-workload-vctools

--- a/packages/x64dbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/x64dbg.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,8 @@ try {
   VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
   $toolName = 'x64dbg'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+  $category = 'Debuggers'
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
   $snapshotDate = '2021-05-08_14-17'
 

--- a/packages/x64dbg.vm/tools/chocolateyuninstall.ps1
+++ b/packages/x64dbg.vm/tools/chocolateyuninstall.ps1
@@ -4,7 +4,8 @@ $toolName = 'x64dbg'
 $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
 
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} 'Debuggers'
+$category = 'Debuggers'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir "x32dbg.lnk"
 Remove-Item $shortcut -Force -ea 0 | Out-Null
 Uninstall-BinFile -Name 'x32dbg'

--- a/packages/x64dbg.vm/x64dbg.vm.nuspec
+++ b/packages/x64dbg.vm/x64dbg.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>x64dbg.vm</id>
-    <version>2021.05.08</version>
+    <version>2021.05.08.20230418</version>
     <description>An open-source x64/x32 debugger for Windows.</description>
     <authors>mrexodia</authors>
     <dependencies>

--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -14,38 +14,9 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-# categories must be synchronized with the issue templates
-CATEGORIES = (
-    "Android",
-    "Cloud",
-    "Debuggers",
-    "Delphi",
-    "Disassemblers",
-    "dotNet",
-    "Forensic",
-    "Hex Editors",
-    "Java",
-    "Javascript",
-    "Networking",
-    "Office",
-    "PDF",
-    "PE",
-    "PowerShell",
-    "Python",
-    "Text Editors",
-    "Utilities",
-    "VB",
-    # CommandoVM
-    "Active Directory",
-    "Command & Control",
-    "Evasion",
-    "Exploitation",
-    "Information Gathering",
-    "Password Attacks",
-    "Vulnerability Analysis",
-    "Web Application",
-    "Wordlists",
-)
+root_path = os.path.abspath(os.path.join(__file__ ,"../../.."))
+with open(f"{root_path}/categories.txt") as file:
+    CATEGORIES = [line.rstrip() for line in file]
 
 UNINSTALL_TEMPLATE_NAME = "chocolateyuninstall.ps1"
 INSTALL_TEMPLATE_NAME = "chocolateyinstall.ps1"


### PR DESCRIPTION
Prevent use of custom (non defined) categories. Modifying the category a package belongs to is a breaking change (breaks updates and uninstalling), so we have fixed the categories and adding new categories needs to be discussed.

Some packages don't have a category (we don't create a link in the tools directory) and need to be ignored when linting.

Note we still need to keep the issue templates in sync manually, but we don't expect this to be a big issue as we don't plan to change them often.

I have added some documentation in https://github.com/mandiant/VM-Packages/wiki/Coding-Conventions/_compare/4fc1c6ac77f6d60d0639c81f8d23c31871fb50d4...9592e06e72738632d04c6a7be9cf0acbfa656f1f Is there any other place we need to document this?

Closes https://github.com/mandiant/VM-Packages/issues/270