### PR TITLE
dnspyex.vm: Fix dnSpy

### DIFF
--- a/packages/dnspyex.vm/dnspyex.vm.nuspec
+++ b/packages/dnspyex.vm/dnspyex.vm.nuspec
@@ -2,12 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dnspyex.vm</id>
-    <version>6.3.0.20230526</version>
+    <version>6.3.0.20230605</version>
     <authors>0xd4d, ElektroKill</authors>
     <description>dnSpyEx is a unofficial continuation of the dnSpy project which is a debugger and .NET assembly editor. You can use it to edit and debug assemblies even if you don't have any source code available.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="dnspyex" version="[6.3.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dnspyex.vm/tools/chocolateyinstall.ps1
+++ b/packages/dnspyex.vm/tools/chocolateyinstall.ps1
@@ -2,12 +2,22 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $toolName = 'dnSpyEx'
+  $toolName = 'dnSpy'
   $category = 'dotNet'
-  $shimPath = 'bin\dnSpy.Console.exe'
 
-  $executablePath = Join-Path ${Env:ChocolateyInstall} $shimPath -Resolve
-  VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $null
+  $zipUrl = "https://github.com/dnSpyEx/dnSpy/releases/download/v6.3.0/dnSpy-netframework.zip"
+  $zipSha256 = "122df37b8668eb38be1c139cb244185824ff0f2ab4b4c81862a8397c6c2e7f1f"
+  $toolDir = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256)[0]
+
+  $toolNameX86 = "$toolName-x86"
+  $executablePathX86 = Join-Path $toolDir "$toolNameX86.exe" -Resolve
+  VM-Install-Shortcut $toolNameX86 $category $executablePathX86
+  Install-BinFile -Name $toolNameX86 -Path $executablePathX86
+
+  $toolNameConsole = "$toolName.Console"
+  $executablePathConsole = Join-Path $toolDir "$toolNameConsole.exe" -Resolve
+  VM-Install-Shortcut $toolNameConsole $category $executablePathConsole -consoleApp $true -arguments $null
+  Install-BinFile -Name $toolNameConsole -Path $executablePathConsole
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/dnspyex.vm/tools/chocolateyuninstall.ps1
+++ b/packages/dnspyex.vm/tools/chocolateyuninstall.ps1
@@ -1,7 +1,15 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'dnSpyEx'
+$toolName = 'dnSpy'
 $category = 'dotNet'
 
-VM-Remove-Tool-Shortcut $toolName $category
+VM-Uninstall $toolName $category
+
+$toolNameX86 = "$toolName-x86"
+VM-Remove-Tool-Shortcut $toolNameX86 $category
+Uninstall-BinFile -Name $toolNameX86
+
+$toolNameConsole = "$toolName.Console"
+VM-Remove-Tool-Shortcut $toolNameConsole $category
+Uninstall-BinFile -Name $toolNameConsole


### PR DESCRIPTION
Install dnSpyEx directly instead of using the community package as it does not install both 64 and 32 versions. Add shortcuts for both GUI applications (in addition to the console app that was already created).

Closes https://github.com/mandiant/VM-Packages/issues/412
Closes https://github.com/mandiant/VM-Packages/issues/370