### PR TITLE
visualstudio: Correct nuspec name

### DIFF
--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1</version>
+    <version>17.6.1.20230703</version>
     <description>IDE.</description>
     <authors>Microsoft</authors>
     <dependencies>


### PR DESCRIPTION
Rename visualstudio.nuspec to visualstudio.vm.nuspec for consistency and because it is what our automation expects.