### PR TITLE
Adding Sliver client

### DIFF
--- a/packages/sliver-client.vm/sliver-client.vm.nuspec
+++ b/packages/sliver-client.vm/sliver-client.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>sliver-client.vm</id>
+    <version>1.5.38</version>
+    <authors>BishopFox</authors>
+    <description>Sliver client, part of the Sliver open source cross-platform adversary emulation/red team framework</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/sliver-client.vm/tools/chocolateyinstall.ps1
+++ b/packages/sliver-client.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'Sliver-Client'
+$category = 'Command & Control'
+
+$exeUrl = 'https://github.com/BishopFox/sliver/releases/download/v1.5.38/sliver-client_windows.exe'
+$exeSha256 = 'ad1117e7a6d3284f9ddc7f8ec841f72b759932d1467cffd9633af242f8f00798'
+
+VM-Install-Single-Exe $toolName $category $exeUrl -exeSha256 $exeSha256

--- a/packages/sliver-client.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sliver-client.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'Sliver-Client'
+$category = 'Command & Control'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
The Sliver client is used as part of an adversary emulation framework. The framework is being used in red team training classes and is a viable alternative to the closed-source Cobalt Strike adversary emulation framework.

Source:
https://github.com/BishopFox/sliver