### PR TITLE
ida.diaphora.vm: Fix common.vm version requirement

### DIFF
--- a/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
+++ b/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.diaphora.vm</id>
-    <version>2.1.0</version>
+    <version>2.1.0.20230617</version>
     <authors>joxeankoret</authors>
     <description>Diaphora is a program diffing tool that works as an IDA plugin.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <!-- This package uses new arguments of VM-Install-From-Zip introduced in common.vm version 0.0.0.20230615 -->
+      <dependency id="common.vm" version="0.0.0.20230615" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.diaphora.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.diaphora.vm/tools/chocolateyinstall.ps1
@@ -1,16 +1,12 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-    $toolName = 'diaphora'
-    $category = 'Utilities'
-    $executableName = "diaphora.py"
+$toolName = 'diaphora'
+$category = 'Utilities'
+$executableName = "diaphora.py"
 
-    $zipUrl = 'https://github.com/joxeankoret/diaphora/archive/refs/tags/2.1.0.zip'
-    $zipSha256 = 'bd946942081b46991e8ee5a2788088110e0eef7649791c661ed41566d4dd2993'
+$zipUrl = 'https://github.com/joxeankoret/diaphora/archive/refs/tags/2.1.0.zip'
+$zipSha256 = 'bd946942081b46991e8ee5a2788088110e0eef7649791c661ed41566d4dd2993'
 
-    # Diaphora needs to be executed from IDA, do not install bin file
-    VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -executableName $executableName -innerFolder $true -withoutBinFile
-} catch {
-    VM-Write-Log-Exception $_
-}
+# Diaphora needs to be executed from IDA, do not install bin file
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -executableName $executableName -innerFolder $true -withoutBinFile


### PR DESCRIPTION
- Require common.vm version >= 0.0.0.20230615, as this package uses new arguments of `VM-Install-From-Zip` and installation fails in previous versions.
- Remove unneeded try-catch.