### PR TITLE
Standardize PowerShell Shortcuts

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20230714</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -475,7 +475,7 @@ function VM-Install-Single-Ps1 {
         Get-ChocolateyWebFile @packageArgs
         VM-Assert-Path $scriptPath
 
-        $shortcut = Join-Path $shortcutDir "$toolName.ps1.lnk"
+        $shortcut = Join-Path $shortcutDir "$toolName.lnk"
         $targetCmd = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
 
         if ($ps1Cmd) {


### PR DESCRIPTION
`common.vm` function `VM-Install-Raw-GitHub-Repo` used for a lot of the PowerShell packages defines the shortcut like this:
```
$shortcut = Join-Path $shortcutDir "$toolName.lnk"
```

However, `VM-Install-Single-Ps1` defines it differently, adding a double file extension with `ps1`:
```
$shortcut = Join-Path $shortcutDir "$toolName.ps1.lnk"
```

This creates an inconsistency, where some PowerShell tools have a `ps1` in their shortcut and some don't. This PR removes the `ps1` extension from the shortcut.