### PR TITLE
Reinstall packages to prevent transient failures

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build and test all packages
         id: test
-        run: scripts/test/test_install.ps1 -all
+        run: scripts/test/test_install.ps1 -all -max_tries 3
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
         if: always()


### PR DESCRIPTION
We often get in the daily run the error:
`The remote file either doesn't exist, is unauthorized, or is forbidden for url`

Reinstall a package when the installation fails to prevent transient failures in tests. Reinstall twice by default to avoid delaying test runs (locally and in PRs) too much. Run it three times in the daily runs as time is not an issue in this case and the transient failures are very annoying in the logs.

Similar approach as in: https://github.com/actions/runner-images/pull/721

Closes https://github.com/mandiant/VM-Packages/issues/311 