### PR TITLE
Add ida.plugin.capa.vm

### DIFF
--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.capa.vm</id>
+    <version>6.1.0</version>
+    <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
+    <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20230927" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    # Install plugin
+    $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v6.1.0/capa/ida/plugin/capa_explorer.py"
+    $pluginSha256 = "a9a60d9066c170c4e18366eb442f215009433bcfe277d3c6d0c4c9860824a7d3"
+    $pluginsDir = New-Item "$Env:APPDATA\Hex-Rays\IDA Pro\plugins" -ItemType "directory" -Force
+    $pluginPath = Join-Path $pluginsDir "capa_explorer.py"
+    $packageArgs = @{
+        packageName = ${Env:ChocolateyPackageName}
+        url = $pluginUrl
+        checksum = $pluginSha256
+        checksumType = "sha256"
+        fileFullPath = $pluginPath
+        forceDownload = $true
+    }
+    Get-ChocolateyWebFile @packageArgs
+    VM-Assert-Path $pluginPath
+
+    # Download capa rules
+    $rulesUrl = "https://github.com/mandiant/capa-rules/archive/refs/tags/v6.1.0.zip"
+    $rulesSha256 = "d87240475b2989e919f65381556f28b455a2f7d6cd35d95acdbbbe9f04f86c84"
+    $packageArgs = @{
+        packageName    = ${Env:ChocolateyPackageName}
+        unzipLocation  = $pluginsDir
+        url            = $rulesUrl
+        checksum       = $rulesSha256
+        checksumType   = 'sha256'
+    }
+    Install-ChocolateyZipPackage @packageArgs
+    $rulesDir = Join-Path $pluginsDir "capa-rules-6.1.0" -Resolve
+
+    # Set capa rules in the capa plugin
+    $registryPath = 'HKCU:\SOFTWARE\IDAPython\IDA-Settings\capa'
+    New-Item $registryPath -Force | Out-Null
+    # ida_settings expects '/' in the rule path
+    $value = $rulesDir.replace("\", "/")
+    Set-ItemProperty $registryPath -Name "rule_path" -Value "`"$value`"" -Force | Out-Null
+} catch {
+  VM-Write-Log-Exception $_
+}
+

--- a/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginsDir = "$Env:APPDATA\Hex-Rays\IDA Pro\plugins"
+
+# Uninstall plugin
+$pluginPath = Join-Path $pluginsDir "capa_explorer.py"
+Remove-Item $pluginPath
+
+# Delete capa rules
+$rulesDir = Join-Path $pluginsDir "capa-rules-6.1.0"
+Remove-Item $rulesDir
+
+# Delete registry information
+Remove-Item 'HKCU:\SOFTWARE\IDAPython\IDA-Settings\capa'

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230906</version>
+    <version>0.0.0.20230927</version>
     <description>Metapackage to install common Python 3.9 libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="vcbuildtools.vm" />
-      <dependency id="python3" version="[3.9.0, 3.10.0)" />
+      <dependency id="python3" version="[3.10.0, 3.11.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ try {
     $outputFile = VM-New-Install-Log $toolDir
 
     # Fix pip version
-    Invoke-Expression "py -3.9 -m pip install pip~=23.2.1 >> $outputFile"
+    Invoke-Expression "py -3.10 -m pip install pip~=23.2.1 >> $outputFile"
 
     $failures = @()
     $modules = $modulesXml.modules.module
@@ -21,19 +21,19 @@ try {
             $intallValue = $module.url
         }
 
-        Invoke-Expression "py -3.9 -m pip install $intallValue 2>&1 >> $outputFile"
+        Invoke-Expression "py -3.10 -m pip install $intallValue 2>&1 >> $outputFile"
 
         if ($LastExitCode -eq 0) {
-            Write-Host "`t[+] Installed Python 3.9 module: $($module.name)" -ForegroundColor Green
+            Write-Host "`t[+] Installed Python 3.10 module: $($module.name)" -ForegroundColor Green
         } else {
-            Write-Host "`t[!] Failed to install Python 3.9 module: $($module.name)" -ForegroundColor Red
+            Write-Host "`t[!] Failed to install Python 3.10 module: $($module.name)" -ForegroundColor Red
             $failures += $module.Name
         }
     }
 
     if ($failures.Count -gt 0) {
         foreach ($module in $failures) {
-            VM-Write-Log "ERROR" "Failed to install Python 3.9 module: $module"
+            VM-Write-Log "ERROR" "Failed to install Python 3.10 module: $module"
         }
         $outputFile = $outputFile.replace('lib\', 'lib-bad\')
         VM-Write-Log "ERROR" "Check $outputFile for more information"

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -3,6 +3,7 @@
     <module name="acefile"/>
     <module name="art"/>
     <module name="binwalk" url="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"/>
+    <module name="flare-capa"/>
     <module name="capstone-windows"/>
     <module name="dissect"/>
     <module name="dnfile"/>

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -306,18 +306,19 @@ class FirstLineDoesNotSetErrorAction(Lint):
 class UsesInvalidCategory(Lint):
     # Some packages don't have a category (we don't create a link in the tools directory)
     EXCLUSIONS = [
+        ".ollydumpex.vm",
+        ".scyllahide.vm",
         "common.vm",
+        "debloat.vm",
         "flarevm.installer.vm",
+        "ida.plugin.capa.vm",
+        "installer.vm",
         "libraries.python2.vm",
         "libraries.python3.vm",
         "notepadplusplus.vm",
         "notepadpp.plugin.",
         "npcap.vm",
-        ".ollydumpex.vm",
-        ".scyllahide.vm",
         "x64dbgpy.vm",
-        "installer.vm",
-        "debloat.vm"
     ]
 
     root_path = os.path.abspath(os.path.join(__file__, "../../.."))


### PR DESCRIPTION
Add ida.plugin.capa.vm that install the capa plugin for IDA.

The package has libraries.python3.vm as dependency, that installs the flare-capa Python library. This library has been updated to use Python 10 due to the following IDA bug:
- https://github.com/mandiant/capa/issues/681

Closes https://github.com/mandiant/VM-Packages/issues/466