### PR TITLE
Use new pestudio URL & update automatically version URLs

### DIFF
--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -27,7 +27,7 @@ jobs:
             $package = $packagePath.Name
             $newVersion = 0
             # Test indepdendly every type of update and commit what works
-            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL')) {
+            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
               echo "$package $version"

--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -41,6 +41,7 @@ jobs:
                   $newVersion = $version
                 } else {
                   echo "$package $version FAILED"
+                  git diff
                 }
               }
               # Clean changes and built packages

--- a/packages/pestudio.vm/pestudio.vm.nuspec
+++ b/packages/pestudio.vm/pestudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pestudio.vm</id>
-    <version>9.53</version>
+    <version>9.53.0.20230629</version>
     <authors>Marc Ochsenmeier</authors>
     <description>The goal of pestudio is to spot artifacts of executable files in order to ease and accelerate Malware Initial Assessment.</description>
     <dependencies>

--- a/packages/pestudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/pestudio.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'pestudio'
 $category = 'PE'
 
-$zipUrl = 'https://www.winitor.com/tools/pestudio/current/pestudio.zip'
+$zipUrl = 'https://www.winitor.com/tools/pestudio/current/pestudio-9.53.zip'
 $zipSha256 = 'ded56a58d7c5e06453f22a875d6a58ec0c07031e1c0873acc06b288a2d9658d8'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -innerFolder $true

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -111,6 +111,8 @@ def update_github_url(package):
         sha256 = get_sha256(url)
         latest_sha256 = get_sha256(latest_url)
         # Hash can be uppercase or downcase
+        if not latest_sha256:
+            return None
         content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
     content = content.replace(version, latest_version)

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -30,6 +30,7 @@ def replace_version(latest_version, nuspec_content):
     return latest_version, re.sub("<version>[^<]+</version>", f"<version>{latest_version}</version>", nuspec_content)
 
 
+# Get latest version from GitHub releases
 def get_latest_version(org, project, version):
     response = requests.get(f"https://api.github.com/repos/{org}/{project}/releases/latest")
     if not response.ok:
@@ -39,32 +40,52 @@ def get_latest_version(org, project, version):
     return latest_version
 
 
+# Get url response's content hash (SHA256)
 def get_sha256(url):
-    return hashlib.sha256(requests.get(url).content).hexdigest()
+    response = requests.get(url)
+    if not response.ok:
+        return None
+    return hashlib.sha256(response.content).hexdigest()
 
 
+# Get first three segments of version (which can be preceded by `v`)
+# For example:
+# v1.2.3 -> 1.2.3
+# 1.2.3-p353 -> 1.2.3
+# 1.2.3.4 -> 1.2.3
+# v1.2 -> 1.2
+# 1 -> 1
 def format_version(version):
-    # Get first three segments of version (which can be preceded by `v`)
-    # For example:
-    # v1.2.3 -> 1.2.3
-    # 1.2.3-p353 -> 1.2.3
-    # 1.2.3.4 -> 1.2.3
-    # v1.2 -> 1.2
-    # 1 -> 1
     match = re.match("v?(?P<version>\d+(.\d+){0,2})", version)
     if not match:
         raise ValueError(f"wrong version: {version}")
     return match.group("version")
 
 
-def update_github_url(package):
-    chocolateyinstall_path = f"packages/{package}/tools/chocolateyinstall.ps1"
+# Replace version in the package's nuspec file
+def update_nuspec_version(package, latest_version):
+    nuspec_path = f"packages/{package}/{package}.nuspec"
+    with open(nuspec_path, "r") as file:
+        content = file.read()
+    latest_version, content = replace_version(latest_version, content)
+    with open(nuspec_path, "w") as file:
+        file.write(content)
+
+
+# read the chocolateyinstall.ps1 package file
+def get_install_script(package):
+    install_script_path = f"packages/{package}/tools/chocolateyinstall.ps1"
     try:
-        file = open(chocolateyinstall_path, "r")
+        file = open(install_script_path, "r")
     except FileNotFoundError:
         # chocolateyinstall.ps1 may not exist for metapackages
