### PR TITLE
Installer updates

### DIFF
--- a/packages/common.vm/README.md
+++ b/packages/common.vm/README.md
@@ -15,14 +15,9 @@ The environment variables below are configurable by the user:
     - VM common directory containing anything related to VM-packages (e.g., shared module, log file, saved config file, etc...)
 - `TOOL_LIST_DIR`
   - Default Path:
-    - *`%PROGRAMDATA%`*`\Microsoft\Windows\Start Menu\Programs\Tools`
+    - *`%USERPROFILE%`*`\Desktop\Tools`
   - Use:
     - Path to a directory containing tool shortcuts
-- `TOOL_LIST_SHORTCUT`
-  - Default Path:
-    - *`%USERPROFILE%`*`\Desktop\Tools.lnk`
-  - Use:
-    - Path to a shortcut file (`.lnk`) that points to *`%TOOL_LIST_DIR%`*
 - `RAW_TOOLS_DIR`
   - Default Path:
     - *`%SYSTEMDRIVE%`*`\Tools`

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230714</version>
+    <version>0.0.0.20230904</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/chocolateyinstall.ps1
+++ b/packages/common.vm/tools/chocolateyinstall.ps1
@@ -89,7 +89,7 @@ Write-Host -ForegroundColor Green "[+] PSModulePath set to:" $prevPath
 $envVarName = "TOOL_LIST_DIR"
 $toolListDir = [Environment]::GetEnvironmentVariable($envVarName, 2)
 if (-Not (Test-Path env:\$envVarName) -Or ($toolListDir -eq $null)) {
-    $toolListDir = Join-Path ${Env:ProgramData} "Microsoft\Windows\Start Menu\Programs\Tools"
+    $toolListDir = Join-Path ${Env:USERPROFILE} "Desktop\Tools"
     if (-Not (Test-Path $toolListDir) ) {
         New-Item -Path $toolListDir -ItemType directory -Force | Out-Null
     }
@@ -105,31 +105,6 @@ if (-Not (Test-Path $toolListDir)) {
     New-Item -Path $toolListDir -ItemType directory -Force | Out-Null
     Write-Host -ForegroundColor Green "[+] Created folder:" $toolListDir
 }
-
-
-# ################################################################################################ #
-# Setup the default tool list directory shortcut and env var if it doesn't exist
-# ################################################################################################ #
-$envVarName = "TOOL_LIST_SHORTCUT"
-$toolListDirShortcut = [Environment]::GetEnvironmentVariable($envVarName, 2)
-if ((-Not (Test-Path env:\$envVarName)) -Or ($toolListDirShortcut -eq $null)) {
-    $toolListDirShortcut = Join-Path ${Env:UserProfile} "Desktop\Tools.lnk"
-    if (-Not (Test-Path $toolListDirShortcut)) {
-        Install-ChocolateyShortcut -ShortcutFilePath $toolListDirShortcut -TargetPath $toolListDir
-    }
-
-    Install-ChocolateyEnvironmentVariable -VariableName $envVarName -VariableValue $toolListDirShortcut -VariableType 'Machine'
-    Set-Item "Env:$envVarName" $toolListDirShortcut -Force
-}
-Write-Host -ForegroundColor Green "[+] TOOL_LIST_SHORTCUT set to:" $toolListDirShortcut
-
-# If the user set the env var but the .lnk file doesn't exist, create it with Choco
-$toolListDirShortcut = [Environment]::ExpandEnvironmentVariables("%$envVarName%")
-if (-Not (Test-Path $toolListDirShortcut)) {
-    Install-ChocolateyShortcut -ShortcutFilePath $toolListDirShortcut -TargetPath $toolListDir
-    Write-Host -ForegroundColor Green "[+] Created shortcut:" $toolListDirShortcut
-}
-
 
 # ################################################################################################ #
 # Set up the default raw tools directory and env var if it doesn't exist

--- a/packages/common.vm/tools/chocolateyuninstall.ps1
+++ b/packages/common.vm/tools/chocolateyuninstall.ps1
@@ -17,7 +17,7 @@ Set-Item "Env:$envVarName" $prevPath -Force
 
 # Remove the env vars and what they point to
 # NOTE: Purposefully NOT recursively deleting RAW_TOOLS_DIR as the user may have other items there
-$envVarNames = @("VM_CONFIG", "TOOL_LIST_DIR", "TOOL_LIST_SHORTCUT", "VM_COMMON_DIR")
+$envVarNames = @("VM_CONFIG", "TOOL_LIST_DIR", "VM_COMMON_DIR")
 foreach ($envVarName in $envVarNames) {
   if (Test-Path env:\$envVarName) {
     $envVarValue = [Environment]::GetEnvironmentVariable($envVarName, 'Machine')

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1080,7 +1080,7 @@ function VM-Execute-Custom-Command{
         foreach ($cmd in $cmds) {
             Start-Process powershell -ArgumentList "-WindowStyle","Hidden","-Command",$cmd -Wait
         }
-        VM-Write-Log "[+] All commands for '$name' have been executed successfully."
+        VM-Write-Log "INFO" "[+] All commands for '$name' have been executed successfully."
     } catch {
         VM-Write-Log "ERROR" "An error occurred while executing commands for '$name'. Error: $_"
     }

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1004,7 +1004,6 @@ function VM-Update-Registry-Value {
             $validatedData = [int64]::Parse($data)
         } elseif ($type -eq "Binary") {
             $validatedData = [byte[]]::new(($data -split '(.{2})' | Where-Object { $_ -match '..' } | ForEach-Object { [convert]::ToByte($_, 16) }))
-
         } else {
             $validatedData = $data
         }
@@ -1086,12 +1085,12 @@ function VM-Execute-Custom-Command{
 }
 
 function VM-Configure-Prompts {
-    # $Env:MandiantVM must be set in the install script
+    # $Env:VMname must be set in the install script
     try {
         # Set PowerShell prompt
         $psprompt = @"
         function prompt {
-            Write-Host (`$Env:MandiantVM + " " + `$(Get-Date)) -ForegroundColor Green
+            Write-Host (`$Env:VMname + " " + `$(Get-Date)) -ForegroundColor Green
             Write-Host ("PS " + `$(Get-Location) + " >") -NoNewLine -ForegroundColor White
             return " "
         }
@@ -1105,7 +1104,7 @@ function VM-Configure-Prompts {
 
         # Set cmd prompt
         ## Configure the command
-        $mandiantVM = $Env:MandiantVM -replace ' ', '' # setx command cannot have spaces
+        $mandiantVM = $Env:VMname -replace ' ', '' # setx command cannot have spaces
         $command = "cmd /c 'setx PROMPT $mandiantVM`$S`$d`$s`$t`$_`$p$+`$g'"
         ## Convert to base64
         $base64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($command))

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1227,3 +1227,25 @@ function VM-Apply-Configurations {
         VM-Write-Log "ERROR" "An error occurred while applying config. Error: $_"
     }
 }
+
+# This function returns a string of "Win10", "Win11", or "Win11ARM"
+function VM-Get-WindowsVersion {
+    $osInfo = Get-WmiObject -Class Win32_OperatingSystem
+
+    # Extract the version number and other details
+    $version = $osInfo.Version
+    $osArchitecture = $osInfo.OSArchitecture
+
+    if ($version -match "^10\.") {
+        return "Win10"
+    }
+    elseif ($version -match "^11\." -and $osArchitecture -eq "64-bit") {
+        return "Win11"
+    }
+    elseif ($version -match "^11\." -and $osArchitecture -eq "ARM64") {
+        return "Win11ARM"
+    }
+    else {
+        return "Unknown"
+    }
+}

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1104,8 +1104,8 @@ function VM-Configure-Prompts {
 
         # Set cmd prompt
         ## Configure the command
-        $mandiantVM = $Env:VMname -replace ' ', '' # setx command cannot have spaces
-        $command = "cmd /c 'setx PROMPT $mandiantVM`$S`$d`$s`$t`$_`$p$+`$g'"
+        $VMname = $Env:VMname -replace ' ', '' # setx command cannot have spaces
+        $command = "cmd /c 'setx PROMPT $VMname`$S`$d`$s`$t`$_`$p$+`$g'"
         ## Convert to base64
         $base64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($command))
         ## Run command

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -906,7 +906,7 @@ function VM-Remove-Appx-Package {
             }
             catch {
                 VM-Write-Log-Exception $_
-            }           
+            }
         } else {
             VM-Write-Log "WARN" "[+] Installed $appName not found on the system."
         }
@@ -919,7 +919,7 @@ function VM-Remove-Appx-Package {
             }
             catch {
                 VM-Write-Log-Exception $_
-            } 
+            }
         } else {
             VM-Write-Log "WARN" "[+] Provisioned $appName not found on the system."
         }
@@ -969,7 +969,7 @@ function VM-Disable-Scheduled-Task {
         } else {
             VM-Write-Log "ERROR" "[+] Scheduled task '$name' not found."
         }
-    
+
     } catch {
         VM-Write-Log "ERROR" "An error occurred while disabling the '$name' scheduled task. Error: $_"
     }
