### PR TITLE
pestudio.vm: Update to fix broken hash

### DIFF
--- a/packages/pestudio.vm/pestudio.vm.nuspec
+++ b/packages/pestudio.vm/pestudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pestudio.vm</id>
-    <version>9.51</version>
+    <version>9.52</version>
     <authors>Marc Ochsenmeier</authors>
     <description>The goal of pestudio is to spot artifacts of executable files in order to ease and accelerate Malware Initial Assessment.</description>
     <dependencies>

--- a/packages/pestudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/pestudio.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'pestudio'
 $category = 'PE'
 
 $zipUrl = 'https://www.winitor.com/tools/pestudio/current/pestudio.zip'
-$zipSha256 = '338DEF87BBAEBAC4D18B8A4B74A8445E3F8FE21E741F92701F705A9749250818'
+$zipSha256 = 'b2018f1ec8df54f2b4c1df659a13cfa8b5b41fa5da18b24c9793c44289420c0a'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true


### PR DESCRIPTION
pestudio has been updated breaking the hash.

I have asked the author if it would be possible that he keeps the old link for some time so that the update doesn't break the package and it seem he is willing to help 🥰  https://twitter.com/ochsenmeier/status/1665675755244736514
![Screenshot 2023-06-06 at 11 22 21](https://github.com/mandiant/VM-Packages/assets/16052290/30baca1b-340d-4e8b-885e-407fc34c7fd1)
