### PR TITLE
Chocolatey 2: Do not used removed shims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
           Set-Location built_pkgs
 
           foreach ($package in $built_pkgs) {
-              cpush -s "https://www.myget.org/F/vm-packages/api/v2" -k ${{ secrets.MYGET_TOKEN }} $package
+              choco push -s "https://www.myget.org/F/vm-packages/api/v2" -k ${{ secrets.MYGET_TOKEN }} $package
           }

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230526</version>
+    <version>0.0.0.20230606</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -840,8 +840,8 @@ Common Environment Variables
     $diskInfo = Get-CimInstance -ClassName Win32_LogicalDisk | Out-String
     $psInfo = $PSVersionTable.PSVersion
     $psInfoClr = $PSVersionTable.CLRVersion
-    $chocoInfo = chocolatey --version
-    $installedPackages = chocolatey list -l -r -all
+    $chocoInfo = choco --version
+    $installedPackages = choco list -r
     $boxstarerInfo = $installedPackages | Select-String -Pattern "Boxstarter" | Out-String
     $installedPackages = $installedPackages | Out-String
 

--- a/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
+++ b/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>flarevm.installer.vm</id>
-    <version>0.0.0.20221201</version>
+    <version>0.0.0.20230606</version>
     <title>FLARE VM Installer</title>
     <authors>FLARE</authors>
     <description>Generic installer for Mandiant's custom virtual machines. Originally created by FLARE for FLARE VM, a malware analysis environment.</description>

--- a/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,8 @@ $global:VerbosePreference = "SilentlyContinue"
 Import-Module vm.common -Force -DisableNameChecking
 
 function Get-InstalledPackages {
-    if (Get-Command clist -ErrorAction:SilentlyContinue) {
-        chocolatey list -l -r -all | ForEach-Object {
+    if (Get-Command choco -ErrorAction:SilentlyContinue) {
+        choco list -r | ForEach-Object {
             $Name, $Version = $_ -split '\|'
             New-Object -TypeName psobject -Property @{
                 'Name' = $Name
@@ -60,7 +60,7 @@ try {
         }
     }
 
-    $installedPackages = chocolatey list -l -r -all | Out-String
+    $installedPackages = choco list -r | Out-String
     VM-Write-Log "INFO" "Packages installed:`n$installedPackages"
 
     # Write each failed package to failure file


### PR DESCRIPTION
Some of our packages do not work with Chocolatey 2. See https://github.com/chocolatey/choco/issues/2642

Closes https://github.com/mandiant/VM-Packages/issues/409
Related https://github.com/mandiant/flare-vm/issues/458
Related https://github.com/mandiant/flare-vm/issues/456