### PR TITLE
Update number of packages in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Packages](https://img.shields.io/badge/packages-66-blue.svg)](packages)
+[![Packages](https://img.shields.io/badge/packages->100-blue.svg)](packages)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 [![Daily run](https://github.com/mandiant/VM-packages/workflows/daily/badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 


### PR DESCRIPTION
Since we moved the failures to the wiki, we are not updating the number of packages in the README. This label used to be updated with every daily run. Updating it manually till we decide how we want to update it, see https://github.com/mandiant/VM-Packages/issues/440

![Screenshot 2023-06-22 at 13 58 29](https://github.com/mandiant/VM-Packages/assets/16052290/a899ff0c-6686-4163-8cf0-7e415ef4190f)
