### PR TITLE
Fix pestudio.vm

### DIFF
--- a/packages/pestudio.vm/pestudio.vm.nuspec
+++ b/packages/pestudio.vm/pestudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pestudio.vm</id>
-    <version>9.47</version>
+    <version>9.49</version>
     <authors>Marc Ochsenmeier</authors>
     <description>The goal of pestudio is to spot artifacts of executable files in order to ease and accelerate Malware Initial Assessment.</description>
     <dependencies>

--- a/packages/pestudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/pestudio.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'pestudio'
 $category = 'PE'
 
 $zipUrl = 'https://www.winitor.com/tools/pestudio/current/pestudio.zip'
-$zipSha256 = 'E1CA8E305C080EF6880173BD7F17F7E4773C420F8545DB9A72F6958F1AEDDC0A'
+$zipSha256 = '2069D3FF8BA5B523D4CCC76A8C8191A1510F04DAD75EA23E35EB0D14F8C97C07'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true


### PR DESCRIPTION
pestudio uses a download url that does not include the version and breaks with every update. Update to the last version to fix the hash mismatch. See https://www.winitor.com/download2