### PR TITLE
Unify way of displaying errors in GH actions

### DIFF
--- a/.github/actions/upload-logs/action.yml
+++ b/.github/actions/upload-logs/action.yml
@@ -1,0 +1,20 @@
+name: Update logs
+description: Update test install logs to artifacts
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload VM logs to artifacts
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: log-VM-${{ matrix.os }}.zip
+        path: C:\ProgramData\_VM\log.txt
+    - name: Upload chocolatey logs to artifacts
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: logs-choco-${{ matrix.os }}.zip
+        path: |
+          C:\ProgramData\chocolatey\logs\chocolatey.log
+          C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         run: |
           $packages = "${{ steps.files.outputs.added_modified_renamed }}".Split(" ") | Foreach-Object { (Get-Item $_).Directory.Name }
           scripts/test/test_install.ps1 "common.vm $packages"
+      - name: Upload logs to artifacts
+        uses: ./.github/actions/upload-logs
+        if: always()
       - name: Push all built packages to MyGet
         # Only push packages on master if they were built (not if testing was skipped) and
         # only with one version of Windows (otherwise it would be pushed 3 times)
@@ -53,12 +56,3 @@ jobs:
           foreach ($package in $built_pkgs) {
               cpush -s "https://www.myget.org/F/vm-packages/api/v2" -k ${{ secrets.MYGET_TOKEN }} $package
           }
-      - name: Upload chocolatey logs to artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: logs-${{ matrix.os }}.zip
-          path: |
-            C:\ProgramData\chocolatey\logs\chocolatey.log
-            C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt
-            C:\ProgramData\_VM\log.txt

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Build and test all packages
         id: test
         run: scripts/test/test_install.ps1 -all
-      - name: Display log warnings and errors
+      - name: Upload logs to artifacts
+        uses: ./.github/actions/upload-logs
         if: always()
-        run: if (Test-Path -Path C:\ProgramData\_VM\log.txt ) { Select-String "ERR|WARN" -CaseSensitive -Context 0,5 C:\ProgramData\_VM\log.txt }
       - name: Checkout wiki code
         if: always()
         uses: actions/checkout@v3
@@ -42,12 +42,3 @@ jobs:
           git config user.name 'vm-packages'
           git commit -am 'Add daily results'
           git push
-      - name: Upload chocolatey logs to artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: logs-${{ matrix.os }}.zip
-          path: |
-            C:\ProgramData\chocolatey\logs\chocolatey.log
-            C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt
-            C:\ProgramData\_VM\log.txt

--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -33,7 +33,7 @@ jobs:
               echo "$package $version"
               if ($updated -and $version) {
                 # Test package before committing
-                scripts\test\test_install.ps1 $package *>> "test_logs/$package.txt"
+                scripts\test\test_install.ps1 $package | out-null
                 $tested = $?
                 cd $root
                 if ($tested) {
@@ -52,6 +52,9 @@ jobs:
             }
           }
           Exit(0)
+      - name: Upload logs to artifacts
+        uses: ./.github/actions/upload-logs
+        if: always()
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
@@ -63,10 +66,4 @@ jobs:
           # GH actions can not trigger other GH actions,
           # use a Personal Access Token to trigger the CI workflow in the created PR
           token: ${{ secrets.REPO_TOKEN }}
-      - name: Upload test output to assets
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test_logs
-          path: test_logs/
 


### PR DESCRIPTION
There are 3 workflows that install packages and upload/display differently the errors. Upload choco & VM logs as artifacts in two zips for all workflows. Use [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action) to avoid repeating code and ensuring consistency.

You can see it working in https://github.com/Ana06/VM-Packages/pull/29

Closes https://github.com/mandiant/VM-Packages/issues/299