### PR TITLE
upx.vm: Add 32 bit version

### DIFF
--- a/packages/upx.vm/tools/chocolateyinstall.ps1
+++ b/packages/upx.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,9 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'upx'
 $category = 'Utilities'
 
-$zipUrl = 'https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip'
-$zipSha256 = '325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24'
+$zipUrl = "https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win32.zip"
+$zipSha256 = "3f5b59252b0b657143ab945ce10fa0e5c4a509f69588695e11757cb1fc1b7eb7"
+$zipUrl_64 = 'https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip'
+$zipSha256_64 = '325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -zipUrl_64 $zipUrl_64 -zipSha256_64 $zipSha256_64 -consoleApp $true -innerFolder $true

--- a/packages/upx.vm/upx.vm.nuspec
+++ b/packages/upx.vm/upx.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>upx.vm</id>
-    <version>4.0.2</version>
+    <version>4.0.2.20230626</version>
     <authors>markus-oberhumer</authors>
     <description>UPX is a free, secure, portable, extendable, high-performance executable packer for several executable formats.</description>
     <dependencies>


### PR DESCRIPTION
UPX was added in #457 using the win64 version. There is also a win32 version, we can use both with the argument `zipUrl_64` of `VM-Install-From-Zip`.

Closes https://github.com/mandiant/VM-Packages/issues/458