@@ -1097,7 +1097,7 @@ function VM-Configure-Prompts {
             return " "
         }
 "@
-        
+
         # Ensure profile file exists and append new content to it, not overwriting old content
         if (!(Test-Path $profile)) {
             New-Item -ItemType File -Path $profile -Force | Out-Null
@@ -1117,12 +1117,12 @@ function VM-Configure-Prompts {
     } catch {
         VM-Write-Log-Exception $_
     }
-    
+
 }
 
 function VM-Configure-PS-Logging {
     if ($PSVersionTable -And $PSVersionTable.PSVersion.Major -ge 5) {
-        try { 
+        try {
             VM-Write-Log "INFO" "Enabling PowerShell Script Block Logging"
 
             $psLoggingPath = 'HKLM:\SOFTWARE\Wow6432Node\Policies\Microsoft\Windows\PowerShell'

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1177,7 +1177,7 @@ function VM-Apply-Configurations {
             }
         }
 
-        # Process the services
+        # Process the tasks
         if ($config.config.tasks.task) {
             $config.config.tasks.task | ForEach-Object {
                 $descName = $_.name

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1230,19 +1230,19 @@ function VM-Apply-Configurations {
 
 # This function returns a string of "Win10", "Win11", or "Win11ARM"
 function VM-Get-WindowsVersion {
-    $osInfo = Get-WmiObject -Class Win32_OperatingSystem
+    $osInfo = Get-ComputerInfo
 
     # Extract the version number and other details
-    $version = $osInfo.Version
+    $version = $osInfo.OsName
     $osArchitecture = $osInfo.OSArchitecture
 
-    if ($version -match "^10\.") {
+    if ($version -match "10") {
         return "Win10"
     }
-    elseif ($version -match "^11\." -and $osArchitecture -eq "64-bit") {
+    elseif ($version -match "11" -and $osArchitecture -eq "64-bit") {
         return "Win11"
     }
-    elseif ($version -match "^11\." -and $osArchitecture -eq "ARM64") {
+    elseif ($version -match "11" -and $osArchitecture -eq "ARM64") {
         return "Win11ARM"
     }
     else {

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -879,7 +879,6 @@ SignatureStatus: $([SignatureStatus]([UInt32]$avInfo.productState -band [Product
     $envVars = @"
 VM_COMMON_DIR: ${Env:VM_COMMON_DIR}
 TOOL_LIST_DIR: ${Env:TOOL_LIST_DIR}
-TOOL_LIST_SHORTCUT: ${Env:TOOL_LIST_SHORTCUT}
 RAW_TOOLS_DIR: ${Env:RAW_TOOLS_DIR}
 "@
 

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>common.vm</id>
+    <id>debloat.vm</id>
     <version>0.0.0.20230904</version>
     <description>Debloat and performance configurations for Mandiant VMs</description>
     <authors>Mandiant</authors>

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -5,5 +5,8 @@
     <version>0.0.0.20230904</version>
     <description>Debloat and performance configurations for Mandiant VMs</description>
     <authors>Mandiant</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
   </metadata>
 </package>

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>common.vm</id>
+    <version>0.0.0.20230904</version>
+    <description>Debloat and performance configurations for Mandiant VMs</description>
+    <authors>Mandiant</authors>
+  </metadata>
+</package>

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>debloat.vm</id>
     <version>0.0.0.20230904</version>
-    <description>Debloat and performance configurations for Mandiant VMs</description>
+    <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>
       <dependency id="common.vm" />

--- a/packages/debloat.vm/tools/chocolateyinstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyinstall.ps1
@@ -16,6 +16,7 @@ try {
     }
 
     VM-Apply-Configurations $config
+    VM-Write-Log "INFO" "Debloating and performance modifications for $osVersion done"
 
 } catch {
     VM-Write-Log-Exception $_

--- a/packages/debloat.vm/tools/chocolateyinstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,23 @@
+$ErrorActionPreference = 'Stop'
+$packageToolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+
+try {
+    # Determine OS Version
+    $osVersion = VM-Get-WindowsVersion
+
+    switch ($osVersion) {
+        "Win10" { $config = Join-Path $packageToolsDir "win10.xml" }
+        "Win11" { $config = Join-Path $packageToolsDir "win11.xml" }
+        "Win11ARM" { $config = Join-Path $packageToolsDir "win11arm.xml"}
+        default { 
+            VM-Write-Log "WARN" "Debloater unable to determine debloat config, applying win10.xml" 
+            $config = Join-Path $packageToolsDir "win10.xml"
+        }
+    }
+
+    VM-Apply-Configurations $config
+
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/packages/debloat.vm/tools/chocolateyinstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyinstall.ps1
@@ -1,4 +1,6 @@
 $ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
 $packageToolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 try {

--- a/packages/debloat.vm/tools/chocolateyinstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyinstall.ps1
@@ -11,8 +11,8 @@ try {
         "Win10" { $config = Join-Path $packageToolsDir "win10.xml" }
         "Win11" { $config = Join-Path $packageToolsDir "win11.xml" }
         "Win11ARM" { $config = Join-Path $packageToolsDir "win11arm.xml"}
-        default { 
-            VM-Write-Log "WARN" "Debloater unable to determine debloat config, applying win10.xml" 
+        default {
+            VM-Write-Log "WARN" "Debloater unable to determine debloat config, applying win10.xml"
             $config = Join-Path $packageToolsDir "win10.xml"
         }
     }

--- a/packages/debloat.vm/tools/chocolateyuninstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,3 @@
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Rebloating Windows is not supported."

--- a/packages/debloat.vm/tools/chocolateyuninstall.ps1
+++ b/packages/debloat.vm/tools/chocolateyuninstall.ps1
@@ -1,3 +1,0 @@
-$ErrorActionPreference = 'Stop'
-
-Write-Host "Rebloating Windows is not supported."

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -2,6 +2,10 @@
 <config> 
     <apps>
         <!--
+        INFO:
+        Removes installed AppX packages. Try:
+        $packages = Get-AppxPackage
+        $packages.Name
         FORMAT: 
         <app name="APP_NAME"/>
         -->
@@ -42,6 +46,10 @@
     </apps>
     <services>
         <!--
+        INFO:
+        Sets Services to "Manual" startup type. Try:
+        $services = Get-WmiObject -Query "SELECT * FROM Win32_Service WHERE StartMode='Auto'" | Get-Service
+        $services.Name
         FORMAT: 
         <service name="SERVICE_NAME"/>
         -->
@@ -68,6 +76,10 @@
     </services>
     <tasks>
         <!--
+        INFO:
+        Disables Scheduled Tasks. Try:
+        $tasks = Get-ScheduledTask
+        $tasks.TaskName
         FORMAT: 
         <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
         -->
@@ -80,6 +92,8 @@
     </tasks>
     <registry-items>
         <!--
+        INFO:
+        Makes custom edits to the registry
         FORMAT: 
         <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
         -->
@@ -131,12 +145,17 @@
 
     <path-items>
         <!--
+        INFO:
+        Removes files and folders from the system
         FORMAT: 
         <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
         -->
     </path-items>
     <custom-items>
-        <!--FORMAT: 
+        <!--
+        INFO:
+        Performs custom commands
+        FORMAT: 
         <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
         -->
         <custom-item name="Remove OneDrive">

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -165,6 +165,9 @@
             <cmd value='Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -Name "Favorites" -Type Binary -Value ([byte[]](255))'/>
             <cmd value='Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -Name "FavoritesResolve" -ErrorAction SilentlyContinue'/>
         </custom-item>
+        <custom-item name="Unpin all Start Menu Tiles">
+            <cmd value="$key = Get-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CloudStore\Store\Cache\DefaultAccount\*start.tilegrid$windows.data.curatedtilecollection.tilecollection\Current'; $data = $key.Data[0..25] + ([byte[]](202,50,0,226,44,1,1,0,0)); Set-ItemProperty -Path $key.PSPath -Name 'Data' -Type Binary -Value $data; Stop-Process -Name 'ShellExperienceHost' -Force -ErrorAction SilentlyContinue" />
+        </custom-item>
         <custom-item name="Remove Desktop Links">
             <cmd value="del $(Join-Path $env:USERPROFILE 'Desktop\*.lnk')" />
             <cmd value="del $(Join-Path $env:PUBLIC 'Desktop\*.lnk')" />

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -142,7 +142,6 @@
         <registry-item name="Disable Windows Update Automatic Download" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" value="AUOptions" type="DWord" data="2" />
         <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
     </registry-items>
-
     <path-items>
         <!--
         INFO:

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config> 
+    <apps>
+        <!--
+        FORMAT: 
+        <app name="APP_NAME"/>
+        -->
+        <app name="Microsoft.549981C3F5F10"/>
+        <app name="Microsoft.BingWeather"/>
+        <app name="Microsoft.GetHelp"/>
+        <app name="Microsoft.Getstarted"/>
+        <app name="Microsoft.Microsoft3DViewer"/>
+        <app name="Microsoft.MicrosoftOfficeHub"/>
+        <app name="Microsoft.MicrosoftSolitaireCollection"/>
+        <app name="Microsoft.MicrosoftStickyNotes"/>
+        <app name="Microsoft.MixedReality.Portal"/>
+        <app name="Microsoft.MSPaint"/>
+        <app name="Microsoft.Office.OneNote"/>
+        <app name="Microsoft.People"/>
+        <app name="Microsoft.ScreenSketch"/>
+        <app name="Microsoft.SkypeApp"/>
+        <app name="Microsoft.Wallet"/>
+        <app name="Microsoft.Windows.Photos"/>
+        <app name="Microsoft.WindowsAlarms"/>
+        <app name="Microsoft.WindowsCalculator"/>
+        <app name="Microsoft.WindowsCamera"/>
+        <app name="microsoft.windowscommunicationsapps"/>
+        <app name="Microsoft.WindowsFeedbackHub"/>
+        <app name="Microsoft.WindowsMaps"/>
+        <app name="Microsoft.WindowsSoundRecorder"/>
+        <app name="Microsoft.Xbox.TCUI"/>
+        <app name="Microsoft.XboxApp"/>
+        <app name="Microsoft.XboxGameOverlay"/>
+        <app name="Microsoft.XboxGamingOverlay"/>
+        <app name="Microsoft.XboxIdentityProvider"/>
+        <app name="Microsoft.XboxSpeechToTextOverlay"/>
+        <app name="Microsoft.YourPhone"/>
+        <app name="Microsoft.ZuneMusic"/>
+        <app name="Microsoft.ZuneVideo"/>
+        <app name="SpotifyAB.SpotifyMusic"/>
+        <app name="Disney.37853FC22B2CE"/>
+    </apps>
+    <services>
+        <!--
+        FORMAT: 
+        <service name="SERVICE_NAME"/>
+        -->
+        <service name="XboxGipSvc"/>
+        <service name="XblAuthManager"/>
+        <service name="XblGameSave"/>
+        <service name="XboxNetApiSvc"/>
+        <service name="WMPNetworkSvc"/>
+        <service name="WerSvc"/>
+        <service name="SysMain"/>
+        <service name="RetailDemo"/>
+        <service name="Fax"/>
+        <service name="WdiSystemHost"/>
+        <service name="WdiServiceHost"/>
+        <service name="DPS"/>
+        <service name="BITS"/>
+        <service name="WpcMonSvc"/>
+        <service name="wmiApSrv"/>
+        <service name="WbioSrvc"/>
+        <service name="WalletService"/>
+        <service name="TabletInputService"/>
+        <service name="MapsBroker"/>
+        <service name="lfsvc"/>
+    </services>
+    <tasks>
+        <!--
+        FORMAT: 
+        <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
+        -->
+        <task name="Microsoft Compatibility Appraiser" value="Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser"/>
+        <task name="ProgramDataUpdater" value="Microsoft\Windows\Application Experience\ProgramDataUpdater"/>
+        <task name="Proxy" value="Microsoft\Windows\Autochk\Proxy"/>
+        <task name="Consolidator" value="Microsoft\Windows\Customer Experience Improvement Program\Consolidator"/>
+        <task name="UsbCeip" value="Microsoft\Windows\Customer Experience Improvement Program\UsbCeip"/>
+        <task name="Microsoft-Windows-DiskDiagnosticDataCollector" value="Microsoft\Windows\DiskDiagnostic\Microsoft-Windows-DiskDiagnosticDataCollector"/>
+    </tasks>
+    <registry-items>
+        <!--
+        FORMAT: 
+        <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
+        -->
+        <registry-item name="Enable Fast Startup" path="HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" value="HiberbootEnabled" type="DWord" data="1"/>
+        <registry-item name="[1 of 9] Optimize visual effects for performance" path="HKCU:\Control Panel\Desktop" value="DragFullWindows" type="DWord" data="0"/>
+        <registry-item name="[2 of 9] Optimize visual effects for performance" path="HKCU:\Control Panel\Desktop" value="MenuShowDelay" type="DWord" data="0"/>
+        <registry-item name="[3 of 9] Optimize visual effects for performance" path="HKCU:\Control Panel\Desktop\WindowMetrics" value="MinAnimate" type="String" data="0"/>
+        <registry-item name="[4 of 9] Optimize visual effects for performance" path="HKCU:\Control Panel\Keyboard" value="KeyboardDelay" type="DWord" data="0"/>
+        <registry-item name="[5 of 9] Optimize visual effects for performance" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" value="ListviewAlphaSelect" type="DWord" data="0"/>
+        <registry-item name="[6 of 9] Optimize visual effects for performance" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" value="ListviewShadow" type="DWord" data="0"/>
+        <registry-item name="[7 of 9] Optimize visual effects for performance" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" value="TaskbarAnimations" type="DWord" data="0"/>
+        <registry-item name="[8 of 9] Optimize visual effects for performance" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" value="VisualFXSetting" type="DWord" data="3"/>
+        <registry-item name="[9 of 9] Optimize visual effects for performance" path="HKCU:\Software\Microsoft\Windows\DWM" value="EnableAeroPeek" type="DWord" data="0"/>
+        <registry-item name="DisableBingSearch" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" value="BingSearchEnabled" type="DWord" data="0"/>
+        <registry-item name="Disable Cortana Privacy Policy" path="HKCU:\Software\Microsoft\Personalization\Settings" value="AcceptedPrivacyPolicy" type="DWord" data="0" />
+        <registry-item name="Restrict Implicit Text Collection" path="HKCU:\Software\Microsoft\InputPersonalization" value="RestrictImplicitTextCollection" type="DWord" data="1" />
+        <registry-item name="Restrict Implicit Ink Collection" path="HKCU:\Software\Microsoft\InputPersonalization" value="RestrictImplicitInkCollection" type="DWord" data="1" />
+        <registry-item name="Disable Cortana Contact Harvesting" path="HKCU:\Software\Microsoft\InputPersonalization\TrainedDataStore" value="HarvestContacts" type="DWord" data="0" />
+        <registry-item name="Hide Cortana Button" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" value="ShowCortanaButton" type="DWord" data="0" />
+        <registry-item name="Disable Cortana through Policy Manager" path="HKLM:\SOFTWARE\Microsoft\PolicyManager\default\Experience\AllowCortana" value="Value" type="DWord" data="0" />
+        <registry-item name="Disable Cortana through Windows Search Policy" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" value="AllowCortana" type="DWord" data="0" />
+        <registry-item name="Disable Input Personalization" path="HKLM:\SOFTWARE\Policies\Microsoft\InputPersonalization" value="AllowInputPersonalization" type="DWord" data="0" />
+        <registry-item name="Disable Tailored Experiences with Diagnostic Data" path="HKCU:\Software\Policies\Microsoft\Windows\CloudContent" value="DisableTailoredExperiencesWithDiagnosticData" type="DWord" data="1" />
+        <registry-item name="Disable Tailored Experiences with Diagnostic Data" path="HKCU:\Software\Policies\Microsoft\Windows\CloudContent" value="DisableTailoredExperiencesWithDiagnosticData" type="DWord" data="1" />
+        <registry-item name="Disable OneDrive Files On-Demand" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\OneDrive" value="DisableFileSyncNGSC" type="DWord" data="1" />
+        <registry-item name="Disable Advertising ID" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo" value="DisabledByGroupPolicy" type="DWord" data="1" />
+        <registry-item name="Disable Telemetry" path="HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" value="AllowTelemetry" type="DWord" data="0" />
+        <registry-item name="Disable Telemetry Wow6432Node" path="HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Policies\DataCollection" value="AllowTelemetry" type="DWord" data="0" />
+        <registry-item name="Disable Data Collection" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" value="AllowTelemetry" type="DWord" data="0" />
+        <registry-item name="Disable PreviewBuilds" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds" value="AllowBuildPreview" type="DWord" data="0" />
+        <registry-item name="Enable NoGenTicket" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform" value="NoGenTicket" type="DWord" data="1" />
+        <registry-item name="Disable SQM" path="HKLM:\SOFTWARE\Policies\Microsoft\SQMClient\Windows" value="CEIPEnable" type="DWord" data="0" />
+        <registry-item name="Disable AppCompat AIT" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\AppCompat" value="AITEnable" type="DWord" data="0" />
+        <registry-item name="Disable AppCompat Inventory" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\AppCompat" value="DisableInventory" type="DWord" data="1" />
+        <registry-item name="Disable AppV CEIP" path="HKLM:\SOFTWARE\Policies\Microsoft\AppV\CEIP" value="CEIPEnable" type="DWord" data="0" />
+        <registry-item name="Disable PreventHandwritingDataSharing" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\TabletPC" value="PreventHandwritingDataSharing" type="DWord" data="1" />
+        <registry-item name="Disable AllowLinguisticDataCollection" path="HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\TextInput" value="AllowLinguisticDataCollection" type="DWord" data="0" />
+        <registry-item name="Disable Automatic Server Share" path="HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" value="AutoShareServer" type="DWord" data="0" />
+        <registry-item name="Disable Automatic Workstation Share" path="HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" value="AutoShareWks" type="DWord" data="0" />
+        <registry-item name="Hide Taskbar Search" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" value="SearchboxTaskbarMode" type="DWord" data="0" />
+        <registry-item name="Hide Task View" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" value="ShowTaskViewButton" type="DWord" data="0" />
+        <registry-item name="Remove MeetNow User" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" value="HideSCAMeetNow" type="DWord" data="1" />
+        <registry-item name="Remove MeetNow Machine" path="HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" value="HideSCAMeetNow" type="DWord" data="1" />
+        <registry-item name="Remove Bing Tab in Taksbar" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Feeds" value="ShellFeedsTaskbarViewMode" type="DWord" data="2" />
+        <registry-item name="Remove Bing Desktop Search Bar" path="HKLM:\SOFTWARE\Policies\Microsoft\Edge" value="WebWidgetAllowed" type="DWord" data="0" />
+        <registry-item name="Disable Windows Update Automatic Download" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" value="AUOptions" type="DWord" data="2" />
+        <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
+    </registry-items>
+
+    <path-items>
+        <!--
+        FORMAT: 
+        <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
+        -->
+    </path-items>
+    <custom-items>
+        <!--FORMAT: 
+        <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
+        -->
+        <custom-item name="Remove OneDrive">
+            <cmd value="taskkill /f /im OneDrive.exe"/>
+            <cmd value="C:\Windows\SysWOW64\OneDriveSetup.exe /uninstall"/>
+        </custom-item>
+        <custom-item name="Unpin Taskbar Icons">
+            <cmd value='Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -Name "Favorites" -Type Binary -Value ([byte[]](255))'/>
+            <cmd value='Remove-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Taskband" -Name "FavoritesResolve" -ErrorAction SilentlyContinue'/>
+        </custom-item>
+        <custom-item name="Remove Desktop Links">
+            <cmd value="del $(Join-Path $env:USERPROFILE 'Desktop\*.lnk')" />
+            <cmd value="del $(Join-Path $env:PUBLIC 'Desktop\*.lnk')" />
+        </custom-item>
+        <custom-item name="Disabling display and sleep mode timeouts">
+            <cmd value="powercfg /X monitor-timeout-ac 0" />
+            <cmd value="powercfg /X monitor-timeout-dc 0" />
+            <cmd value="powercfg /X standby-timeout-ac 0" />
+            <cmd value="powercfg /X standby-timeout-dc 0" />
+        </custom-item>
+    </custom-items>
+</config>

--- a/packages/debloat.vm/tools/win11.xml
+++ b/packages/debloat.vm/tools/win11.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config> 
+    <apps>
+        <!--
+        FORMAT: 
+        <app name="APP_NAME"/>
+        -->
+    </apps>
+    <services>
+        <!--
+        FORMAT: 
+        <service name="SERVICE_NAME"/>
+        -->
+    </services>
+    <tasks>
+        <!--
+        FORMAT: 
+        <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
+        -->
+    </tasks>
+    <registry-items>
+        <!--
+        FORMAT: 
+        <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
+        -->
+    </registry-items>
+
+    <path-items>
+        <!--
+        FORMAT: 
+        <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
+        -->
+    </path-items>
+    <custom-items>
+        <!--FORMAT: 
+        <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
+        -->
+    </custom-items>
+</config>

--- a/packages/debloat.vm/tools/win11.xml
+++ b/packages/debloat.vm/tools/win11.xml
@@ -2,37 +2,55 @@
 <config> 
     <apps>
         <!--
+        INFO:
+        Removes installed AppX packages. Try:
+        $packages = Get-AppxPackage
+        $packages.Name
         FORMAT: 
         <app name="APP_NAME"/>
         -->
     </apps>
     <services>
         <!--
+        INFO:
+        Sets Services to "Manual" startup type. Try:
+        $services = Get-WmiObject -Query "SELECT * FROM Win32_Service WHERE StartMode='Auto'" | Get-Service
+        $services.Name
         FORMAT: 
         <service name="SERVICE_NAME"/>
         -->
     </services>
     <tasks>
         <!--
+        INFO:
+        Disables Scheduled Tasks. Try:
+        $tasks = Get-ScheduledTask
+        $tasks.TaskName
         FORMAT: 
         <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
         -->
     </tasks>
     <registry-items>
         <!--
+        INFO:
+        Makes custom edits to the registry
         FORMAT: 
         <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
         -->
     </registry-items>
-
     <path-items>
         <!--
+        INFO:
+        Removes files and folders from the system
         FORMAT: 
         <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
         -->
     </path-items>
     <custom-items>
-        <!--FORMAT: 
+        <!--
+        INFO:
+        Performs custom commands
+        FORMAT: 
         <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
         -->
     </custom-items>

--- a/packages/debloat.vm/tools/win11arm.xml
+++ b/packages/debloat.vm/tools/win11arm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config> 
+    <apps>
+        <!--
+        FORMAT: 
+        <app name="APP_NAME"/>
+        -->
+    </apps>
+    <services>
+        <!--
+        FORMAT: 
+        <service name="SERVICE_NAME"/>
+        -->
+    </services>
+    <tasks>
+        <!--
+        FORMAT: 
+        <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
+        -->
+    </tasks>
+    <registry-items>
+        <!--
+        FORMAT: 
+        <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
+        -->
+    </registry-items>
+
+    <path-items>
+        <!--
+        FORMAT: 
+        <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
+        -->
+    </path-items>
+    <custom-items>
+        <!--FORMAT: 
+        <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
+        -->
+    </custom-items>
+</config>

--- a/packages/debloat.vm/tools/win11arm.xml
+++ b/packages/debloat.vm/tools/win11arm.xml
@@ -2,37 +2,55 @@
 <config> 
     <apps>
         <!--
+        INFO:
+        Removes installed AppX packages. Try:
+        $packages = Get-AppxPackage
+        $packages.Name
         FORMAT: 
         <app name="APP_NAME"/>
         -->
     </apps>
     <services>
         <!--
+        INFO:
+        Sets Services to "Manual" startup type. Try:
+        $services = Get-WmiObject -Query "SELECT * FROM Win32_Service WHERE StartMode='Auto'" | Get-Service
+        $services.Name
         FORMAT: 
         <service name="SERVICE_NAME"/>
         -->
     </services>
     <tasks>
         <!--
+        INFO:
+        Disables Scheduled Tasks. Try:
+        $tasks = Get-ScheduledTask
+        $tasks.TaskName
         FORMAT: 
         <task name="DESCRIPTIVE_NAME" value="TASK_NAME"/> 
         -->
     </tasks>
     <registry-items>
         <!--
+        INFO:
+        Makes custom edits to the registry
         FORMAT: 
         <registry-item name="DESCRIPTIVE_NAME" path="REG_PATH" value="REG_VALUE" type="TYPE" data="NEW_DATA"/> 
         -->
     </registry-items>
-
     <path-items>
         <!--
+        INFO:
+        Removes files and folders from the system
         FORMAT: 
         <path-item name="DESCRIPTIVE_NAME" type="dir/file" path="DIR_PATH/FILE_PATH"/>
         -->
     </path-items>
     <custom-items>
-        <!--FORMAT: 
+        <!--
+        INFO:
+        Performs custom commands
+        FORMAT: 
         <custom-item name="DESCRIPTIVE_NAME"> <cmd value="PS_COMMAND"/> ... </custom-item>
         -->
     </custom-items>

--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>installer.vm</id>
+    <version>0.0.0.20230904</version>
+    <title>Mandiant VM Installer</title>
+    <authors>Mandiant</authors>
+    <description>Generic installer for Mandiant's custom virtual machines.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>
+

--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -3,9 +3,8 @@
   <metadata>
     <id>installer.vm</id>
     <version>0.0.0.20230904</version>
-    <title>Mandiant VM Installer</title>
     <authors>Mandiant</authors>
-    <description>Generic installer for Mandiant's custom virtual machines.</description>
+    <description>Generic installer for custom virtual machines.</description>
     <dependencies>
       <dependency id="common.vm" />
     </dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,129 @@
+$ErrorActionPreference = 'Continue'
+$global:VerbosePreference = "SilentlyContinue"
+Import-Module vm.common -Force -DisableNameChecking
+
+function Get-InstalledPackages {
+    if (Get-Command choco -ErrorAction:SilentlyContinue) {
+        powershell.exe "choco list -r" | ForEach-Object {
+            $Name, $Version = $_ -split '\|'
+            New-Object -TypeName psobject -Property @{
+                'Name' = $Name
+                'Version' = $Version
+            }
+        }
+    }
+}
+
+try {
+    # Gather packages to install
+    $installedPackages = (Get-InstalledPackages).Name
+    $configPath = Join-Path ${Env:VM_COMMON_DIR} "config.xml" -Resolve
+    $configXml = [xml](Get-Content $configPath)
+    $packagesToInstall = $configXml.config.packages.package.name | Where-Object { $installedPackages -notcontains $_ }
+
+    # List packages to install
+    Write-Host "[+] Packages to install:"
+    foreach ($package in $packagesToInstall) {
+        Write-Host "`t[+] $package"
+    }
+    Start-Sleep 1
+
+    # Install the packages
+    foreach ($package in $packagesToInstall) {
+        Write-Host "[+] Installing: $package" -ForegroundColor Cyan
+        choco install "$package" -y
+    }
+    Write-Host "[+] Installation complete" -ForegroundColor Green
+
+    # Remove Chocolatey cache
+    $cache = "${Env:LocalAppData}\ChocoCache"
+    Remove-Item $cache -Recurse -Force
+
+    # Construct failed packages file path
+    $desktopPath = [Environment]::GetFolderPath("Desktop")
+    $failedPackages = Join-Path $desktopPath "failed_packages.txt"
+    $failures = @{}
+
+    # Check and list failed packages from "lib-bad"
+    $chocoLibBad = Join-Path ${Env:ProgramData} "chocolatey\lib-bad"
+    if ((Test-Path $chocoLibBad) -and (Get-ChildItem -Path $chocoLibBad | Measure-Object).Count -gt 0) {
+        Get-ChildItem -Path $chocoLibBad | Foreach-Object {
+            $failures[$_.Name] = $true
+        }
+    }
+
+    # Cross-compare packages to install versus installed packages to find failed packages
+    $installedPackages = (Get-InstalledPackages).Name
+    foreach ($package in $packagesToInstall) {
+        if ($installedPackages -notcontains $package) {
+            $failures[$package] = $true
+        }
+    }
+
+    $installedPackages = choco list -r | Out-String
+    VM-Write-Log "INFO" "Packages installed:`n$installedPackages"
+
+    # Write each failed package to failure file
+    foreach ($package in $failures.Keys) {
+        VM-Write-Log "ERROR" "Failed to install: $package"
+        Add-Content $failedPackages $package
+    }
+
+    # Log additional info if we found failed packages
+    $logPath = Join-Path ${Env:VM_COMMON_DIR} "log.txt"
+    if ((Test-Path $failedPackages)) {
+        VM-Write-Log "ERROR" "For each failed package, you may attempt a manual install via: choco install -y <package_name>"
+        VM-Write-Log "ERROR" "Failed package list saved to: $failedPackages"
+        VM-Write-Log "ERROR" "Please check the following logs for additional errors:"
+        VM-Write-Log "ERROR" "`t$logPath (this file)"
+        VM-Write-Log "ERROR" "`t%PROGRAMDATA%\chocolatey\logs\chocolatey.log"
+        VM-Write-Log "ERROR" "`t%LOCALAPPDATA%\Boxstarter\boxstarter.log"
+    }
+
+    # Display installer log if available
+    if ((Test-Path $logPath)) {
+        Write-Host "[-] Please check the following logs for any errors:" -ForegroundColor Yellow
+        Write-Host "`t[-] $logPath" -ForegroundColor Yellow
+        Write-Host "`t[-] %PROGRAMDATA%\chocolatey\logs\chocolatey.log" -ForegroundColor Yellow
+        Write-Host "`t[-] %LOCALAPPDATA%\Boxstarter\boxstarter.log" -ForegroundColor Yellow
+        Start-Sleep 5
+        & notepad.exe $logPath
+    }
+
+    # Let users know installation is complete by setting background, playing win sound, and display message box
+    Set-ItemProperty 'HKCU:\Control Panel\Colors' -Name Background -Value "0 0 0" -Force | Out-Null
+    $backgroundImage = "${Env:VM_COMMON_DIR}\background.png"
+    if ((Test-Path $backgroundImage)) {
+        # Center: 0, Stretch: 2, Fit:6, Fill: 10, Span: 22
+        New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name WallpaperStyle -PropertyType String -Value 6 -Force | Out-Null
+        New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name TileWallpaper -PropertyType String -Value 0 -Force | Out-Null
+        Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public class VMBackground
+{
+    [DllImport("User32.dll",CharSet=CharSet.Unicode)]
+    public static extern int SystemParametersInfo (Int32 uAction, Int32 uParam, String lpvParam, Int32 fuWinIni);
+    [DllImport("User32.dll",CharSet=CharSet.Unicode)]
+    public static extern bool SetSysColors(int cElements, int[] lpaElements, int[] lpaRgbValues);
+}
+"@
+        [VMBackground]::SystemParametersInfo(20, 0, $backgroundImage, 3)
+        [VMBackground]::SetSysColors(1, @(1), @(0x000000))
+    }
+
+    $playWav = New-Object System.Media.SoundPlayer
+    $playWav.SoundLocation = 'https://www.winhistory.de/more/winstart/down/owin31.wav'
+    $playWav.PlaySync()
+
+    Add-Type -AssemblyName PresentationCore,PresentationFramework
+    $msgBody = "Install complete!`nPlease review %VM_COMMON_DIR%\log.txt for any errors.`nThank you"
+    $msgTitle = "VM Installation Complete"
+    $msgButton = 'OK'
+    $msgImage = 'Asterisk'
+    [System.Windows.MessageBox]::Show($msgBody,$msgTitle,$msgButton,$msgImage)
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -19,7 +19,7 @@ try {
     # Install the packages
     try {
         foreach ($package in $packagesToInstall) {
-            VM-Write-Host "INFO" "Installing: $package" -ForegroundColor Cyan
+            VM-Write-Log "INFO" "Installing: $package" -ForegroundColor Cyan
             choco install "$package" -y
             VM-Write-Log "INFO" "$package has been installed"
         }

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -159,7 +159,7 @@ public class VMBackground
     Add-Type -AssemblyName System.Drawing
     # Create form
     $form = New-Object System.Windows.Forms.Form
-    $form.Text = "$Env:MandiantVM Installation Complete"
+    $form.Text = "$Env:VMname Installation Complete"
     $form.TopMost = $true
     $form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
     if ($iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico" -Resolve){

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -19,7 +19,7 @@ try {
     # Install the packages
     try {
         foreach ($package in $packagesToInstall) {
-            Write-Host "[+] Installing: $package" -ForegroundColor Cyan
+            VM-Write-Host "INFO" "Installing: $package" -ForegroundColor Cyan
             choco install "$package" -y
             VM-Write-Log "INFO" "$package has been installed"
         }
@@ -54,14 +54,14 @@ try {
                 }
 
                 # Make the folder "system" to enable custom settings like icon change
-                Start-Process "attrib +s $folderPath" -Wait
+                Start-Process "attrib" -ArgumentList "+s $folderPath" -Wait
 
                 # Write the needed settings into desktop.ini
                 Add-Content -Path $desktopIniPath -Value "[.ShellClassInfo]"
                 Add-Content -Path $desktopIniPath -Value ("IconResource=$iconPath,0")
 
                 # Make the desktop.ini file hidden and system
-                Start-Process "attrib +h +s $desktopIniPath" -Wait
+                Start-Process "attrib" -ArgumentList " +h +s $desktopIniPath" -Wait
             }
     }
     # Refresh the desktop

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -41,12 +41,12 @@ try {
 
     # Configure Desktop\Tools folder with a custom icon
     if ($iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico" -Resolve) {
-        $folderPath = $Env:TOOL_LIST_DIR 
+        $folderPath = $Env:TOOL_LIST_DIR
         # Set the icon
         if (Test-Path -Path $folderPath -PathType Container) {
             # Full path to the desktop.ini file inside the folder
             $desktopIniPath = Join-Path -Path $folderPath -ChildPath 'desktop.ini'
-            
+
             # Check if desktop.ini already exists
             if (-Not (Test-Path -Path $desktopIniPath)) {
                     # Create an empty desktop.ini if it doesn't exist
@@ -95,7 +95,7 @@ try {
     foreach ($package in $installedPackages){
         VM-Write-Log "INFO" "Packages installed:  $($package.Name) | $($package.Version)"
     }
-    
+
     # Write each failed package to failure file
     foreach ($package in $failures.Keys) {
         VM-Write-Log "ERROR" "Failed to install: $package"

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -19,7 +19,7 @@ try {
     # Install the packages
     try {
         foreach ($package in $packagesToInstall) {
-            VM-Write-Log "INFO" "Installing: $package" -ForegroundColor Cyan
+            VM-Write-Log "INFO" "Installing: $package"
             choco install "$package" -y
             VM-Write-Log "INFO" "$package has been installed"
         }

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -287,7 +287,7 @@ class MissesImportCommonVm(Lint):
 
 
 class FirstLineDoesNotSetErrorAction(Lint):
-    EXCLUSIONS = ["libraries.python2.vm", "libraries.python3.vm", "flarevm.installer.vm"]
+    EXCLUSIONS = ["libraries.python2.vm", "libraries.python3.vm", "flarevm.installer.vm", "installer.vm"]
     FIRST_LINE = "$ErrorActionPreference = 'Stop'"
     name = "first line must set error handling to stop"
     recommendation = f"add `{FIRST_LINE}` to the file"

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -316,6 +316,8 @@ class UsesInvalidCategory(Lint):
         ".ollydumpex.vm",
         ".scyllahide.vm",
         "x64dbgpy.vm",
+        "installer.vm",
+        "debloat.vm"
     ]
 
     root_path = os.path.abspath(os.path.join(__file__, "../../.."))

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -39,7 +39,7 @@ foreach ($package in $packages) {
 }
 
 
-$exclude_tests = @("flarevm.installer.vm", "python3.vm")
+$exclude_tests = @("flarevm.installer.vm", "python3.vm", "installer.vm")
 
 $failures = New-Object Collections.Generic.List[string]
 $failed = 0


### PR DESCRIPTION
## Created `debloater.vm` package
- Added the following functions to `common.vm` from recent Commando release:
```
VM-Remove-Appx-Package
VM-Set-Service-Manual-Start
VM-Disable-Scheduled-Task
VM-Update-Registry-Value
VM-Remove-Path
VM-Execute-Custom-Command
VM-Apply-Configurations
```
- Added `VM-Get-WindowsVersion` function to `common.vm` to identify Win10, Win11, or Win11ARM installations
- Created win10, win11, and win11ARM config files
  - Config files for win11 and win11arm are mostly placeholders for now

## Created `installer.vm` package
- Moved `failed_packages.txt` to `$Env:VM_COMMON_DIR`
  - Mostly for aesthetic reasons. Failed packages log is printed to console output if people need it. Plus we know where it will be if we need to troubleshoot
- Changed background image setting from 6 (fit) to 0 (center)
  - This allows for more customization of the desktop background especially for Commando. Also allows reuse of images from `readme.md` and the background setting
  - Should still work with flarevm's current background
- **Important:** Changed variable/file name `config.xml` (previously holding package and variables) to `packages.xml` to avoid confusion with the new custom configs that can be supported
  - Installer script for Mandiant VMs should now place a `packages.xml` file _AND_ a `config.xml` file into `$Env:VM_COMMON_DIR`
  - `installer.vm` now expects packages to be listed in the `packages.xml` file
  - `installer.vm` now expects OS configurations to be listed in the `config.xml` file
- Created new prompt dialog box that will force itself to be the top window
  - Added functionality to include a custom `.ico` file (expected in `$Env:VM_COMMON_DIR\vm.ico`)
  - Expects a variable `$Env:MandiantVM` to exist (explained below)
- Added function to change icon of Desktop `Tools` folder (using the custom `.ico` file above)
  - More changes to this folder listed below
- No longer popping `log.txt` for cleaner exit of installation
  - log locations are still listed at the close of installation if needed
- Fixed bug where installed apps were not being logged to log.txt
- Moved `Get-InstalledPackages` function to `common.vm`

## Changes/additions to `common.vm`
- Added `VM-Configure-Prompts` function to add "Mandiant VM" and timestamps to PowerShell and cmd
  - **Important:** Above "Mandiant VM" is a placeholder. Added an environment variable in Commando installer script to set this variable (set to Commando VM). When the script runs on Commando the PS Prompt will now be "Commando VM" but when Flare VM is updated it will read "Flare VM"
  - Expects a variable `$Env:MandiantVM` to exist
- Added `VM-Configure-PS-Logging` function
- Changed location of Desktop `Tools` folder to actually be on the desktop
  - This does not affect `RAW_TOOLS_DIR` as that is different.. This folder is just the folder with all the shortcuts
  - This was originally located in the Start Menu which I believe was a legacy Win7 thing
  - By moving the folder to the desktop itself we can now configure a custom `.ico` file for the folder for ultimate flexing
- Removed `TOOL_LIST_SHORTCUT` because this variable is not referenced by any of our packages or install scripts. This function is also what used to create the shortcut on the desktop, and now that the Tools folder lives on the desktop (Not the `RAW_TOOLS_DIR`, just the folder that hosts all the other shortcuts) we dont need the shortcut
- Added all of the functions mentioned above