### PR TITLE
More improvements in installer.vm

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20230926</version>
+    <version>0.0.0.20231013</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -157,7 +157,7 @@ function VM-Check-Reboot {
     )
     try {
         if (Test-PendingReboot){
-            VM-Write-Log "ERROR" "Host must be rebooted before continuing install of $package.`n"
+            VM-Write-Log "ERROR" "Host must be rebooted before continuing installation of $package.`n"
             Invoke-Reboot
             exit 1
         }

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -157,7 +157,7 @@ function VM-Check-Reboot {
     )
     try {
         if (Test-PendingReboot){
-            VM-Write-Log "ERROR" "[Err] Host must be rebooted before continuing install of $package.`n"
+            VM-Write-Log "ERROR" "Host must be rebooted before continuing install of $package.`n"
             Invoke-Reboot
             exit 1
         }
@@ -681,7 +681,7 @@ function VM-Write-Log-Exception {
     )
     $msg = $error_record.Exception.Message
     $position_msg = $error_record.InvocationInfo.PositionMessage
-    VM-Write-Log "ERROR" "[ERR] $msg`r`n$position_msg"
+    VM-Write-Log "ERROR" "$msg`r`n$position_msg"
     throw $error_record
 }
 
@@ -919,23 +919,23 @@ function VM-Remove-Appx-Package {
                 VM-Write-Log-Exception $_
             }
         } else {
-            VM-Write-Log "WARN" "[+] Installed $appName not found on the system."
+            VM-Write-Log "WARN" "`tInstalled $appName not found on the system."
         }
         # Check if the app is provisioned
         $provisionedPackage = Get-AppxProvisionedPackage -Online | Where-Object { $_.DisplayName -eq $appName } -ErrorAction SilentlyContinue
         if ($provisionedPackage) {
             try {
                 Remove-AppxProvisionedPackage -PackageName $provisionedPackage.PackageName -Online -ErrorAction SilentlyContinue
-                VM-Write-Log "INFO" $("Provisioned package " + $provisionedPackage.PackageName + " removed")
+                VM-Write-Log "INFO" $("`tProvisioned package " + $provisionedPackage.PackageName + " removed")
             }
             catch {
                 VM-Write-Log-Exception $_
             }
         } else {
-            VM-Write-Log "WARN" "[+] Provisioned $appName not found on the system."
+            VM-Write-Log "WARN" "`tProvisioned $appName not found on the system."
         }
     } catch {
-        VM-Write-Log "ERROR" "An error occurred while removing the $appName package. Error: $_"
+        VM-Write-Log "ERROR" "`tAn error occurred while removing the $appName package. Error: $_"
     }
 }
 
