### PR TITLE
ida.diaphora.vm: Add diaphora

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230606</version>
+    <version>0.0.0.20230615</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -323,9 +323,13 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [bool] $consoleApp=$false,
         [Parameter(Mandatory=$false)]
-        [bool] $innerFolder=$false, # subfolder in zip with the app files
+        [bool] $innerFolder=$false, # Subfolder in zip with the app files
         [Parameter(Mandatory=$false)]
-        [string] $arguments = "--help"
+        [string] $arguments = "--help",
+        [Parameter(Mandatory=$false)]
+        [string] $executableName, # Executable name, needed if different from "$toolName.exe"
+        [Parameter(Mandatory=$false)]
+        [switch] $withoutBinFile # Tool should not be installed as a bin file
     )
     try {
         $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
@@ -371,9 +375,10 @@ function VM-Install-From-Zip {
             }
         }
 
-        $executablePath = Join-Path $toolDir "$toolName.exe" -Resolve
+        if (-Not $executableName) { $executableName = "$toolName.exe" }
+        $executablePath = Join-Path $toolDir $executableName -Resolve
         VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
-        Install-BinFile -Name $toolName -Path $executablePath
+        if (-Not $withoutBinFile) { Install-BinFile -Name $toolName -Path $executablePath }
         return $executablePath
     } catch {
         VM-Write-Log-Exception $_

--- a/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
+++ b/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.diaphora.vm</id>
+    <version>2.1.0</version>
+    <authors>joxeankoret</authors>
+    <description>Diaphora is a program diffing tool that works as an IDA plugin.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.diaphora.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.diaphora.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'diaphora'
+    $category = 'Utilities'
+    $executableName = "diaphora.py"
+
+    $zipUrl = 'https://github.com/joxeankoret/diaphora/archive/refs/tags/2.1.0.zip'
+    $zipSha256 = 'bd946942081b46991e8ee5a2788088110e0eef7649791c661ed41566d4dd2993'
+
+    # Diaphora needs to be executed from IDA, do not install bin file
+    VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -executableName $executableName -innerFolder $true -withoutBinFile
+} catch {
+    VM-Write-Log-Exception $_
+}

--- a/packages/ida.diaphora.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.diaphora.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'diaphora'
+$category = 'Utilities'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
Note diaphora is a bit different than the existent packages, as doesn't contain an executable, but a Python script that needs to be run from IDA. We just unzip the tool files to the Tools directory. Adjust the helper `VM-Install-From-Zip` to support this case.

I think we shouldn't add diaphora as default package for flare-vm, but I would like to install it myself.

Closes https://github.com/mandiant/VM-Packages/issues/268