### PR TITLE
Add malware-jail

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230615</version>
+    <version>0.0.0.20230616</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -181,7 +181,7 @@ function VM-New-Install-Log {
     return $outputFile
 }
 
-# This functions returns $executablePath and $toolDir (outputed by Install-ChocolateyZipPackage)
+# This functions returns $toolDir
 function VM-Install-Raw-GitHub-Repo {
     [CmdletBinding()]
     Param
@@ -303,7 +303,7 @@ function VM-Install-Shortcut{
     VM-Assert-Path $shortcut
 }
 
-# This functions returns $executablePath and $toolDir (outputed by Install-ChocolateyZipPackage)
+# This functions returns $toolDir (outputed by Install-ChocolateyZipPackage) and $executablePath
 function VM-Install-From-Zip {
     [CmdletBinding()]
     Param

--- a/packages/malware-jail.vm/malware-jail.vm.nuspec
+++ b/packages/malware-jail.vm/malware-jail.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>malware-jail.vm</id>
+    <version>0.0.0.20230616</version>
+    <authors>Hynek Petrak</authors>
+    <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="nodejs" version="[6.6.0, 7.0.0)" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/malware-jail.vm/malware-jail.vm.nuspec
+++ b/packages/malware-jail.vm/malware-jail.vm.nuspec
@@ -7,7 +7,7 @@
     <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="nodejs" version="[6.6.0, 7.0.0)" />
+      <dependency id="nodejs" version="6.6.0" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/malware-jail.vm/tools/chocolateyinstall.ps1
+++ b/packages/malware-jail.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'malware-jail'
+    $category = 'Javascript'
+
+    $zipUrl = 'https://github.com/HynekPetrak/malware-jail/archive/52d580bd76e0e0fc3ff2543758bb8fc45355c668.zip'
+    $zipSha256 = '24a9312635b95e4ccc41d5719a67f0db23cd577a648f33c7dab5d47c249531fd'
+    # Install dependencies with npm when running shortcut as we ignore errors below
+    $powershellCommand = "npm install; node jailme.js -h -b list"
+
+    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+
+} catch {
+    VM-Write-Log-Exception $_
+}
+
+# Prevent the following warning from failing the package: "npm WARN deprecated request@2.79.0"
+$ErrorActionPreference = 'Continue'
+# Get absolute path as npm is not in path until Powershell is restarted
+$npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
+# Install tool dependencies with npm
+Set-Location $toolDir; & "$npmPath" install | Out-Null

--- a/packages/malware-jail.vm/tools/chocolateyinstall.ps1
+++ b/packages/malware-jail.vm/tools/chocolateyinstall.ps1
@@ -5,8 +5,8 @@ try {
     $toolName = 'malware-jail'
     $category = 'Javascript'
 
-    $zipUrl = 'https://github.com/HynekPetrak/malware-jail/archive/52d580bd76e0e0fc3ff2543758bb8fc45355c668.zip'
-    $zipSha256 = '24a9312635b95e4ccc41d5719a67f0db23cd577a648f33c7dab5d47c249531fd'
+    $zipUrl = 'https://github.com/HynekPetrak/malware-jail/archive/ec370f1433652fdd346995f1d6f00b26368aa611.zip'
+    $zipSha256 = '027b59bdb5c0b8b20ae348269b320b924be34c4cb4ae708704290e67c23e8d4d'
     # Install dependencies with npm when running shortcut as we ignore errors below
     $powershellCommand = "npm install; node jailme.js -h -b list"
 

--- a/packages/malware-jail.vm/tools/chocolateyuninstall.ps1
+++ b/packages/malware-jail.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'malware-jail'
+$category = 'Javascript'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
Add malware-jail, Ignore warnings while installing dependencies with npm to avoid failing the package. There may be a better way to do it, please let me know if you know how. 😄 

Update the common.vm documentation in this PR as well as it was not accurate and was getting me confused while adding malware-jail.