### PR TITLE
Add 'unzip "infected"' and 'Open with IDA" to right click menu

### DIFF
--- a/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
+++ b/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>7zip-15-05.vm</id>
-    <version>15.05</version>
+    <version>15.05.0.20230926</version>
     <authors>Igor Pavlov</authors>
     <description>7-Zip file archiver. This version is able to extract NSIS scripts.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230926" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
@@ -31,8 +31,15 @@ try {
   Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
   VM-Assert-Path $shortcut
 
-  $executablePath = Join-Path $toolDir "7z.exe" -Resolve
-  Install-BinFile -Name $toolName -Path $executablePath
+  $7zExecutablePath = Join-Path $toolDir "7z.exe" -Resolve
+  Install-BinFile -Name $toolName -Path $7zExecutablePath
+
+  # Add 7z unzip with password "infected" to the right menu for the most common extensions.
+  # 7z can unzip other file extensions like .docx but these don't likely use the infected password.
+  $extensions = @(".7z", ".bzip2", ".gzip", ".tar", ".wim", ".xz", ".txz", ".zip", ".rar")
+  foreach ($extension in $extensions) {
+    VM-Add-To-Right-Click-Menu $toolName 'unzip "infected"' "`"$7zExecutablePath`" e -pinfected `"%1`"" "$executablePath" -extension $extension
+  }
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/7zip-15-05.vm/tools/chocolateyuninstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyuninstall.ps1
@@ -12,3 +12,8 @@ Uninstall-BinFile -Name $toolName
 
 # Manually silently uninstall
 VM-Uninstall-With-Uninstaller "7-Zip 15.05*" "EXE" "/S"
+
+$extensions = @(".7z", ".bzip2", ".gzip", ".tar", ".wim", ".xz", ".txz", ".zip", ".rar")
+foreach ($extension in $extensions) {
+  VM-Remove-From-Right-Click-Menu $toolName -extension $extension
+}

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230904</version>
+    <version>0.0.0.20230925</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230925</version>
+    <version>0.0.0.20230926</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -698,14 +698,20 @@ function VM-Add-To-Right-Click-Menu {
         [string] $menuIcon,
         [Parameter(Mandatory=$false)]
         [ValidateSet("file", "directory")]
-        [string] $type="file"
+        [string] $type="file",
+        [Parameter(Mandatory=$false)]
+        [string] $extension
     )
     try {
-        # Determine if file or directory should show item in right-click menu
-        if ($type -eq "file") {
-            $key = "*"
+        if ($extension) {
+          $key = "SystemFileAssociations\$extension"
         } else {
-            $key = "directory"
+          # Determine if file or directory should show item in right-click menu
+          if ($type -eq "file") {
+              $key = "*"
+          } else {
+              $key = "directory"
+          }
         }
         $key_path = "HKCR:\$key\shell\$menuKey"
 
@@ -716,7 +722,7 @@ function VM-Add-To-Right-Click-Menu {
 
         # Add right-click menu display name
         if (-NOT (Test-Path -LiteralPath $key_path)) {
-            New-Item -Path $key_path | Out-Null
+            New-Item -Path $key_path -Force | Out-Null
         }
         Set-ItemProperty -LiteralPath $key_path -Name '(Default)' -Value "$menuLabel" -Type String
         if ($menuIcon) {
@@ -740,14 +746,20 @@ function VM-Remove-From-Right-Click-Menu {
         [String] $menuKey, # name of registry key
         [Parameter(Mandatory=$false)]
         [ValidateSet("file", "directory")]
-        [string] $type="file"
+        [string] $type="file",
+        [Parameter(Mandatory=$false)]
+        [string] $extension
     )
     try {
-        # Determine if file or directory should show item in right-click menu
-        if ($type -eq "file") {
-            $key = "*"
+        if ($extension) {
+          $key = "SystemFileAssociations\$extension"
         } else {
-            $key = "directory"
+          # Determine if file or directory should show item in right-click menu
+          if ($type -eq "file") {
+              $key = "*"
+          } else {
+              $key = "directory"
+          }
         }
         $key_path = "HKCR:\$key\shell\$menuKey"
 

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -694,11 +694,11 @@ function VM-Add-To-Right-Click-Menu {
         [string] $menuLabel, # value displayed in right-click menu
         [Parameter(Mandatory=$true, Position=2)]
         [string] $command,
-        [Parameter(Mandatory=$true, Position=3)]
+        [Parameter(Mandatory=$false, Position=3)]
+        [string] $menuIcon,
+        [Parameter(Mandatory=$false)]
         [ValidateSet("file", "directory")]
-        [string] $type,
-        [Parameter(Mandatory=$false, Position=4)]
-        [string] $menuIcon
+        [string] $type="file"
     )
     try {
         # Determine if file or directory should show item in right-click menu
@@ -738,9 +738,9 @@ function VM-Remove-From-Right-Click-Menu {
     (
         [Parameter(Mandatory=$true, Position=0)]
         [String] $menuKey, # name of registry key
-        [Parameter(Mandatory=$true, Position=1)]
+        [Parameter(Mandatory=$false)]
         [ValidateSet("file", "directory")]
-        [string] $type
+        [string] $type="file"
     )
     try {
         # Determine if file or directory should show item in right-click menu

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.07.20230523</version>
+    <version>3.07.20230925</version>
     <authors>Hellsp@wn, horsicq</authors>
     <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/die.vm/tools/chocolateyinstall.ps1
+++ b/packages/die.vm/tools/chocolateyinstall.ps1
@@ -11,7 +11,7 @@ try {
   $zipSha256_64 = '3450169643be76484ac4bd5e1473f6f4745d9825c8a07255a3925a4a6e8bad7e'
 
   $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -zipUrl_64 $zipUrl_64 -zipSha256_64 $zipSha256_64)[-1]
-  VM-Add-To-Right-Click-Menu $toolName "detect it easy (DIE)" "`"$executablePath`" `"%1`"" "file" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "detect it easy (DIE)" "`"$executablePath`" `"%1`"" "$executablePath"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/die.vm/tools/chocolateyuninstall.ps1
+++ b/packages/die.vm/tools/chocolateyuninstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'die'
 $category = 'Utilities'
 
 VM-Uninstall $toolName $category
-VM-Remove-From-Right-Click-Menu $toolName "file"
+VM-Remove-From-Right-Click-Menu $toolName

--- a/packages/explorersuite.vm/explorersuite.vm.nuspec
+++ b/packages/explorersuite.vm/explorersuite.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>explorersuite.vm</id>
-    <version>0.0.0.20230523</version>
+    <version>0.0.0.20230925</version>
     <authors>Erik Pistelli</authors>
     <description>A suite of tools including CFF Explorer and a process viewer.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/explorersuite.vm/tools/chocolateyinstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyinstall.ps1
@@ -31,7 +31,7 @@ try {
   # "Open with CFF Explorer" is added to the registry for several extensions,
   # add it for all extension with same key to avoid duplication.
   # Use same label and no icon to make it look the same for all extensions.
-  VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExplorerExecutablePath`" %1" "file"
+  VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExplorerExecutablePath`" %1"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
@@ -7,6 +7,6 @@ foreach ($subtoolName in $subtoolNames) {
   VM-Remove-Tool-Shortcut  $subtoolName $category
 }
 
-VM-Remove-From-Right-Click-Menu 'CFF explorer' "file"
+VM-Remove-From-Right-Click-Menu 'CFF explorer'
 
 VM-Uninstall-With-Uninstaller "Explorer Suite IV" "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"

--- a/packages/file.vm/file.vm.nuspec
+++ b/packages/file.vm/file.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>file.vm</id>
-    <version>0.0.0.20170108</version>
+    <version>0.0.0.20230925</version>
     <description>A Windows port of the Linux `file` utility for checking header magics</description>
     <authors>Nolen Scaiffe</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/file.vm/tools/chocolateyinstall.ps1
+++ b/packages/file.vm/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ try {
     $scriptPath = Join-Path $executableDir "leave_file_open.bat"
     [IO.File]::WriteAllLines($scriptPath, $("`"$executablePath`" %1", "PAUSE"))
 
-    VM-Add-To-Right-Click-Menu $toolName "file type" "`"$scriptPath`" `"%1`"" "file"
+    VM-Add-To-Right-Click-Menu $toolName "file type" "`"$scriptPath`" `"%1`""
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/file.vm/tools/chocolateyuninstall.ps1
+++ b/packages/file.vm/tools/chocolateyuninstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'file'
 $category = 'Utilities'
 
 VM-Uninstall $toolName $category
-VM-Remove-From-Right-Click-Menu $toolName "file"
+VM-Remove-From-Right-Click-Menu $toolName

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20230524</version>
+    <version>0.0.0.20230925</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
@@ -9,8 +9,8 @@ try {
   $zipUrl_64 = "https://www.nirsoft.net/utils/hashmyfiles-x64.zip"
 
   $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipUrl_64 $zipUrl_64)[-1]
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "file" "$executablePath"
-  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "directory" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "$executablePath"
+  VM-Add-To-Right-Click-Menu $toolName "HashMyFiles" "`"$executablePath`" /file `"%1`"" "$executablePath" -type "directory"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/hashmyfiles.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyuninstall.ps1
@@ -5,5 +5,5 @@ $toolName = 'hashmyfiles'
 $category = 'Utilities'
 
 VM-Uninstall $toolName $category
-VM-Remove-From-Right-Click-Menu $toolName "file"
-VM-Remove-From-Right-Click-Menu $toolName "directory"
+VM-Remove-From-Right-Click-Menu $toolName
+VM-Remove-From-Right-Click-Menu $toolName -type "directory"

--- a/packages/hxd.vm/hxd.vm.nuspec
+++ b/packages/hxd.vm/hxd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hxd.vm</id>
-    <version>2.5.0.20230524</version>
+    <version>2.5.0.20230925</version>
     <authors>Maël Hörz</authors>
     <description>Freeware hex editor</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
       <dependency id="hxd" version="[2.5.0.0]" />
     </dependencies>
   </metadata>

--- a/packages/hxd.vm/tools/chocolateyinstall.ps1
+++ b/packages/hxd.vm/tools/chocolateyinstall.ps1
@@ -13,7 +13,7 @@ try {
 
     Install-BinFile -Name $toolName -Path $executablePath
 
-    VM-Add-To-Right-Click-Menu $toolName $toolName "`"$executablePath`" `"%1`"" "file" "$executablePath"
+    VM-Add-To-Right-Click-Menu $toolName $toolName "`"$executablePath`" `"%1`"" "$executablePath"
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/hxd.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hxd.vm/tools/chocolateyuninstall.ps1
@@ -5,5 +5,5 @@ $toolName = 'HxD'
 $category = 'Hex Editors'
 
 VM-Remove-Tool-Shortcut $toolName $category
-VM-Remove-From-Right-Click-Menu $toolName "file"
+VM-Remove-From-Right-Click-Menu $toolName
 Uninstall-BinFile -Name $toolName

--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>7.6.20230418</version>
+    <version>7.6.20230926</version>
     <authors>hex-rays</authors>
     <description>Free version of IDA, a powerful Interactive DisAssembler and debugger</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20230925" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -29,6 +29,17 @@ try {
   if (Test-Path $desktopShortcut) {
     Remove-Item $desktopShortcut -Force -ea 0
   }
+
+  $menuIcon = Join-Path $toolDir "ida.ico" -Resolve
+  # Run a Powershell script to open with last IDA Pro version which is likely installed after the IDA free package.
+  # It takes slightly longer than using an static path but it works after installing IDA Pro and every time you update it.
+  # The "-WindowStyle hidden" still shows the Powershell Window briefly: https://github.com/PowerShell/PowerShell/issues/3028
+  # We could use the run-hidden wrapper, which won't display the Window but is likely slightly slower.
+  $script = "`$idaExecutable = Get-Item '$Env:programfiles\IDA Pro *\ida.exe' | Select-Object -Last 1; if (!`$idaExecutable) { `$idaExecutable = '$executablePath' }; & `$idaExecutable '%1'"
+  VM-Add-To-Right-Click-Menu $toolName 'Open with IDA' "powershell.exe -WindowStyle hidden `"$script`"" "$menuIcon"
+  # Repeat for x64
+  $script = "`$idaExecutable = Get-Item '$Env:programfiles\IDA Pro *\ida64.exe' | Select-Object -Last 1; if (!`$idaExecutable) { `$idaExecutable = '$executablePath' }; & `$idaExecutable '%1'"
+  VM-Add-To-Right-Click-Menu $toolName-64 'Open with IDA (x64)' "powershell.exe -WindowStyle hidden `"$script`"" "$executablePath"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/idafree.vm/tools/chocolateyuninstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyuninstall.ps1
@@ -12,3 +12,6 @@ Uninstall-BinFile -Name $toolName
 
 # Manually silently uninstall
 VM-Uninstall-With-Uninstaller "IDA Freeware*?7.6" "EXE" "--mode unattended"
+
+VM-Remove-From-Right-Click-Menu $toolName
+VM-Remove-From-Right-Click-Menu $toolName-64


### PR DESCRIPTION
- Add 7z unzip with password "infected" option to the right menu for the most common extensions.
![Screenshot 2023-09-26 at 19 12 15](https://github.com/mandiant/VM-Packages/assets/16052290/39f8378e-625e-4916-b06f-9262fa4e7e10)

- Add "Open with IDA" and "Open with IDA (x64)" to the right click menu. The command executes a Powershell script that looks for the latest IDA Pro version and uses it to open the file. If no IDA Pro version is found, it opens the file with IDA free.
  ![Screenshot 2023-09-26 at 19 11 38](https://github.com/mandiant/VM-Packages/assets/16052290/04c89762-6f63-4186-b2b2-f56bbcd0f8a0)

- Simplify calls to `VM-Remove-From-Right-Click-Menu` by giving `type` as default value as it is `file` in most of the cases.

Closes https://github.com/mandiant/VM-Packages/issues/480