### PR TITLE
Use os.path.join in lint.py

### DIFF
--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -322,7 +322,7 @@ class UsesInvalidCategory(Lint):
     ]
 
     root_path = os.path.abspath(os.path.join(__file__, "../../.."))
-    categories_txt = f"{root_path}/categories.txt"
+    categories_txt = os.path.join(root_path, "categories.txt")
     with open(categories_txt) as file:
         CATEGORIES = [line.rstrip() for line in file]
         logger.debug(CATEGORIES)


### PR DESCRIPTION
`os.path.join` uses the format suitable for the OS Python is running on, using `/` in Linux and `\` in Windows. We were mixing them up in the GH action run that uses Windows:
```
D:\a\VM-Packages\VM-Packages/categories.txt
```