@@ -952,9 +952,9 @@ function VM-Set-Service-Manual-Start {
 
         if ($service) {
             Set-Service -Name $service.Name -StartupType Manual
-            VM-Write-Log "INFO" "[+] Service $serviceName has been disabled."
+            VM-Write-Log "INFO" "Service $serviceName has been disabled."
         } else {
-            VM-Write-Log "WARN" "[+] Service $serviceName not found."
+            VM-Write-Log "WARN" "Service $serviceName not found."
         }
     } catch {
         VM-Write-Log "ERROR" "An error occurred while setting the service startup type. Error: $_"
@@ -976,9 +976,9 @@ function VM-Disable-Scheduled-Task {
     try {
         $output = Disable-ScheduledTask -TaskName $value -ErrorAction SilentlyContinue
         if ($output){
-            VM-Write-Log "INFO" "[+] Scheduled task '$name' has been disabled."
+            VM-Write-Log "INFO" "Scheduled task '$name' has been disabled."
         } else {
-            VM-Write-Log "ERROR" "[+] Scheduled task '$name' not found."
+            VM-Write-Log "ERROR" "Scheduled task '$name' not found."
         }
 
     } catch {
@@ -1024,13 +1024,13 @@ function VM-Update-Registry-Value {
         if (!(Test-Path -Path $path)) {
             # Create the registry key
             New-Item -Path $path -Force | Out-Null
-            VM-Write-Log "INFO" "`t[+] Registry key created: $path"
+            VM-Write-Log "INFO" "Registry key created: $path"
         } else {
-            VM-Write-Log "WARN" "`t[+] Registry key already exists: $path"
+            VM-Write-Log "WARN" "Registry key already exists: $path"
         }
 
         Set-ItemProperty -Path $path -Name $value -Value $validatedData -Type $type -Force | Out-Null
-        VM-Write-Log "INFO" "[+] $name has been successful"
+        VM-Write-Log "INFO" "$name has been successful"
     } catch {
         VM-Write-Log "ERROR" "Failed to update the registry value. Error: $_"
     }
@@ -1056,16 +1056,16 @@ function VM-Remove-Path {
         if ($type -eq "file") {
             if (Test-Path -Path $path -PathType Leaf) {
                 Remove-Item -Path $path -Force
-                VM-Write-Log "INFO" "[+] $name has been successfully removed."
+                VM-Write-Log "INFO" "$name has been successfully removed."
             } else {
-                VM-Write-Log "WARN" "[+] $path does not exist."
+                VM-Write-Log "WARN" "$path does not exist."
             }
         } elseif ($type -eq "dir") {
             if (Test-Path -Path $path -PathType Container) {
                 Remove-Item -Path $path -Recurse -Force
-                VM-Write-Log "INFO" "[+] $name has been successfully removed."
+                VM-Write-Log "INFO" "$name has been successfully removed."
             } else {
-                VM-Write-Log "WARN" "[+] $path does not exist."
+                VM-Write-Log "WARN" "$path does not exist."
             }
         }
     } catch {
@@ -1090,9 +1090,9 @@ function VM-Execute-Custom-Command{
         foreach ($cmd in $cmds) {
             Start-Process powershell -ArgumentList "-WindowStyle","Hidden","-Command",$cmd -Wait
         }
-        VM-Write-Log "INFO" "[+] All commands for '$name' have been executed successfully."
+        VM-Write-Log "INFO" "`tAll commands for '$name' have been executed successfully."
     } catch {
-        VM-Write-Log "ERROR" "An error occurred while executing commands for '$name'. Error: $_"
+        VM-Write-Log "ERROR" "`tAn error occurred while executing commands for '$name'. Error: $_"
     }
 }
 

--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20231016</version>
+    <version>0.0.0.20231017</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -21,12 +21,16 @@ try {
         foreach ($package in $packagesToInstall) {
             VM-Write-Log "INFO" "Installing: $package"
             choco install "$package" -y
-            VM-Write-Log "INFO" "$package has been installed"
+            if ($LASTEXITCODE) {
+              VM-Write-Log "INFO" "`t$package has been installed"
+            } else {
+              VM-Write-Log "ERROR" "`t$package has not been installed"
+            }
         }
     } catch {
         VM-Write-Log-Exception $_
     }
-    VM-Write-Log "INFO" "[+] All packages complete"
+    VM-Write-Log "INFO" "[+] Packages installation complete"
 
     # Set Profile/Version specific configurations
     VM-Write-Log "INFO" "[+] Beginning Windows OS VM profile configuration changes"

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -175,7 +175,8 @@ public class VMBackground
     $form.Text = "$Env:VMname Installation Complete"
     $form.TopMost = $true
     $form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
-    if ($iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico" -Resolve){
+    $iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico"
+    if (Test-Path $iconPath) {
         $form.Icon = New-Object System.Drawing.Icon($iconPath)
     }
     # Create a FlowLayoutPanel

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -30,10 +30,10 @@ try {
     } catch {
         VM-Write-Log-Exception $_
     }
-    VM-Write-Log "INFO" "[+] Packages installation complete"
+    VM-Write-Log "INFO" "Packages installation complete"
 
     # Set Profile/Version specific configurations
-    VM-Write-Log "INFO" "[+] Beginning Windows OS VM profile configuration changes"
+    VM-Write-Log "INFO" "Beginning Windows OS VM profile configuration changes"
     $configPath = Join-Path $Env:VM_COMMON_DIR "config.xml" -Resolve
     VM-Apply-Configurations $configPath
 

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -124,6 +124,8 @@ try {
         Write-Host "`t[-] $logPath" -ForegroundColor Yellow
         Write-Host "`t[-] %PROGRAMDATA%\chocolatey\logs\chocolatey.log" -ForegroundColor Yellow
         Write-Host "`t[-] %LOCALAPPDATA%\Boxstarter\boxstarter.log" -ForegroundColor Yellow
+        Start-Sleep 5
+        & notepad.exe $logPath
     }
 
     # Let users know installation is complete by setting lock screen & wallpaper background, playing win sound, and display message box


### PR DESCRIPTION
- Do not require an icon, I didn't realised it is used twice in https://github.com/mandiant/VM-Packages/pull/683
- Make clear if installation fails as the log message was IMO a bit confusing when a package fails to install.
- Do not use prefixes in the messages passed to `VM-Write-Log` as the output looks very weird. This was also an issue in the common.vm package. Example:
  
  **Before**
  ```
  2023/10/13 11:34:29 [installer.vm] chocolateyinstall.ps1 [+] INFO : Installing: ana.vm
  2023/10/13 11:34:32 [installer.vm] chocolateyinstall.ps1 [+] INFO : ana.vm has been installed
  2023/10/13 11:34:32 [installer.vm] chocolateyinstall.ps1 [+] INFO : [+] All packages complete
  2023/10/13 11:34:32 [installer.vm] chocolateyinstall.ps1 [+] INFO : [+] Beginning Windows OS VM profile configuration changes
  2023/10/13 11:34:32 [installer.vm] vm.common.psm1 [+] INFO : »[+] Registry key created: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\CabinetState
  2023/10/13 11:34:33 [installer.vm] vm.common.psm1 [+] INFO : [+] Show full directory path in Explorer title bar has been successful
  ```
  **After**
  ```
  2023/10/13 14:15:44 [installer.vm] chocolateyinstall.ps1 [+] INFO : Installing: ana.vm
  2023/10/13 14:15:48 [installer.vm] chocolateyinstall.ps1 [+] ERROR : »ana.vm has not been installed
  2023/10/13 14:15:48 [installer.vm] chocolateyinstall.ps1 [+] INFO : Installing: hashmyfiles.vm
  2023/10/13 14:16:04 [installer.vm] chocolateyinstall.ps1 [+] ERROR : »hashmyfiles.vm has not been installed
  2023/10/13 14:16:04 [installer.vm] chocolateyinstall.ps1 [+] INFO : Packages installation complete
  2023/10/13 14:16:04 [installer.vm] chocolateyinstall.ps1 [+] INFO : Beginning Windows OS VM profile configuration changes
  2023/10/13 14:16:04 [installer.vm] vm.common.psm1 [+] WARN : [+] Registry key already exists: HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\CabinetState
  2023/10/13 14:16:04 [installer.vm] vm.common.psm1 [+] INFO : [+] Show full directory path in Explorer title bar has been successful
  ```
- Open error log after installation is completed as it is currently done in flarevm.installer.vm
