### PR TITLE
Commando Package Recategorization

### DIFF
--- a/packages/asreproast.vm/asreproast.vm.nuspec
+++ b/packages/asreproast.vm/asreproast.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>asreproast.vm</id>
-    <version>0.0.0.20180925</version>
+    <version>0.0.0.20230713</version>
     <authors>HarmJ0y</authors>
     <description>Project that retrieves crackable hashes from KRB5 AS-REP responses for users without kerberoast preauthentication enabled.</description>
     <dependencies>

--- a/packages/asreproast.vm/tools/chocolateyinstall.ps1
+++ b/packages/asreproast.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ASREPRoast'
-$Category = 'Credential Access'
+$category = 'Credential Access'
 
 $zipUrl = 'https://codeload.github.com/HarmJ0y/ASREPRoast/zip/1c94ef12038df1378f5e663fe3b8137e46c60896'
 $zipSha256 = '3e90bb0755f9076e74ad749a188ad99b9dc11f197d4366a8eaa4f056953e4cab'

--- a/packages/asreproast.vm/tools/chocolateyinstall.ps1
+++ b/packages/asreproast.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ASREPRoast'
-$category = 'Password Attacks'
+$Category = 'Credential Access'
 
 $zipUrl = 'https://codeload.github.com/HarmJ0y/ASREPRoast/zip/1c94ef12038df1378f5e663fe3b8137e46c60896'
 $zipSha256 = '3e90bb0755f9076e74ad749a188ad99b9dc11f197d4366a8eaa4f056953e4cab'

--- a/packages/asreproast.vm/tools/chocolateyuninstall.ps1
+++ b/packages/asreproast.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ASREPRoast'
-$category = 'Password Attacks'
+$Category = 'Credential Access'
 
 VM-Uninstall $toolName $category

--- a/packages/asreproast.vm/tools/chocolateyuninstall.ps1
+++ b/packages/asreproast.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ASREPRoast'
-$Category = 'Credential Access'
+$category = 'Credential Access'
 
 VM-Uninstall $toolName $category

--- a/packages/azurehound.vm/azurehound.vm.nuspec
+++ b/packages/azurehound.vm/azurehound.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>azurehound.vm</id>
-    <version>2.0.4</version>
+    <version>2.0.4.20230713</version>
     <authors>BloodHoundAD</authors>
     <description>AzureHound is the BloodHound data collector for Microsoft Azure.</description>
     <dependencies>

--- a/packages/azurehound.vm/tools/chocolateyinstall.ps1
+++ b/packages/azurehound.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'AzureHound'
-$category = 'Cloud'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/BloodHoundAD/AzureHound/releases/download/v2.0.4/azurehound-windows-amd64.zip'
 $zipSha256 = 'd1748d7bac190f14dc4a95cb872870ee0ebf57e6bdc000bb011fb4d92b0f500d'

--- a/packages/azurehound.vm/tools/chocolateyuninstall.ps1
+++ b/packages/azurehound.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'AzureHound'
-$category = 'Cloud'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
+++ b/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound-custom-queries.vm</id>
-    <version>0.0.0.20230626</version>
+    <version>0.0.0.20230713</version>
     <authors>hausec</authors>
     <description>Custom Query list for the Bloodhound GUI based off my cheatsheet</description>
     <dependencies>

--- a/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound-Custom-Queries'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/hausec/Bloodhound-Custom-Queries/archive/7ef9099665aa82238bfd57d7a11c09cd4dd9381b.zip'
 $zipSha256 = '78a71b9797506200b4c86bdad6799ba8c3519171353ce329dff5ff4fc703ddb0'

--- a/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound-Custom-Queries'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/hausec/Bloodhound-Custom-Queries/archive/7ef9099665aa82238bfd57d7a11c09cd4dd9381b.zip'
 $zipSha256 = '78a71b9797506200b4c86bdad6799ba8c3519171353ce329dff5ff4fc703ddb0'

