### PR TITLE
Bring stringsifter back

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230825</version>
+    <version>0.0.0.20230906</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -9,9 +9,8 @@ try {
     # Create output file to log python module installation details
     $outputFile = VM-New-Install-Log $toolDir
 
-    # Fix pip version, stringsifter doesn't install with pip 23:
-    # https://github.com/mandiant/stringsifter/issues/29
-    Invoke-Expression "py -3.9 -m pip install pip==20.1 >> $outputFile"
+    # Fix pip version
+    Invoke-Expression "py -3.9 -m pip install pip~=23.2.1 >> $outputFile"
 
     $failures = @()
     $modules = $modulesXml.modules.module

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -22,8 +22,7 @@
     <module name="pyOpenSSL"/>
     <module name="psutil"/>
     <module name="requests"/>
-    <!-- Restrict stringsifter dependencies https://github.com/mandiant/stringsifter/issues/30 -->
-    <!-- <module name="stringsifter" url ="https://github.com/Ana06/stringsifter/archive/refs/heads/master.zip"/> -->
+    <module name="stringsifter"/>
     <module name="uncompyle6"/>
     <module name="unpy2exe"/>
     <module name="unicorn"/>


### PR DESCRIPTION
Use upstream version as a new version has been released that also includes the fixes in the patched version. Increase the pip version to the latest one.

Closes https://github.com/mandiant/VM-Packages/issues/644