### PR TITLE
Replace success/failure badges by failures file

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Updating the wiki fails if between the checkout of the wiki and the push of the update the other job pushes its update
+      max-parallel: 1
       matrix:
         os: [windows-2019, windows-2022]
     steps:
@@ -23,27 +25,23 @@ jobs:
       - name: Display log warnings and errors
         if: always()
         run: if (Test-Path -Path C:\ProgramData\_VM\log.txt ) { Select-String "ERR|WARN" -CaseSensitive -Context 0,5 C:\ProgramData\_VM\log.txt }
-      - name: Update badges in README
-        if: always() && matrix.os == 'windows-2022'
-        run: |
-          # test_install.ps1 writes success_failure.json with contents: `{success: n, failure: m}`
-          $succ = (Get-Content "success_failure.json" | ConvertFrom-Json).success
-          $fail = (Get-Content "success_failure.json" | ConvertFrom-Json).failure
-          $total = (Get-Content "success_failure.json" | ConvertFrom-Json).total
-          # URL format: `https://img.shields.io/badge/pkgs--install--pass-1337-green.svg`
-          (Get-Content README.md) -replace 'pkgs--install--pass-(\d{1,})-', "pkgs--install--pass-$succ-" -replace 'pkgs--install--fail-(\d{1,})-', "pkgs--install--fail-$fail-" -replace 'packages-(\d{1,})-blue', "packages-$total-blue" | Out-File README.md
+      - name: Checkout wiki code
+        if: always()
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Add results to wiki
+        if: always()
+        run: python scripts/utils/generate_daily_results.py ${{ github.repository }} ${{ github.sha }} ${{ github.run_number }} ${{ github.run_id }} ${{ matrix.os }}
       - name: Commit changes
-        if: always() && matrix.os == 'windows-2022'
+        if: always()
         run: |
+          cd wiki
           git config user.email 'vm-packages@mandiant.com'
           git config user.name 'vm-packages'
-          git add README.md
-          git commit -m 'Update daily success/failure badges'
-      - name: Push changes
-        if: always() && matrix.os == 'windows-2022'
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          git commit -am 'Add daily results'
+          git push
       - name: Upload chocolatey logs to artifacts
         uses: actions/upload-artifact@v3
         if: always()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Packages](https://img.shields.io/badge/packages-66-blue.svg)](packages)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
-[![Daily run success](https://img.shields.io/badge/pkgs--install--pass-61-green.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3Adaily+branch%3Amain)
-[![Daily run failure](https://img.shields.io/badge/pkgs--install--fail-3-orange.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3Adaily+branch%3Amain)
+[![Daily run](https://github.com/mandiant/VM-packages/workflows/daily/badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 
 # Virtual Machine Packages
 

--- a/scripts/utils/generate_daily_results.py
+++ b/scripts/utils/generate_daily_results.py
@@ -6,6 +6,8 @@ from datetime import datetime
 _, repository, commit, run_number, run_id, os = sys.argv
 
 # Do not keep old failures as logs are only kept for 90 days
+MAX_ENTRIES = 200
+HEADER_SIZE = 3
 result_file = "success_failure.json"
 log_file = "wiki/Daily-Failures.md"
 
@@ -16,10 +18,13 @@ url = f"https://github.com/{repository}"
 # Short OS (windows-2019 -> Win19) for nicer table display
 run = f"[#{run_number}]({url}/actions/runs/{run_id}) Win{os[-2:]}"
 date = datetime.today().strftime("%Y-%m-%d %H:%M")
-log_line = f"\n| {run} | {date} | {result['failure']}/{result['total']} |"
+log_line = f"| {run} | {date} | {result['failure']}/{result['total']} |"
 for package in result["failures"]:
     log_line += f" [{package}]({url}/blob/{commit}/packages/{package})"
-log_line += " |"
+log_line += " |\n"
 
-with open(log_file, "a") as log_f:
-    log_f.write(log_line)
+with open(log_file) as log_f_read:
+    lines = log_f_read.readlines()
+
+with open(log_file, "w") as log_f_write:
+    log_f_write.writelines(lines[:HEADER_SIZE] + [log_line] + lines[HEADER_SIZE:MAX_ENTRIES])

--- a/scripts/utils/generate_daily_results.py
+++ b/scripts/utils/generate_daily_results.py
@@ -1,0 +1,25 @@
+import json
+import sys
+from datetime import datetime
+
+# _, github.repository, github.sha, github.run_number, github.run_id, github.job, os
+_, repository, commit, run_number, run_id, os = sys.argv
+
+# Do not keep old failures as logs are only kept for 90 days
+result_file = "success_failure.json"
+log_file = "wiki/Daily-Failures.md"
+
+with open(result_file) as result_f:
+    result = json.load(result_f)
+
+url = f"https://github.com/{repository}"
+# Short OS (windows-2019 -> Win19) for nicer table display
+run = f"[#{run_number}]({url}/actions/runs/{run_id}) Win{os[-2:]}"
+date = datetime.today().strftime("%Y-%m-%d %H:%M")
+log_line = f"\n| {run} | {date} | {result['failure']}/{result['total']} |"
+for package in result["failures"]:
+    log_line += f" [{package}]({url}/blob/{commit}/packages/{package})"
+log_line += " |"
+
+with open(log_file, "a") as log_f:
+    log_f.write(log_line)


### PR DESCRIPTION
The success/failure badges didn't turned out to be as useful as anticipated and they generate a noisy commit almost every day. Replace the badges by a failures log file in the wiki that allows us to easily see which packages failed. This still generates a commit in the wiki, but it is better than in the project. I also think this file is more useful than the badges so that the commits are worth it.

This is how the page in the wiki looks like:
![Screenshot 2023-04-20 at 17 24 56](https://user-images.githubusercontent.com/16052290/233413300-4431ab32-1d67-49c9-b8b3-92ca62f91df8.png)