--- a/packages/bloodhound-custom-queries.vm/tools/chocolateyuninstall.ps1
+++ b/packages/bloodhound-custom-queries.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound-Custom-Queries'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/bloodhound-custom-queries.vm/tools/chocolateyuninstall.ps1
+++ b/packages/bloodhound-custom-queries.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound-Custom-Queries'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/bloodhound.vm/bloodhound.vm.nuspec
+++ b/packages/bloodhound.vm/bloodhound.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound.vm</id>
-    <version>4.3.1</version>
+    <version>4.3.1.20230713</version>
     <description>BloodHound uses graph theory to reveal the hidden and often unintended relationships within an Active Directory environment.</description>
     <authors>Andrew Robbins, Rohan Vazarkar, Will Schroeder</authors>
     <dependencies>

--- a/packages/bloodhound.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = "https://github.com/BloodHoundAD/BloodHound/releases/download/v4.3.1/BloodHound-win32-ia32.zip"
 $zipSha256 = "8d2a5cc827299d47424631882399067acf41d040c5b2aacf95092aec22d90c97"

--- a/packages/bloodhound.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = "https://github.com/BloodHoundAD/BloodHound/releases/download/v4.3.1/BloodHound-win32-ia32.zip"
 $zipSha256 = "8d2a5cc827299d47424631882399067acf41d040c5b2aacf95092aec22d90c97"

--- a/packages/bloodhound.vm/tools/chocolateyuninstall.ps1
+++ b/packages/bloodhound.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category
 

--- a/packages/bloodhound.vm/tools/chocolateyuninstall.ps1
+++ b/packages/bloodhound.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BloodHound'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category
 

--- a/packages/certify.vm/certify.vm.nuspec
+++ b/packages/certify.vm/certify.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>certify.vm</id>
-    <version>1.1.0</version>
+    <version>1.1.0.20230713</version>
     <authors>HarmJ0y, leechristensen</authors>
     <description>Certify is a C# tool to enumerate and abuse misconfigurations in Active Directory Certificate Services (AD CS).</description>
     <dependencies>

--- a/packages/certify.vm/tools/chocolateyinstall.ps1
+++ b/packages/certify.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Certify'
-$category = 'Active Directory'
+$category = 'Exploitation'
 
 $zipUrl = 'https://github.com/GhostPack/Certify/archive/fb297ad30476cfdba745b9062171cd7ac145a16d.zip'
 $zipSha256 = '4827485203eb08271e953bbd5816e95bf8b0b897ae0937c798525afe7ed5b9e0'

--- a/packages/certify.vm/tools/chocolateyuninstall.ps1
+++ b/packages/certify.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Certify'
-$category = 'Active Directory'
+$category = 'Exploitation'
 
 VM-Uninstall $toolName $category

--- a/packages/confuserex.vm/confuserex.vm.nuspec
+++ b/packages/confuserex.vm/confuserex.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>confuserex.vm</id>
-    <version>1.6.0</version>
+    <version>1.6.0.20230713</version>
     <authors>mkaring</authors>
     <description>ConfuserEx is a open-source protector for .NET applications. It is the successor of Confuser project.</description>
     <dependencies>

--- a/packages/confuserex.vm/tools/chocolateyinstall.ps1
+++ b/packages/confuserex.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'ConfuserEx'
-  $category = 'Evasion'
+  $category = 'Payload Development'
   $shimPath = 'bin\ConfuserEx.exe'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/confuserex.vm/tools/chocolateyuninstall.ps1
+++ b/packages/confuserex.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ConfuserEx'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
+++ b/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotnettojscript.vm</id>
-    <version>0.0.0.20230602</version>
+    <version>0.0.0.20230713</version>
     <authors>James Forshaw</authors>
     <description>A tool to generate a JScript which bootstraps an arbitrary .NET Assembly and class.</description>
     <dependencies>

--- a/packages/dotnettojscript.vm/tools/chocolateyinstall.ps1
+++ b/packages/dotnettojscript.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DotNetToJScript'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 $zipUrl = 'https://github.com/tyranid/DotNetToJScript/archive/4dbe155912186f9574cb1889386540ba0e80c316.zip'
 $zipSha256 = '12566bdfced108fafba97548c59c07be55988beb1c1e970e62bf40ddaebc4a0a'

--- a/packages/dotnettojscript.vm/tools/chocolateyuninstall.ps1
+++ b/packages/dotnettojscript.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DotNetToJScript'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 VM-Uninstall $toolName $category

