### PR TITLE
Installer improvements

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20230904</version>
+    <version>0.0.0.20231009</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -122,8 +122,17 @@ try {
         Write-Host "`t[-] %LOCALAPPDATA%\Boxstarter\boxstarter.log" -ForegroundColor Yellow
     }
 
-    # Let users know installation is complete by setting background, playing win sound, and display message box
-    # Set background
+    # Let users know installation is complete by setting lock screen & wallpaper background, playing win sound, and display message box
+
+    # Set lock screen image
+    $lockScreenImage = "${Env:VM_COMMON_DIR}\lockscreen.png"
+    if ((Test-Path $lockScreenImage)) {
+        New-Item "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP" -Force | Out-Null
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP" -Name LockScreenImagePath -PropertyType String -Value $lockScreenImage -Force | Out-Null
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\PersonalizationCSP" -Name LockScreenImageStatus -PropertyType DWord -Value 1 -Force | Out-Null
+    }
+
+    # Set wallpaper
     Set-ItemProperty 'HKCU:\Control Panel\Colors' -Name Background -Value "0 0 0" -Force | Out-Null
     $backgroundImage = "${Env:VM_COMMON_DIR}\background.png"
     if ((Test-Path $backgroundImage)) {

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -39,8 +39,9 @@ try {
     # Configure PowerShell Logging
     VM-Configure-PS-Logging
 
-    # Configure Desktop\Tools folder with a custom icon
-    if ($iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico" -Resolve) {
+    # Configure Desktop\Tools folder with a custom icon if it exists
+    $iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico"
+    if (Test-Path $iconPath) {
         $folderPath = $Env:TOOL_LIST_DIR
         # Set the icon
         if (Test-Path -Path $folderPath -PathType Container) {

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -128,7 +128,9 @@ try {
     $backgroundImage = "${Env:VM_COMMON_DIR}\background.png"
     if ((Test-Path $backgroundImage)) {
         # Center: 0, Stretch: 2, Fit:6, Fill: 10, Span: 22
-        New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name WallpaperStyle -PropertyType String -Value 0 -Force | Out-Null
+        $img = [System.Drawing.Image]::FromFile($backgroundImage);
+        $wallpaperStyle = if ($img.Width/$img.Height -ge 16/9) { 0 } else { 6 }
+        New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name WallpaperStyle -PropertyType String -Value $wallpaperStyle -Force | Out-Null
         New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name TileWallpaper -PropertyType String -Value 0 -Force | Out-Null
         Add-Type -TypeDefinition @"
 using System;

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -30,8 +30,8 @@ try {
 
     # Set Profile/Version specific configurations
     VM-Write-Log "INFO" "[+] Beginning Windows OS VM profile configuration changes"
-    $configFile = Join-Path $Env:VM_COMMON_DIR "config.xml" -Resolve
-    VM-Apply-Configurations $configFile
+    $configPath = Join-Path $Env:VM_COMMON_DIR "config.xml" -Resolve
+    VM-Apply-Configurations $configPath
 
     # Configure PowerShell and cmd prompts
     VM-Configure-Prompts


### PR DESCRIPTION
- FLARE-VM does not use an icon for the tools folder at the moment. Do not make the installer fail if the icon file does not exist.
- be consistent with variable names: use `configPath` (and not `configFile`) for configuration file paths to be
consistent with the configuration file few lines up.
-  Use the WallpaperStyle setting `center` (0) if images' width/height is bigger or equal than 16:9 ht and `fit` (6) otherwise. Using the width/height ratio ensure that different images (including the ones used at the moment in Commando VM and FLARE-VM) are displayed nicely.
- Set the lock screen image if `%VM_COMMON_DIR%\lockscreen.png` is present.
![Screenshot 2023-10-10 at 15 25 49](https://github.com/mandiant/VM-Packages/assets/16052290/7789f7da-f40a-4ac6-86cc-0aca38a63c69)
