### PR TITLE
Chocolatey Package List Bug Workaround

### DIFF
--- a/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
+++ b/packages/flarevm.installer.vm/flarevm.installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>flarevm.installer.vm</id>
-    <version>0.0.0.20230606</version>
+    <version>0.0.0.20230626</version>
     <title>FLARE VM Installer</title>
     <authors>FLARE</authors>
     <description>Generic installer for Mandiant's custom virtual machines. Originally created by FLARE for FLARE VM, a malware analysis environment.</description>

--- a/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/flarevm.installer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 function Get-InstalledPackages {
     if (Get-Command choco -ErrorAction:SilentlyContinue) {
-        choco list -r | ForEach-Object {
+        powershell.exe "choco list -r" | ForEach-Object {
             $Name, $Version = $_ -split '\|'
             New-Object -TypeName psobject -Property @{
                 'Name' = $Name


### PR DESCRIPTION
The CommandoVM team originally found this issue when we went through a full install of Commando. The `flarevm.installer.vm` package would misreport the currently installed packages and try to reinstall already installed ones after every restart, considerably slowing down the process.

I tried to reproduce the issue by running `Get-InstalledPackages` in my own terminal, but the installed packages list appeared correct. The issue is only present when run inside Boxstarter and I reproduced it by running `Install-BoxstarterPackage` on a PowerShell script with the function.

Test script contents:
```powershell
function Get-InstalledPackages {
    if (Get-Command choco -ErrorAction:SilentlyContinue) {
        choco list -r | ForEach-Object {
            $Name, $Version = $_ -split '\|'
            New-Object -TypeName psobject -Property @{
                'Name' = $Name
                'Version' = $Version
            }
        }
    }
}

(Get-InstalledPackages).Name
```

Expected output format resulting from running `test.ps1` in Terminal:
```
common.vm
flarevm.installer.vm
notepadplusplus
notepadplusplus.install
notepadplusplus.vm
```

Actual output format when executed with `Install-BoxstarterPackage -PackageName .\test.ps1`
```
7zip-15-05.vm|15.5.0
common.vm|0.0.0.20230616
flarevm.installer.vm|0.0.0.20230606
notepadplusplus|8.5.4
notepadplusplus.install|8.5.4
notepadplusplus.vm|8.5.4
telnet.vm|0.0.0.20230317
```

As you can see, the `Get-InstalledPackages` function returns immediately upon execution of `choco list -r`. I tried to redirect `choco list -r` output to a pipe, a variable, and a file - nothing fixed the issue. We are not able to redirect the output resulting from calling `choco` directly inside of the Boxstarter package script, so as a workaround I called it inside a nested `powershell.exe` command as shown below:

```powershell
function Get-InstalledPackages {
    if (Get-Command choco -ErrorAction:SilentlyContinue) {
        powershell.exe "choco list -r" | ForEach-Object {
            $Name, $Version = $_ -split '\|'
            New-Object -TypeName psobject -Property @{
                'Name' = $Name
                'Version' = $Version
            }
        }
    }
}

(Get-InstalledPackages).Name
```

This seems to resolve the issue.