--- a/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
+++ b/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gadgettojscript.vm</id>
-    <version>2.0</version>
+    <version>2.0.0.20230713</version>
     <authors>med0x2e</authors>
     <description>A tool for generating .NET serialized gadgets that can trigger .NET assembly load/execution when deserialized using BinaryFormatter from JS/VBS/VBA scripts.</description>
     <dependencies>

--- a/packages/gadgettojscript.vm/tools/chocolateyinstall.ps1
+++ b/packages/gadgettojscript.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GadgetToJScript'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 $zipUrl = 'https://github.com/med0x2e/GadgetToJScript/archive/98f50984015c29eecb11c6c4ddc3c2cc3a6669da.zip'
 $zipSha256 = '093451115744beec90e7de4efc61857361b56d16a3a31d78182a8c7ef675938b'

--- a/packages/gadgettojscript.vm/tools/chocolateyuninstall.ps1
+++ b/packages/gadgettojscript.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GadgetToJScript'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 VM-Uninstall $toolName $category

--- a/packages/gobuster.vm/gobuster.vm.nuspec
+++ b/packages/gobuster.vm/gobuster.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gobuster.vm</id>
-    <version>3.5.0</version>
+    <version>3.5.0.20230713</version>
     <description>Directory/file and DNS busting tool written in Go</description>
     <authors>OJ Reeves</authors>
     <dependencies>

--- a/packages/gobuster.vm/tools/chocolateyinstall.ps1
+++ b/packages/gobuster.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoBuster'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = "https://github.com/OJ/gobuster/releases/download/v3.5.0/gobuster_3.5.0_Windows_x86_64.zip"
 $zipSha256 = "6b2df88eb8fc3046f54116992e9a924284d2ebb228c810eb8e799a18181e2ec8"

--- a/packages/gobuster.vm/tools/chocolateyinstall.ps1
+++ b/packages/gobuster.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoBuster'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = "https://github.com/OJ/gobuster/releases/download/v3.5.0/gobuster_3.5.0_Windows_x86_64.zip"
 $zipSha256 = "6b2df88eb8fc3046f54116992e9a924284d2ebb228c810eb8e799a18181e2ec8"

--- a/packages/gobuster.vm/tools/chocolateyuninstall.ps1
+++ b/packages/gobuster.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoBuster'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/gobuster.vm/tools/chocolateyuninstall.ps1
+++ b/packages/gobuster.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoBuster'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/nanodump.vm/nanodump.vm.nuspec
+++ b/packages/nanodump.vm/nanodump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nanodump.vm</id>
-    <version>0.0.0.20230530</version>
+    <version>0.0.0.20230713</version>
     <authors>fortra</authors>
     <description>A Beacon Object File that creates a minidump of the LSASS process.</description>
     <dependencies>

--- a/packages/nanodump.vm/tools/chocolateyinstall.ps1
+++ b/packages/nanodump.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'NanoDump'
-$Category = 'Credential Access'
+$category = 'Credential Access'
 
 $zipUrl = 'https://github.com/fortra/nanodump/archive/c211c5f72b2438afb09d0eb917fe32150be91344.zip'
 $zipSha256 = '461a16ae517aebb65adc37a0da8f8c04fa4836da35a69239dc2f90f8098b5da0'

--- a/packages/nanodump.vm/tools/chocolateyinstall.ps1
+++ b/packages/nanodump.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'NanoDump'
-$category = 'Password Attacks'
+$Category = 'Credential Access'
 
 $zipUrl = 'https://github.com/fortra/nanodump/archive/c211c5f72b2438afb09d0eb917fe32150be91344.zip'
 $zipSha256 = '461a16ae517aebb65adc37a0da8f8c04fa4836da35a69239dc2f90f8098b5da0'

--- a/packages/nanodump.vm/tools/chocolateyuninstall.ps1
+++ b/packages/nanodump.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'NanoDump'
-$Category = 'Credential Access'
+$category = 'Credential Access'
 
 VM-Uninstall $toolName $category

--- a/packages/nanodump.vm/tools/chocolateyuninstall.ps1
+++ b/packages/nanodump.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'NanoDump'
-$category = 'Password Attacks'
+$Category = 'Credential Access'
 
 VM-Uninstall $toolName $category

