### PR TITLE
Fix several shortcuts & Unify how shortcuts are created 

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230523</version>
+    <version>0.0.0.20230526</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -265,6 +265,44 @@ function VM-Install-Raw-GitHub-Repo {
     }
 }
 
+function VM-Install-Shortcut{
+    [CmdletBinding()]
+    Param
+    (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $toolName,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $category,
+        [Parameter(Mandatory=$true, Position=2)]
+        [string] $executablePath,
+        [Parameter(Mandatory=$false)]
+        [bool] $consoleApp=$false,
+        [Parameter(Mandatory=$false)]
+        [switch] $runAsAdmin=$false,
+        [Parameter(Mandatory=$false)]
+        [string] $executableDir,
+        [Parameter(Mandatory=$false)]
+        [string] $arguments = "--help"
+    )
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+    $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+
+    if ($consoleApp) {
+        if (!$executableDir) {
+            $executableDir  = Join-Path ${Env:UserProfile} "Desktop"
+        }
+        VM-Assert-Path $executableDir
+
+        $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
+        # Change to executable dir, print command to execute, and execute command
+        $executableArgs = "/K `"cd `"$executableDir`" && echo $executableDir^> $executablePath $arguments && `"$executablePath`" $arguments`""
+        Install-ChocolateyShortcut -ShortcutFilePath $shortcut -TargetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $executableDir -IconLocation $executablePath -RunAsAdmin $runAsAdmin
+    } else {
+        Install-ChocolateyShortcut -ShortcutFilePath $shortcut -TargetPath $executablePath -RunAsAdmin $runAsAdmin
+    }
+    VM-Assert-Path $shortcut
+}
+
 # This functions returns $executablePath and $toolDir (outputed by Install-ChocolateyZipPackage)
 function VM-Install-From-Zip {
     [CmdletBinding()]
@@ -285,11 +323,12 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [bool] $consoleApp=$false,
         [Parameter(Mandatory=$false)]
-        [bool] $innerFolder=$false # subfolder in zip with the app files
+        [bool] $innerFolder=$false, # subfolder in zip with the app files
+        [Parameter(Mandatory=$false)]
+        [string] $arguments = "--help"
     )
     try {
         $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
-        $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
         # Remove files from previous zips for upgrade
         VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
@@ -333,18 +372,7 @@ function VM-Install-From-Zip {
         }
 
         $executablePath = Join-Path $toolDir "$toolName.exe" -Resolve
-        $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-
-        if ($consoleApp) {
-            $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe"
-            $executableDir  = Join-Path ${Env:UserProfile} "Desktop"
-            $executableArgs = "/K `"cd `"$executableDir`" && `"$executablePath`" --help`""
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $executableDir -IconLocation $executablePath
-        } else {
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-        }
-        VM-Assert-Path $shortcut
-
+        VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
         Install-BinFile -Name $toolName -Path $executablePath
         return $executablePath
     } catch {
@@ -370,11 +398,12 @@ function VM-Install-Single-Exe {
         [Parameter(Mandatory=$false)]
         [string] $exeSha256_64,
         [Parameter(Mandatory=$false)]
-        [bool] $consoleApp=$false
+        [bool] $consoleApp=$false,
+        [Parameter(Mandatory=$false)]
+        [string] $arguments = "--help"
     )
     try {
         $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
-        $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
         # Get the file extension from the URL
         $ext = (Split-Path -Path $exeUrl -Leaf).Split(".")[-1]
@@ -394,18 +423,7 @@ function VM-Install-Single-Exe {
         Get-ChocolateyWebFile @packageArgs
         VM-Assert-Path $executablePath
 
-        $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-
-        if ($consoleApp) {
-            $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
-            $executableDir  = Join-Path ${Env:UserProfile} "Desktop" -Resolve
-            $executableArgs = "/K `"cd `"$executableDir`" && `"$executablePath`" --help`""
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $executableDir -IconLocation $executablePath
-        } else {
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-        }
-        VM-Assert-Path $shortcut
-
+        VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
         Install-BinFile -Name $toolName -Path $executablePath
         return $executablePath
     } catch {
@@ -536,7 +554,9 @@ function VM-Install-With-Installer {
         [Parameter(Mandatory=$false)]
         [array] $validExitCodes= @(0, 3010, 1605, 1614, 1641),
         [Parameter(Mandatory=$false)]
-        [bool] $consoleApp=$false
+        [bool] $consoleApp=$false,
+        [Parameter(Mandatory=$false)]
+        [string] $arguments = "--help"
     )
     try {
         $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
@@ -589,18 +609,7 @@ function VM-Install-With-Installer {
         Install-ChocolateyInstallPackage @packageArgs
         VM-Assert-Path $executablePath
 
-        $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-        $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-        if ($consoleApp) {
-            $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe"
-            $executableDir  = Join-Path ${Env:UserProfile} "Desktop"
-            $executableArgs = "/K `"cd `"$executableDir`" && `"$executablePath`" --help`""
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $executableDir -IconLocation $executablePath
-        } else {
-            Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-        }
-        VM-Assert-Path $shortcut
-
+        VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
         Install-BinFile -Name $toolName -Path $executablePath
     } catch {
         VM-Write-Log-Exception $_

--- a/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
+++ b/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>de4dot-cex.vm</id>
-    <version>4.0.0</version>
+    <version>4.0.0.20230526</version>
     <authors>ViRb3</authors>
     <description>A de4dot fork with full support for vanilla ConfuserEx</description>
     <dependencies>

--- a/packages/de4dot-cex.vm/tools/chocolateyinstall.ps1
+++ b/packages/de4dot-cex.vm/tools/chocolateyinstall.ps1
@@ -1,10 +1,18 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'de4dot'
-$category = 'dotNet'
+try {
+    $toolName = 'de4dot'
+    $category = 'dotNet'
 
-$zipUrl = 'https://github.com/ViRb3/de4dot-cex/releases/download/v4.0.0/de4dot-cex.zip'
-$zipSha256 = 'C726CBD18B894CA63B7F6A565C6C86EF512B96E68119C6502CDF64A51F6A1C78'
+    $zipUrl = 'https://github.com/ViRb3/de4dot-cex/releases/download/v4.0.0/de4dot-cex.zip'
+    $zipSha256 = 'C726CBD18B894CA63B7F6A565C6C86EF512B96E68119C6502CDF64A51F6A1C78'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256
+    VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true
+
+    # Add link for de4dot-x64.exe
+    $executablePath = Join-Path ${Env:RAW_TOOLS_DIR} "de4dot\$toolName-x64.exe" -Resolve
+    VM-Install-Shortcut "$toolName-x64" $category $executablePath -consoleApp $true
+} catch {
+    VM-Write-Log-Exception $_
+}

--- a/packages/de4dot-cex.vm/tools/chocolateyuninstall.ps1
+++ b/packages/de4dot-cex.vm/tools/chocolateyuninstall.ps1
@@ -5,3 +5,4 @@ $toolName = 'de4dot'
 $category = 'dotNet'
 
 VM-Uninstall $toolName $category
+VM-Remove-Tool-Shortcut "$toolName-x64" $category

--- a/packages/dnspyex.vm/dnspyex.vm.nuspec
+++ b/packages/dnspyex.vm/dnspyex.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dnspyex.vm</id>
-    <version>6.3.0</version>
+    <version>6.3.0.20230526</version>
     <authors>0xd4d, ElektroKill</authors>
     <description>dnSpyEx is a unofficial continuation of the dnSpy project which is a debugger and .NET assembly editor. You can use it to edit and debug assemblies even if you don't have any source code available.</description>
     <dependencies>

--- a/packages/dnspyex.vm/tools/chocolateyinstall.ps1
+++ b/packages/dnspyex.vm/tools/chocolateyinstall.ps1
@@ -6,11 +6,8 @@ try {
   $category = 'dotNet'
   $shimPath = 'bin\dnSpy.Console.exe'
 
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
   $executablePath = Join-Path ${Env:ChocolateyInstall} $shimPath -Resolve
-  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin
-  VM-Assert-Path $shortcut
+  VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $null
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
+++ b/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>rundotnetdll.vm</id>
-    <version>2.2</version>
+    <version>2.2.0.20230526</version>
     <description>A simple utility to list all methods of a given .NET Assembly and to invoke them.</description>
     <authors>Antonio Parata</authors>
     <dependencies>

--- a/packages/rundotnetdll.vm/tools/chocolateyinstall.ps1
+++ b/packages/rundotnetdll.vm/tools/chocolateyinstall.ps1
@@ -7,5 +7,5 @@ $category = 'dotNet'
 $zipUrl = 'https://github.com/enkomio/RunDotNetDll/releases/download/2.2/RunDotNetDll.zip'
 $zipSha256 = '27B922861DD27C8DC484524EB7B3AE8F2FB6CA44C1C7086D9ED529A7B4E7CC1D'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -arguments $null
 


### PR DESCRIPTION
- Unify how shortcuts are created by introducing a `VM-Install-Shortcut` helper function in common and use it in the other helper functions.
- Fix dnspyex shortcut
- Fix rundotnetdll shortcut
- Fix ce4dot shortcut
- Ad de4dot-x64 shortcut