### PR TITLE
Disabling stringsifter for the time being

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230522</version>
+    <version>0.0.0.20230822</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -20,7 +20,7 @@
     <module name="psutil"/>
     <module name="requests"/>
     <!-- Restrict stringsifter dependencies https://github.com/mandiant/stringsifter/issues/30 -->
-    <module name="stringsifter" url ="https://github.com/Ana06/stringsifter/archive/refs/heads/master.zip"/>
+    <!-- <module name="stringsifter" url ="https://github.com/Ana06/stringsifter/archive/refs/heads/master.zip"/> -->
     <module name="uncompyle6"/>
     <module name="unpy2exe"/>
     <module name="unicorn"/>


### PR DESCRIPTION
Stringsifter is currently breaking new additions to libraries.python3.vm.

This PR disables Stringsifter until a fix is made.