--- a/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
+++ b/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>outflank-c2-tool-collection.vm</id>
-    <version>0.0.0.20230530</version>
+    <version>0.0.0.20230713</version>
     <authors>outflank</authors>
     <description>Contains a collection of tools which integrate with Cobalt Strike (and possibly other C2 frameworks) through BOF and reflective DLL loading techniques.</description>
     <dependencies>

--- a/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
+++ b/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Outflank C2 Tool Collection'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/outflanknl/C2-Tool-Collection/archive/f02df22a206ee329bc582a8427d1aa1e54309d9a.zip'
 $zipSha256 = '825e3372f6caf540ecbc20f31af6f4b9e711bd6ce64fb09d7d151cf4224de3d8'

--- a/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
+++ b/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Outflank C2 Tool Collection'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/outflanknl/C2-Tool-Collection/archive/f02df22a206ee329bc582a8427d1aa1e54309d9a.zip'
 $zipSha256 = '825e3372f6caf540ecbc20f31af6f4b9e711bd6ce64fb09d7d151cf4224de3d8'

--- a/packages/outflank-c2-tool-collection.vm/tools/chocolateyuninstall.ps1
+++ b/packages/outflank-c2-tool-collection.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Outflank C2 Tool Collection'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/outflank-c2-tool-collection.vm/tools/chocolateyuninstall.ps1
+++ b/packages/outflank-c2-tool-collection.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Outflank C2 Tool Collection'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/routesixtysink.vm/routesixtysink.vm.nuspec
+++ b/packages/routesixtysink.vm/routesixtysink.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>routesixtysink.vm</id>
-    <version>0.0.0.20230603</version>
+    <version>0.0.0.20230713</version>
     <authors>Dillon Franke, Michael Maturi</authors>
     <description>Route Sixty-Sink is an open source tool that enables defenders and security researchers alike to quickly identify vulnerabilities in any .NET assembly using automated source-to-sink analysis.</description>
     <dependencies>

--- a/packages/routesixtysink.vm/tools/chocolateyinstall.ps1
+++ b/packages/routesixtysink.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RouteSixtySink'
-$category = 'Web Application'
+$category = 'dotNet'
 
 $zipUrl = 'https://github.com/mandiant/route-sixty-sink/archive/59195003c84d75fabf6cc573c233dfb60d631f8a.zip'
 $zipSha256 = '860df7a6f8b8b135e27e731d1cc11a61837a390fc7da46652f82920040802f15'

--- a/packages/routesixtysink.vm/tools/chocolateyuninstall.ps1
+++ b/packages/routesixtysink.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RouteSixtySink'
-$category = 'Web Application'
+$category = 'dotNet'
 
 VM-Uninstall $toolName $category

--- a/packages/seatbelt.vm/seatbelt.vm.nuspec
+++ b/packages/seatbelt.vm/seatbelt.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>seatbelt.vm</id>
-    <version>1.2.0</version>
+    <version>1.2.0.20230713</version>
     <authors>harmj0y, tifkin_</authors>
     <description>Seatbelt is a C# project that performs a number of security oriented host-survey "safety checks" relevant from both offensive and defensive security perspectives.</description>
     <dependencies>

--- a/packages/seatbelt.vm/tools/chocolateyinstall.ps1
+++ b/packages/seatbelt.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SeatBelt'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/GhostPack/Seatbelt/archive/96bd958cf45e3d877d842ce20906e1aa5fdc91c8.zip'
 $zipSha256 = '05f6da0d0b77adfae105f2030862882fc8790cf47d98ec053762b9ac99250184'

--- a/packages/seatbelt.vm/tools/chocolateyinstall.ps1
+++ b/packages/seatbelt.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SeatBelt'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/GhostPack/Seatbelt/archive/96bd958cf45e3d877d842ce20906e1aa5fdc91c8.zip'
 $zipSha256 = '05f6da0d0b77adfae105f2030862882fc8790cf47d98ec053762b9ac99250184'

