### PR TITLE
Missing Shortcut Working Directory Change

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230616</version>
+    <version>0.0.0.20230711</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -428,7 +428,7 @@ function VM-Install-Single-Exe {
         Get-ChocolateyWebFile @packageArgs
         VM-Assert-Path $executablePath
 
-        VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
+        VM-Install-Shortcut -toolName $toolName -category $category -executableDir $toolDir -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
         Install-BinFile -Name $toolName -Path $executablePath
         return $executablePath
     } catch {


### PR DESCRIPTION
@Menn1s noticed that a shortcut for a tool installed with the `common.vm` function `VM-Install-Single-Exe` was not changing the working directory into the tool folder, but instead defaulting to the user desktop #447 

Upon investigation, I found that this occurs because the `common.vm` function `VM-Install-Shortcut` does the following check:
```
if (!$executableDir) {
            $executableDir  = Join-Path ${Env:UserProfile} "Desktop"
}
```

Yet `VM-Install-Single-Exe` does not pass it the `executableDir` argument, as seen here:
```
VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
```

Therefore, because we never pass the executable directory, it will always default to the user desktop no matter what. The fix is to pass the directory to the function:
```
VM-Install-Shortcut -toolName $toolName -category $category -executableDir $toolDir -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
```

