### PR TITLE
Improve/fix right click menu

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230522</version>
+    <version>0.0.0.20230523</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20221220</version>
+    <version>0.0.0.20230522</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -691,6 +691,7 @@ function VM-Add-To-Right-Click-Menu {
         } else {
             $key = "directory"
         }
+        $key_path = "HKCR:\$key\shell\$menuKey"
 
         # Check and map "HKCR" to correct drive
         if (-NOT (Test-Path -path 'HKCR:')) {
@@ -698,16 +699,16 @@ function VM-Add-To-Right-Click-Menu {
         }
 
         # Add right-click menu display name
-        if (-NOT (Test-Path -LiteralPath "HKCR:\$key\shell\$menuKey")) {
-            New-Item -Path "HKCR:\$key\shell\$menuKey" | Out-Null
+        if (-NOT (Test-Path -LiteralPath $key_path)) {
+            New-Item -Path $key_path | Out-Null
         }
-        Set-ItemProperty -LiteralPath "HKCR:\$key\shell\$menuKey" -Name '(Default)' -Value "$menuLabel" -Type String
+        Set-ItemProperty -LiteralPath $key_path -Name '(Default)' -Value "$menuLabel" -Type String
 
         # Add command to run when executed from right-click menu
-        if(-NOT (Test-Path -LiteralPath "HKCR:\$key\shell\$menuKey\command")) {
-            New-Item -Path "HKCR:\$key\shell\$menuKey\command" | Out-Null
+        if(-NOT (Test-Path -LiteralPath "$key_path\command")) {
+            New-Item -Path "$key_path\command" | Out-Null
         }
-        Set-ItemProperty -LiteralPath "HKCR:\$key\shell\$menuKey\command" -Name '(Default)' -Value $command -Type String
+        Set-ItemProperty -LiteralPath "$key_path\command" -Name '(Default)' -Value $command -Type String
     } catch {
         VM-Write-Log "ERROR" "Failed to add $menuKey to right-click menu"
     }
@@ -729,6 +730,7 @@ function VM-Remove-From-Right-Click-Menu {
         } else {
             $key = "directory"
         }
+        $key_path = "HKCR:\$key\shell\$menuKey"
 
         # Check and map "HKCR" to correct drive
         if (-NOT (Test-Path -path 'HKCR:')) {
@@ -736,8 +738,8 @@ function VM-Remove-From-Right-Click-Menu {
         }
 
         # Remove right-click menu settings from registry
-        if (Test-Path -LiteralPath "HKCR:\$key\shell\$menuKey") {
-            Remove-Item -LiteralPath "HKCR:\$key\shell\$menuKey" -Recurse
+        if (Test-Path -LiteralPath $key_path) {
+            Remove-Item -LiteralPath $key_path -Recurse
         }
     } catch {
         VM-Write-Log "ERROR" "Failed to remove $menuKey from right-click menu"

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -682,7 +682,9 @@ function VM-Add-To-Right-Click-Menu {
         [string] $command,
         [Parameter(Mandatory=$true, Position=3)]
         [ValidateSet("file", "directory")]
-        [string] $type
+        [string] $type,
+        [Parameter(Mandatory=$false, Position=4)]
+        [string] $menuIcon
     )
     try {
         # Determine if file or directory should show item in right-click menu
@@ -703,6 +705,9 @@ function VM-Add-To-Right-Click-Menu {
             New-Item -Path $key_path | Out-Null
         }
         Set-ItemProperty -LiteralPath $key_path -Name '(Default)' -Value "$menuLabel" -Type String
+        if ($menuIcon) {
+          Set-ItemProperty -LiteralPath $key_path -Name 'Icon' -Value "$menuIcon" -Type String
+        }
 
         # Add command to run when executed from right-click menu
         if(-NOT (Test-Path -LiteralPath "$key_path\command")) {

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.07</version>
+    <version>3.07.20230523</version>
     <authors>Hellsp@wn, horsicq</authors>
     <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
     <dependencies>

--- a/packages/die.vm/tools/chocolateyinstall.ps1
+++ b/packages/die.vm/tools/chocolateyinstall.ps1
@@ -11,7 +11,7 @@ try {
   $zipSha256_64 = '3450169643be76484ac4bd5e1473f6f4745d9825c8a07255a3925a4a6e8bad7e'
 
   $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -zipUrl_64 $zipUrl_64 -zipSha256_64 $zipSha256_64)[-1]
-  VM-Add-To-Right-Click-Menu $toolName "detect it easy (DIE)" "`"$executablePath`" `"%1`"" "file"
+  VM-Add-To-Right-Click-Menu $toolName "detect it easy (DIE)" "`"$executablePath`" `"%1`"" "file" "$executablePath"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/explorersuite.vm.nuspec
+++ b/packages/explorersuite.vm/explorersuite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>explorersuite.vm</id>
-    <version>0.0.0.20221115</version>
+    <version>0.0.0.20230523</version>
     <authors>Erik Pistelli</authors>
     <description>A suite of tools including CFF Explorer and a process viewer.</description>
     <dependencies>

--- a/packages/explorersuite.vm/tools/chocolateyinstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyinstall.ps1
@@ -26,7 +26,12 @@ try {
     VM-Assert-Path $shortcut
   }
 
-  Install-BinFile -Name 'CFFExplorer' -Path (Join-Path $toolDir 'CFF Explorer.exe')
+  $cffExplorerExecutablePath = Join-Path $toolDir 'CFF Explorer.exe' -Resolve
+  Install-BinFile -Name 'CFFExplorer' -Path $cffExplorerExecutablePath
+  # "Open with CFF Explorer" is added to the registry for several extensions,
+  # add it for all extension with same key to avoid duplication.
+  # Use same label and no icon to make it look the same for all extensions.
+  VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExplorerExecutablePath`" %1" "file"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
@@ -7,4 +7,6 @@ foreach ($subtoolName in $subtoolNames) {
   VM-Remove-Tool-Shortcut  $subtoolName $category
 }
 
+VM-Remove-From-Right-Click-Menu 'CFF explorer' "file"
+
 VM-Uninstall-With-Uninstaller "Explorer Suite IV" "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20230523</version>
+    <version>0.0.0.20230524</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20220113</version>
+    <version>0.0.0.20230523</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>

--- a/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
@@ -9,8 +9,8 @@ try {
   $zipUrl_64 = "https://www.nirsoft.net/utils/hashmyfiles-x64.zip"
 
   $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipUrl_64 $zipUrl_64)[-1]
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "file"
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "directory"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "file" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "directory" "$executablePath"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
@@ -9,8 +9,8 @@ try {
   $zipUrl_64 = "https://www.nirsoft.net/utils/hashmyfiles-x64.zip"
 
   $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipUrl_64 $zipUrl_64)[-1]
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "file" "$executablePath"
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" `"%1`"" "directory" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "file" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "directory" "$executablePath"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/hxd.vm/hxd.vm.nuspec
+++ b/packages/hxd.vm/hxd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hxd.vm</id>
-    <version>2.5.0.20230425</version>
+    <version>2.5.0.20230524</version>
     <authors>Maël Hörz</authors>
     <description>Freeware hex editor</description>
     <dependencies>

--- a/packages/hxd.vm/tools/chocolateyinstall.ps1
+++ b/packages/hxd.vm/tools/chocolateyinstall.ps1
@@ -12,6 +12,8 @@ try {
     VM-Assert-Path $shortcut
 
     Install-BinFile -Name $toolName -Path $executablePath
+
+    VM-Add-To-Right-Click-Menu $toolName $toolName "`"$executablePath`" `"%1`"" "file" "$executablePath"
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/hxd.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hxd.vm/tools/chocolateyuninstall.ps1
@@ -5,5 +5,5 @@ $toolName = 'HxD'
 $category = 'Hex Editors'
 
 VM-Remove-Tool-Shortcut $toolName $category
+VM-Remove-From-Right-Click-Menu $toolName "file"
 Uninstall-BinFile -Name $toolName
-


### PR DESCRIPTION
- Support icons in the right click menu by adding an argument to the `VM-Add-To-Right-Click-Menu` helper function
- Add icon to the right click menu entries of DIE and HashMyFiles
- Fix HashMyFiles right click menu command.
- Add CFF explorer (for all extensions) and HxD to the right click menu.

![Screenshot 2023-05-24 at 22 33 22](https://github.com/mandiant/VM-Packages/assets/16052290/1955347f-4095-46d6-966f-a3ddf9973c9d)

Closes https://github.com/mandiant/VM-Packages/issues/250

@mr-tz @emtuls some extra manual testing would be good if you have time to ensure this works as everybody expects. 😉 