### PR TITLE
Improve package updates automation

### DIFF
--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -25,24 +25,31 @@ jobs:
           New-Item test_logs -itemType Directory | Out-Null
           foreach ($packagePath in (Get-ChildItem packages)){
             $package = $packagePath.Name
-            $version = python scripts\utils\update_package.py $package
-            $updated = $?
-            echo "$package $version"
-            if ($updated -and $version) {
-              # Test package before committing
-              scripts\test\test_install.ps1 $package *>> "test_logs/$package.txt"
-              $tested = $?
-              cd $root
-              if ($tested) {
-                git add "packages/$package/"
-                git commit -m "Update $package to $version"
-              } else {
-                echo "$package $version FAILED"
+            $newVersion = 0
+            # Test indepdendly every type of update and commit what works
+            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL')) {
+              $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
+              $updated = $?
+              echo "$package $version"
+              if ($updated -and $version) {
+                # Test package before committing
+                scripts\test\test_install.ps1 $package *>> "test_logs/$package.txt"
+                $tested = $?
+                cd $root
+                if ($tested) {
+                  git add "packages/$package/"
+                  $newVersion = $version
+                } else {
+                  echo "$package $version FAILED"
+                }
               }
+              # Clean changes and built packages
+              git restore .
+              Remove-Item built_pkgs -Recurse -ErrorAction Ignore
             }
-            # Clean changes and built packages
-            git restore .
-            Remove-Item built_pkgs -Recurse -ErrorAction Ignore
+            if ($newVersion) {
+              git commit -m "Update $package to $newVersion"
+            }
           }
           Exit(0)
       - name: Create Pull Request

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -44,7 +44,9 @@ Set-Location $built_pkgs_dir
 $failed = 0
 $success = 0
 foreach ($package in $built_pkgs) {
-    choco install $package -y -r -s "'.;https://www.myget.org/F/vm-packages/api/v2;https://community.chocolatey.org/api/v2/'" --no-progress --force
+    # install looks for a nuspec with the same version as the installed one
+    # upgrade installs the last found version (even if the package is not installed)
+    choco upgrade $package -y -r -s "'.;https://www.myget.org/F/vm-packages/api/v2;https://community.chocolatey.org/api/v2/'" --no-progress --force
     if ($validExitCodes -notcontains $LASTEXITCODE) {
         Write-Host -ForegroundColor Red "[ERROR] Failed to install $package"
         $failed += 1

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -59,14 +59,18 @@ def format_version(version):
 
 def update_github_url(package):
     chocolateyinstall_path = f"packages/{package}/tools/chocolateyinstall.ps1"
-    with open(chocolateyinstall_path, "r") as file:
-        content = file.read()
-        # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
-        # Match urls like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
-        matches = re.findall(
-            "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/(?P<version>[^/]+)/[^\"']+)[\"']",
-            content,
-        )
+    try:
+        file = open(chocolateyinstall_path, "r")
+    except FileNotFoundError:
+        # chocolateyinstall.ps1 may not exist for metapackages
+        return None
+    content = file.read()
+    # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
+    # Match urls like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
+    matches = re.findall(
+        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/(?P<version>[^/]+)/[^\"']+)[\"']",
+        content,
+    )
 
     # It is not a GitHub release
     if not matches:


### PR DESCRIPTION
In case a package had GitHub release and dependencies updates, only the GitHub release was updated. The ideas was to avoid updating many things at once. But this is causing problems with packages (like CyberChef with GoogleChrome as dependency) whose dependencies use download links that break often (like the ones that don't include the version). In this case, any update to the package which doesn't update the failing dependency will make the test fail.

Update and test dependencies and GitHub url independently. This way we ensure we update as much as we can and prevent the described problem.

In addition, catch the `FileNotFoundError` exception caused by metapackages that don't have `chocolateyinstall.ps1` when trying to read this file to update it. This exception is not breaking our CI, but it displayed in the logs.

**After this PR, we will be able to update CyberChef and Python3**