### PR TITLE
Rubeus patch for resolving SHA256 mismatch on 2.2.3 release

### DIFF
--- a/packages/rubeus.vm/rubeus.vm.nuspec
+++ b/packages/rubeus.vm/rubeus.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rubeus.vm</id>
-    <version>2.2.1</version>
+    <version>2.2.3</version>
     <authors>harmj0y</authors>
     <description>Rubeus is a C# toolset for raw Kerberos interaction and abuses.</description>
     <dependencies>

--- a/packages/rubeus.vm/tools/chocolateyinstall.ps1
+++ b/packages/rubeus.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'Rubeus'
 $category = 'Credential Access'
 
 $zipUrl = 'https://github.com/GhostPack/Rubeus/archive/refs/heads/master.zip'
-$zipSha256 = 'f6d1650043e528e24b4bc5c1f24e64ff0c4bbcf72537b84b1d8f866dd8ab8ccb'
+$zipSha256 = 'DC61768AF588A5FCC1CEDC491E8DF81BC652A96A1A032741034E40B75EC404F2'
 
 VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256


### PR DESCRIPTION
This resolves #628 by updating SHA256 hash and version number to reflect most recent build.  

Ref: https://github.com/GhostPack/Rubeus/commit/92413123b38d4cd2782737d247845e51169d89c7