### PR TITLE
windbg.vm: Add WinDbg

### DIFF
--- a/packages/windbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/windbg.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'WinDbg'
+    $category = 'Debuggers'
+
+    # It seems WinDbg is now distributed as an .appinstaller and we need to install it using Add-AppxPackage
+    Add-AppxPackage -AppInstallerFile 'https://windbg.download.prss.microsoft.com/dbazure/prod/1-0-0/windbg.appinstaller'
+
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+    $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+    $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe"
+    # Use `start` to close the open console
+    $executableArgs = "/C start WinDbgX.exe"
+    $executableDir  = Join-Path ${Env:UserProfile} "Desktop"
+    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $executableDir -RunAsAdmin
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/packages/windbg.vm/tools/chocolateyuninstall.ps1
+++ b/packages/windbg.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'WinDbg'
+$category = 'Debuggers'
+
+VM-Remove-Tool-Shortcut $toolName $category
+
+Get-AppxPackage *WinDbg* | Remove-AppxPackage

--- a/packages/windbg.vm/windbg.vm.nuspec
+++ b/packages/windbg.vm/windbg.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>windbg.vm</id>
+    <version>0.0.0</version>
+    <authors>Microsoft</authors>
+    <description>WinDbg is a debugger that can be used to analyze crash dumps, debug live user-mode and kernel-mode code, and examine CPU registers and memory.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>
+


### PR DESCRIPTION
It seems WinDbg is now distributed as an `.appinstaller` (which uses a `.msixbundl`) and we need to install it using `Add-AppxPackage`. At least I didn't found an easy way to install it directly using choco helper functions.

Closes https://github.com/mandiant/VM-Packages/issues/252