### PR TITLE
added unzip location to VM-Install-From-Zip

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231013</version>
+    <version>0.0.0.20231020</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -329,10 +329,17 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [string] $executableName, # Executable name, needed if different from "$toolName.exe"
         [Parameter(Mandatory=$false)]
-        [switch] $withoutBinFile # Tool should not be installed as a bin file
+        [switch] $withoutBinFile, # Tool should not be installed as a bin file
+        [Parameter(Mandatory=$false)]
+        [string] $unzipLocation
     )
     try {
-        $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
+        if ($unzipLocation) {
+            $toolDir = Join-Path $unzipLocation $toolName
+        } else {
+            $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
+            $unzipLocation = $toolDir
+        }
 
         # Remove files from previous zips for upgrade
         VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
@@ -346,7 +353,7 @@ function VM-Install-From-Zip {
         # Download and unzip
         $packageArgs = @{
             packageName    = ${Env:ChocolateyPackageName}
-            unzipLocation  = $toolDir
+            unzipLocation  = $unzipLocation
             url            = $zipUrl
             checksum       = $zipSha256
             checksumType   = 'sha256'


### PR DESCRIPTION
This allows us to choose a specific location that we want to unzip our binary to. This is required for the `psnotify` package to work, as `psnotify` requires being located in the "C:\" directory, not the default "C:\Tools" which is our current default.