--- a/packages/seatbelt.vm/tools/chocolateyuninstall.ps1
+++ b/packages/seatbelt.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SeatBelt'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/seatbelt.vm/tools/chocolateyuninstall.ps1
+++ b/packages/seatbelt.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SeatBelt'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharphound.vm/sharphound.vm.nuspec
+++ b/packages/sharphound.vm/sharphound.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharphound.vm</id>
-    <version>1.1.1</version>
+    <version>1.1.1.20230713</version>
     <authors>specterops</authors>
     <description>SharpHound is an Active Directory ingester tool for BloodHound.</description>
     <dependencies>

--- a/packages/sharphound.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharphound.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpHound'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/BloodHoundAD/SharpHound/releases/download/v1.1.1/SharpHound-v1.1.1.zip'
 $zipSha256 = '224d47658e0e7ddc256eb97725179a35e42fed02f7717cf5b62afbae26dcb36b'

--- a/packages/sharphound.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharphound.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpHound'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/BloodHoundAD/SharpHound/releases/download/v1.1.1/SharpHound-v1.1.1.zip'
 $zipSha256 = '224d47658e0e7ddc256eb97725179a35e42fed02f7717cf5b62afbae26dcb36b'

--- a/packages/sharphound.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharphound.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpHound'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharphound.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharphound.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpHound'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharpview.vm/sharpview.vm.nuspec
+++ b/packages/sharpview.vm/sharpview.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpview.vm</id>
-    <version>0.0.0.20230602</version>
+    <version>0.0.0.20230713</version>
     <authors>tevora</authors>
     <description>.NET port of PowerView used for information gathering within Active Directory</description>
     <dependencies>

--- a/packages/sharpview.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpview.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpView'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/tevora-threat/SharpView/archive/b60456286b41bb055ee7bc2a14d645410cca9b74.zip'
 $zipSha256 = 'b5b2dd91fe22f56fb846d849052fc3205f177cbd067069e6d829e38eea0aca49'

--- a/packages/sharpview.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpview.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpView'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/tevora-threat/SharpView/archive/b60456286b41bb055ee7bc2a14d645410cca9b74.zip'
 $zipSha256 = 'b5b2dd91fe22f56fb846d849052fc3205f177cbd067069e6d829e38eea0aca49'

--- a/packages/sharpview.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharpview.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpView'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharpview.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharpview.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpView'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharpwmi.vm/sharpwmi.vm.nuspec
+++ b/packages/sharpwmi.vm/sharpwmi.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpwmi.vm</id>
-    <version>0.0.0.20230626</version>
+    <version>0.0.0.20230713</version>
     <authors>HarmJ0y</authors>
     <description>SharpWMI is a C# implementation of various WMI functionality.</description>
     <dependencies>

--- a/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpWMI'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/GhostPack/SharpWMI/archive/0600f57aeb4733ba6fec585388af2f1ac4483b58.zip'
 $zipSha256 = '0dbdd04a8a62e16de40373ae416b732cd48fb642ac7b3ff243bb9580249058f5'

--- a/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpWMI'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/GhostPack/SharpWMI/archive/0600f57aeb4733ba6fec585388af2f1ac4483b58.zip'
 $zipSha256 = '0dbdd04a8a62e16de40373ae416b732cd48fb642ac7b3ff243bb9580249058f5'

--- a/packages/sharpwmi.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharpwmi.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpWMI'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/sharpwmi.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sharpwmi.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SharpWMI'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
+++ b/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>situational-awareness-bof.vm</id>
-    <version>0.0.0.20230529</version>
+    <version>0.0.0.20230713</version>
     <authors>trustedsec</authors>
     <description>Provides a set of basic situational awareness commands implemented in a Beacon Object File (BOF). This allows you to perform some checks on a host before you begin executing commands that may be more invasive.</description>
     <dependencies>

--- a/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Situational Awareness BOF'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/trustedsec/CS-Situational-Awareness-BOF/archive/refs/heads/master.zip'
 $zipSha256 = 'e3673d7e41ad6d36ca7d6d44821f68238aae9968e062acb6d96fc7663c87bbdb'

--- a/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Situational Awareness BOF'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/trustedsec/CS-Situational-Awareness-BOF/archive/refs/heads/master.zip'
 $zipSha256 = 'e3673d7e41ad6d36ca7d6d44821f68238aae9968e062acb6d96fc7663c87bbdb'

