### PR TITLE
Add dncil package

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230824</version>
+    <version>0.0.0.20230825</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -6,6 +6,7 @@
     <module name="capstone-windows"/>
     <module name="dissect"/>
     <module name="dnfile"/>
+    <module name="dncil"/>
     <module name="hexdump"/>
     <module name="ldapdomaindump"/>
     <module name="mkyara"/>


### PR DESCRIPTION
This PR adds `dncil` , a useful tool for .NET analysis, to our python packages installed via PIP.

The repo for the tool can be found here: https://github.com/mandiant/dncil.