### PR TITLE
visualstudio.vm: Add Visual Studio Community 2022

### DIFF
--- a/packages/visualstudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'VisualStudio'
+    $category = 'Utilities'
+
+    # Install with choco instead as dependency to provide params to add common components
+    # The community package chocolatey-visualstudio.extension 1.11 includes a -DefaultParameterValues parameter
+    # that would be a better solution (as it would allow to change the parameters when installing the package),
+    # but only a preview is available at the moment.
+    choco install visualstudio2022community --params "--add Microsoft.VisualStudio.Component.CoreEditor --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --includeRecommended"
+
+    $executablePath = Join-Path ${Env:ProgramFiles} "Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe" -Resolve
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+    $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
+    VM-Assert-Path $shortcut
+} catch {
+    VM-Write-Log-Exception $_
+}

--- a/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'VisualStudio'
+$category = 'Utilities'
+
+VM-Remove-Tool-Shortcut $toolName $category
+
+choco uninstall visualstudio2022community --removedependencies

--- a/packages/visualstudio.vm/visualstudio.nuspec
+++ b/packages/visualstudio.vm/visualstudio.nuspec
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>visualstudio.vm</id>
+    <version>0.0.0.20230525</version>
+    <description>IDE.</description>
+    <authors>Microsoft</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+      <!-- Install any 2.16.x.y version of nasm, this syntax is not automatically updated,
+      what is desirable in this case to ensure the assembler works in the same way. -->
+      <dependency id="nasm" version="[2.16,2.17)"/>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Add package for Visual Studio Community that install the community package `visualstudio2022community` adding the following common components:
- Visual Studio core editor
- Desktop development with C++
- .NET desktop development

I am not sure if there is a better way to install `visualstudio2022community` with parameters than using `choco install` in the install script, but this seems to work. The community package `chocolatey-visualstudio.extension` 1.11 includes a `-DefaultParameterValues` parameter that would be a better solution (as it would allow to change the parameters when installing the package), but only a preview is available at the moment. A stable release of a package is not allowed to have on a prerelease dependency.

Install the nasm assembler as dependency.

Closes https://github.com/mandiant/VM-Packages/issues/306
Closes https://github.com/mandiant/VM-Packages/issues/307