### PR TITLE
Add pythonnet package

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230822</version>
+    <version>0.0.0.20230824</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -16,6 +16,7 @@
     <module name="pycryptodome"/>
     <module name="pyftpdlib"/>
     <module name="pyreadline"/>
+    <module name="pythonnet"/>
     <module name="pyOpenSSL"/>
     <module name="psutil"/>
     <module name="requests"/>


### PR DESCRIPTION
This PR adds the Python.NET package, useful for integrating .NET CLR with python, to our list of python packages installed via PIP.

The repo for the package can be found here: https://github.com/pythonnet/pythonnet