### PR TITLE
Fix stringsifter & improve libraries.python3.vm installer

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230517</version>
+    <version>0.0.0.20230522</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ try {
     # https://github.com/mandiant/stringsifter/issues/29
     Invoke-Expression "py -3.9 -m pip install pip==20.1 >> $outputFile"
 
-    $failures = @{}
+    $failures = @()
     $modules = $modulesXml.modules.module
     foreach ($module in $modules) {
         Write-Host "[+] Attempting to install Python3 module: $($module.name)"
@@ -28,12 +28,12 @@ try {
             Write-Host "`t[+] Installed Python 3.9 module: $($module.name)" -ForegroundColor Green
         } else {
             Write-Host "`t[!] Failed to install Python 3.9 module: $($module.name)" -ForegroundColor Red
-            $failures[$module.Name] = $true
+            $failures += $module.Name
         }
     }
 
-    if ($failures.Keys.Count -gt 0) {
-        foreach ($module in $failures.Keys) {
+    if ($failures.Count -gt 0) {
+        foreach ($module in $failures) {
             VM-Write-Log "ERROR" "Failed to install Python 3.9 module: $module"
         }
         $outputFile = $outputFile.replace('lib\', 'lib-bad\')

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -9,8 +9,9 @@ try {
     # Create output file to log python module installation details
     $outputFile = VM-New-Install-Log $toolDir
 
-    # Upgrade pip
-    Invoke-Expression "py -3.9 -m pip install -qq --no-cache-dir --upgrade pip 2>&1 >> $outputFile"
+    # Fix pip version, stringsifter doesn't install with pip 23:
+    # https://github.com/mandiant/stringsifter/issues/29
+    Invoke-Expression "py -3.9 -m pip install pip==20.1 >> $outputFile"
 
     $failures = @{}
     $modules = $modulesXml.modules.module
@@ -39,6 +40,8 @@ try {
         VM-Write-Log "ERROR" "Check $outputFile for more information"
         exit 1
     }
+    # Avoid WARNINGs to fail the package install
+    exit 0
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -19,8 +19,8 @@
     <module name="pyOpenSSL"/>
     <module name="psutil"/>
     <module name="requests"/>
-    <!-- Having issues manually installing as well... -->
-    <!-- <module name="stringsifter"/> -->
+    <!-- Restrict stringsifter dependencies https://github.com/mandiant/stringsifter/issues/30 -->
+    <module name="stringsifter" url ="https://github.com/Ana06/stringsifter/archive/refs/heads/master.zip"/>
     <module name="uncompyle6"/>
     <module name="unpy2exe"/>
     <module name="unicorn"/>


### PR DESCRIPTION
- Use a patched version that restrict the dependencies [https://github.com/Ana06/stringsifter](https://github.com/mandiant/stringsifter/compare/master...Ana06:stringsifter:master). Note it uses scikit-learn 0.23 which is not supposed to support Python 3.9, but I have tested and seems to work (I assume stringsifter doesn not use all the functionality of scikit-learn). To update scikit-learn in stringsifter, the pickle models need to be recreated (maybe not easy). So I think this is a good solution (as long as it works).
  - https://github.com/mandiant/stringsifter/issues/30
- Use a lower version of pip as fasttext (dependency of stringsifter) doesn't install with newer pip versions
  - https://github.com/mandiant/stringsifter/issues/29
 - Use array instead of hash in libraries.python3.vm as there is no reason to use a hash and the code looks a bit nicer as we don't have to access the keys.