--- a/packages/situational-awareness-bof.vm/tools/chocolateyuninstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Situational Awareness BOF'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/situational-awareness-bof.vm/tools/chocolateyuninstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Situational Awareness BOF'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/stracciatella.vm/stracciatella.vm.nuspec
+++ b/packages/stracciatella.vm/stracciatella.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>stracciatella.vm</id>
-    <version>0.7</version>
+    <version>0.7.0.20230713</version>
     <authors>mgeeky</authors>
     <description>Powershell runspace from within C# (aka SharpPick technique) with AMSI, ETW and Script Block Logging disabled.</description>
     <dependencies>

--- a/packages/stracciatella.vm/tools/chocolateyinstall.ps1
+++ b/packages/stracciatella.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Stracciatella'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 $zipUrl = 'https://github.com/mgeeky/Stracciatella/archive/acc83e21951049ab4998ecd18f5e4fa01e1527da.zip'
 $zipSha256 = 'd9299fca780945becf9907b052112e7149fb2a2d51e28f0e73e8326455f47a82'

--- a/packages/stracciatella.vm/tools/chocolateyuninstall.ps1
+++ b/packages/stracciatella.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Stracciatella'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 VM-Uninstall $toolName $category

--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>2023.6.27</version>
+    <version>2023.6.27.20230713</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite of troubleshooting tools.</description>
     <dependencies>

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -48,7 +48,7 @@ try {
 
   ###
   # Second category
-  $Category = 'Reconnaissance'
+  $category = 'Reconnaissance'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $executablePath = Join-Path $toolDir 'ADExplorer.exe' -Resolve

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -48,7 +48,7 @@ try {
 
   ###
   # Second category
-  $category = 'Information Gathering'
+  $Category = 'Reconnaissance'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $executablePath = Join-Path $toolDir 'ADExplorer.exe' -Resolve

--- a/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
@@ -15,7 +15,7 @@ VM-Remove-Tool-Shortcut 'procmon' $category
 
 ###
 # Second category
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 VM-Remove-Tool-Shortcut 'ADExplorer' $category
 
 ###

--- a/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
@@ -15,7 +15,7 @@ VM-Remove-Tool-Shortcut 'procmon' $category
 
 ###
 # Second category
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 VM-Remove-Tool-Shortcut 'ADExplorer' $category
 
 ###

--- a/packages/teamfiltration.vm/teamfiltration.vm.nuspec
+++ b/packages/teamfiltration.vm/teamfiltration.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>teamfiltration.vm</id>
-    <version>3.5.0</version>
+    <version>3.5.0.20230713</version>
     <authors>Flangvik</authors>
     <description>TeamFiltration is a cross-platform framework for enumerating, spraying, exfiltrating, and backdooring O365 AAD accounts.</description>
     <dependencies>

--- a/packages/teamfiltration.vm/tools/chocolateyinstall.ps1
+++ b/packages/teamfiltration.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'TeamFiltration'
-$category = 'Cloud'
+$category = 'Exploitation'
 
 $zipUrl = 'https://github.com/Flangvik/TeamFiltration/releases/download/v3.5.0/TeamFiltration-Win-v3.5.0.zip'
 $zipSha256 = 'c91362172789aa47f45200fac925c5c8ade35cd9a8863f154d27dc5e0a2ed916'

--- a/packages/teamfiltration.vm/tools/chocolateyuninstall.ps1
+++ b/packages/teamfiltration.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'TeamFiltration'
-$category = 'Cloud'
+$category = 'Exploitation'
 
 VM-Uninstall $toolName $category

--- a/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Remote Operations BOF'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/trustedsec/CS-Remote-OPs-BOF/archive/a7ef2b8551568778c2603a15ea83220188009a79.zip'
 $zipSha256 = '61bf693272484d9f9ea25871ea57489cb24248c014782cacad1c1bb80e90962b'

--- a/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Remote Operations BOF'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 $zipUrl = 'https://github.com/trustedsec/CS-Remote-OPs-BOF/archive/a7ef2b8551568778c2603a15ea83220188009a79.zip'
 $zipSha256 = '61bf693272484d9f9ea25871ea57489cb24248c014782cacad1c1bb80e90962b'

--- a/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyuninstall.ps1
+++ b/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Remote Operations BOF'
-$category = 'Information Gathering'
+$Category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyuninstall.ps1
+++ b/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Remote Operations BOF'
-$Category = 'Reconnaissance'
+$category = 'Reconnaissance'
 
 VM-Uninstall $toolName $category

--- a/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
+++ b/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>truestedsec-remote-ops-bof.vm</id>
-    <version>0.0.0.20230530</version>
+    <version>0.0.0.20230713</version>
     <authors>trustedsec</authors>
     <description>Addition to Situational Awareness BOFs intended for single task Windows primitives such as creating a task, stopping a service, etc.</description>
     <dependencies>

--- a/packages/unhook-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/unhook-bof.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Unhook BOF'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 $zipUrl = 'https://github.com/rsmudge/unhook-bof/archive/fa3c8d8a397719c5f2310334e6549bea541b209c.zip'
 $zipSha256 = '086f7ded18af7b397be78f63a7b4879bb1a6722f4b192d0139a02863332089ef'

--- a/packages/unhook-bof.vm/tools/chocolateyuninstall.ps1
+++ b/packages/unhook-bof.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Unhook BOF'
-$category = 'Evasion'
+$category = 'Payload Development'
 
 VM-Uninstall $toolName $category

--- a/packages/unhook-bof.vm/unhook-bof.vm.nuspec
+++ b/packages/unhook-bof.vm/unhook-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>unhook-bof.vm</id>
-    <version>0.0.0.20230530</version>
+    <version>0.0.0.20230713</version>
     <authors>rsmudge, physics-sec</authors>
     <description>This is a Beacon Object File to refresh DLLs and remove their hooks. The code is from Cylance's Universal Unhooking research.</description>
     <dependencies>

--- a/packages/whisker.vm/tools/chocolateyinstall.ps1
+++ b/packages/whisker.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Whisker'
-$category = 'Active Directory'
+$category = 'Persistence'
 
 $zipUrl = 'https://github.com/eladshamir/Whisker/archive/0bc2a0acc4a92b49c69d873f7ac565340a5f3291.zip'
 $zipSha256 = 'b181b639f2d18fb37e045d27cbe522e7b97aaa85c30dc0cb9bc75eaf6b939f9a'

--- a/packages/whisker.vm/tools/chocolateyuninstall.ps1
+++ b/packages/whisker.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Whisker'
-$category = 'Active Directory'
+$category = 'Persistence'
 
 VM-Uninstall $toolName $category

--- a/packages/whisker.vm/whisker.vm.nuspec
+++ b/packages/whisker.vm/whisker.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>whisker.vm</id>
-    <version>0.0.0.20230602</version>
+    <version>0.0.0.20230713</version>
     <authors>Elad Shamir</authors>
     <description>Whisker is a C# tool for taking over Active Directory user and computer accounts by manipulating their msDS-KeyCredentialLink attribute, effectively adding "Shadow Credentials" to the target account.</description>
     <dependencies>


### PR DESCRIPTION
## The Problem
Originally CommandoVM categories were created to align with Kali Linux, however it has become apparent that its categorization of packages tends to lump several categories into one (ex. Exploitation). We seek to bring clarity to how tools are categorized and to update outdated category names, where relevant. 

## The Solution
**Deprecated categories:**
- Active Directory - almost all packages we have are for Active Directory, making this overly broad
- Cloud - with how integrated Azure is becoming with Active Directory, tools for them are increasingly intertwined, making it harder to categorize something as only specific to cloud.
- Evasion - evasion is technically a part of tooling within multiple categories
- Information Gathering - renamed to "Reconnaissance" to align with MITRE ATT&CK 
- Password Attacks - ambiguous title. Renamed to "Credential Access" for clarity and to align with MITRE ATT&CK
- Vulnerability Analysis - unnecessary category with an ambiguous title
- Web Application - deprecated in favor of a web profile for CommandoVM

**New Categories:**
- Credential Access - renamed from "Password Attacks"
- Lateral Movement - moved some tools from "Exploitation" here
- Payload Development - moved some tools from "Exploitation" and almost all from "Evasion" here
- Persistence - moved some tools from "Exploitation" here
- Privilege Escalation - moved some tools from "Exploitation" here
- Reconnaissance - renamed from "Information Gathering"