-        return None
-    content = file.read()
+        return (None, None)
+    return (install_script_path, file.read())
+
+
+# Update package using GitHub releases
+def update_github_url(package):
+    install_script_path, content = get_install_script(package)
     # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
     # Match urls like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
     matches = re.findall(
@@ -93,15 +114,71 @@ def update_github_url(package):
         content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
     content = content.replace(version, latest_version)
-    with open(chocolateyinstall_path, "w") as file:
+    with open(install_script_path, "w") as file:
         file.write(content)
 
-    nuspec_path = f"packages/{package}/{package}.nuspec"
-    with open(nuspec_path, "r") as file:
-        content = file.read()
-    latest_version, content = replace_version(latest_version, content)
-    with open(nuspec_path, "w") as file:
+    update_nuspec_version(package, latest_version)
+
+    return latest_version
+
+
+def get_increased_version(url, version):
+    version_list_original = version.split(".")
+    # Try all possible increased versions, for example for 12.0.1
+    # ['12.0.1.1', '13', '13.0', '13.0.0', '13.0.0.0', '12.1', '12.1.0', '12.0.2']
+    # New possible segment
+    versions = [ version + ".1"]
+    for i in range(len(version_list_original)):
+        version_list = version_list_original.copy()
+        version_list[i] = str(int(version_list[i]) + 1)
+        version_i = ".".join(version_list[:i+1])
+        versions.append(version_i)
+        # Try max of 4 segments
+        for j in range(i, 3-i):
+            version_i += ".0"
+            versions.append(version_i)
+    for latest_version in versions:
+        latest_url = url.replace(version, latest_version)
+        latest_sha256 = get_sha256(latest_url)
+        if latest_sha256:
+            return (latest_version, latest_sha256)
+    return (None, None)
+
+
+# Update package which uses a generic url that includes the version
+def update_version_url(package):
+    install_script_path, content = get_install_script(package)
+    # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
+    # Match urls like:
+    # - https://download.sweetscape.com/010EditorWin32Installer12.0.1.exe
+    # - https://www.winitor.com/tools/pestudio/current/pestudio-9.53.zip
+    matches = re.findall("[\"'](https{0,1}://.+?[A-Za-z\-_]((?:\d{1,4}\.){1,3}\d{1,4})[\w\.\-]+)[\"']", content)
+
+    # It doesn't include a download url with the version
+    if not matches:
+        return None
+
+    latest_version = None
+    for url, version in matches:
+        latest_version_match, latest_sha256 = get_increased_version(url, version)
+        # No newer version available
+        if (not latest_version_match) or (latest_version_match == version):
+            return None
+        # The version of the 32 and 64 bit downloads need to be the same, we only have one nuspec
+        if latest_version and latest_version_match != latest_version:
+            return None
+        latest_version = latest_version_match
+        latest_url = url.replace(version, latest_version)
+        sha256 = get_sha256(url)
+        # Hash can be uppercase or downcase
+        content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
+
+    content = content.replace(version, latest_version)
+    with open(install_script_path, "w") as file:
         file.write(content)
+
+    update_nuspec_version(package, latest_version)
+
     return latest_version
 
 
@@ -146,7 +223,8 @@ def update_dependencies(package):
 class UpdateType(IntEnum):
     DEPENDENCIES = 1
     GITHUB_URL = 2
-    ALL = DEPENDENCIES | GITHUB_URL
+    VERSION_URL = 4
+    ALL = DEPENDENCIES | GITHUB_URL | VERSION_URL
 
     def __str__(self):
         return self.name
@@ -173,6 +251,11 @@ if __name__ == "__main__":
 
     if args.update_type & UpdateType.GITHUB_URL:
         latest_version2 = update_github_url(args.package_name)
+        if latest_version2:
+            latest_version = latest_version2
+
+    if args.update_type & UpdateType.VERSION_URL:
+        latest_version2 = update_version_url(args.package_name)
         if latest_version2:
             latest_version = latest_version2
 


### PR DESCRIPTION
pestudio uses now a link that includes the version and will exist for two months, giving us time to update without breaking the package. Thanks to marc ochsenmeier for providing the new URL! 💘 

Try to update generic URLs by increasing the version sequentially in scripts/utils/update_package.py. Now the script is able to update tools like pestudio, and 010editor. You can see it working here: https://github.com/Ana06/VM-Packages/pull/7

This means **pestudio won't break anymore and we can add it back to the default flare-vm installation**. I'll send a PR in a moment. 😄 