### PR TITLE
installer.vm: Fix bug with background

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20231017</version>
+    <version>0.0.0.20231018</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -145,7 +145,7 @@ try {
         # WallpaperStyle - Center: 0, Stretch: 2, Fit:6, Fill: 10, Span: 22
         Add-Type -AssemblyName System.Drawing
         $img = [System.Drawing.Image]::FromFile($backgroundImage);
-        $wallpaperStyle = if ($img.Width/$img.Height -ge 16/9) { 0 } else { 6 }
+        $wallpaperStyle = if ($img.Width/$img.Height -ge 16/9) { 6 } else { 0 }
         New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name WallpaperStyle -PropertyType String -Value $wallpaperStyle -Force | Out-Null
         New-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name TileWallpaper -PropertyType String -Value 0 -Force | Out-Null
         Add-Type -TypeDefinition @"


### PR DESCRIPTION
This condition should be flipped as we want to use the `fit` style for wide images.