### PR TITLE
Fixed linter regex

### DIFF
--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -334,7 +334,7 @@ class UsesInvalidCategory(Lint):
         # utf-8-sig ignores BOM
         file_content = open(path, "r", encoding="utf-8-sig").read()
 
-        match = re.search("\$category = ['\"](?P<category>[\w ]+)['\"]", file_content)
+        match = re.search("\$category = ['\"](?P<category>[\w &]+)['\"]", file_content)
         if not match or match.group("category") not in self.CATEGORIES:
             return True
         return False


### PR DESCRIPTION
per PRs #328 and #372, the linter had faulty regex that didn't approve of the "Command & Control" category.

thanks to @mr-tz for the fix suggested in #328 