### PR TITLE
installer.vm: fix bug by adding System.Drawing

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20231009</version>
+    <version>0.0.0.20231016</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -136,7 +136,8 @@ try {
     Set-ItemProperty 'HKCU:\Control Panel\Colors' -Name Background -Value "0 0 0" -Force | Out-Null
     $backgroundImage = "${Env:VM_COMMON_DIR}\background.png"
     if ((Test-Path $backgroundImage)) {
-        # Center: 0, Stretch: 2, Fit:6, Fill: 10, Span: 22
+        # WallpaperStyle - Center: 0, Stretch: 2, Fit:6, Fill: 10, Span: 22
+        Add-Type -AssemblyName System.Drawing
         $img = [System.Drawing.Image]::FromFile($backgroundImage);
         $wallpaperStyle = if ($img.Width/$img.Height -ge 16/9) { 0 } else { 6 }
         New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name WallpaperStyle -PropertyType String -Value $wallpaperStyle -Force | Out-Null


### PR DESCRIPTION
I forgot to add the classes from the System.Drawing .NET assembly in the following PR:
https://github.com/mandiant/VM-Packages/pull/683

This caused the installer.vm package installation to fail.

Fixes https://github.com/mandiant/VM-Packages/issues/693