### PR TITLE
Add pkg-unpacker & introduce Packers category 

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_metapackage.yml
+++ b/.github/ISSUE_TEMPLATE/new_metapackage.yml
@@ -70,6 +70,7 @@ body:
         - Lateral Movement
         - Networking
         - Office
+        - Packers
         - Password Attacks
         - Payload Development
         - PDF

--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -89,6 +89,7 @@ body:
         - Lateral Movement
         - Networking
         - Office
+        - Packers
         - Password Attacks
         - Payload Development
         - PDF

--- a/categories.txt
+++ b/categories.txt
@@ -18,6 +18,7 @@ Javascript
 Lateral Movement
 Networking
 Office
+Packers
 Password Attacks
 Payload Development
 PDF

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pkg-unpacker.vm</id>
+    <version>1.0.0</version>
+    <authors>LockBlock-dev</authors>
+    <description>Unpacker for pkg applications.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="nodejs" version="[20.7.0]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
+++ b/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,19 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $toolName = 'pkg-unpacker'
+    $category = 'Packers'
+    $zipUrl = 'https://github.com/LockBlock-dev/pkg-unpacker/archive/b1fd5200e1bf656dedef6817c177c8bb2dc38028.zip'
+    $zipSha256 = '6eed1d492d37ca3934a3bc838c2256719a3e78ccf72ce1b1ca07684519ace16c'
+    $powershellCommand = "Write-Output '> node unpack.js'; node unpack.js"
+
+    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+
+    # Get absolute path as npm is not in path until Powershell is restarted
+    $npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
+    # Install tool dependencies with npm
+    Set-Location $toolDir; & "$npmPath" install | Out-Null
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/pkg-unpacker.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pkg-unpacker.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'pkg-unpacker'
+$category = 'Packers'
+
+VM-Uninstall $toolName $category

--- a/packages/upx.vm/tools/chocolateyinstall.ps1
+++ b/packages/upx.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'upx'
-$category = 'Utilities'
+$category = 'Packers'
 
 $zipUrl = "https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-win32.zip"
 $zipSha256 = "066c62993ce904f9f377ce849e85b77d1e2cf477d554c36c5ff89f6d3f0fa072"

--- a/packages/upx.vm/tools/chocolateyuninstall.ps1
+++ b/packages/upx.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'upx'
-$category = 'Utilities'
+$category = 'Packers'
 
 VM-Uninstall $toolName $category

--- a/packages/upx.vm/upx.vm.nuspec
+++ b/packages/upx.vm/upx.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>upx.vm</id>
-    <version>4.1.0</version>
+    <version>4.1.0.20230929</version>
     <authors>markus-oberhumer</authors>
     <description>UPX is a free, secure, portable, extendable, high-performance executable packer for several executable formats.</description>
     <dependencies>


### PR DESCRIPTION
Add pkg-unpacker, a nodejs tool installed similarly to malware-jail. Introduce a `Packers` category as the Utilities folder is getting big and to make easier finding tools. Add upx and pkg-unpacker to the packers category. Moving upx to the Packers category  likely breaks updates. But out documentation explains that updates are best-effort and mentions this case. I think it is better to introduce this category now that we only have to move one tool.
