### PR TITLE
Adding package dnfile

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230822</version>
+    <version>0.0.0.20230824</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -5,6 +5,7 @@
     <module name="binwalk" url="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"/>
     <module name="capstone-windows"/>
     <module name="dissect"/>
+    <module name="dnfile"/>
     <module name="hexdump"/>
     <module name="ldapdomaindump"/>
     <module name="mkyara"/>


### PR DESCRIPTION
This PR is to add the Python library `dnfile`, a tool that helps parse .NET executables, to the list of Python modules installed via PIP.

The package repository can be found here: https://github.com/malwarefrank/dnfile