### PR TITLE
Add python3.vm

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20230927</version>
-    <description>Metapackage to install common Python 3.9 libraries</description>
+    <version>0.0.0.20231019</version>
+    <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="vcbuildtools.vm" />
-      <dependency id="python3" version="[3.10.0, 3.11.0)" />
+      <dependency id="python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -16,12 +16,12 @@ try {
     $modules = $modulesXml.modules.module
     foreach ($module in $modules) {
         Write-Host "[+] Attempting to install Python3 module: $($module.name)"
-        $intallValue = $module.name
+        $installValue = $module.name
         if ($module.url) {
-            $intallValue = $module.url
+            $installValue = $module.url
         }
 
-        Invoke-Expression "py -3.10 -m pip install $intallValue 2>&1 >> $outputFile"
+        Invoke-Expression "py -3.10 -m pip install $installValue 2>&1 >> $outputFile"
 
         if ($LastExitCode -eq 0) {
             Write-Host "`t[+] Installed Python 3.10 module: $($module.name)" -ForegroundColor Green

--- a/packages/python3.vm/python3.vm.nuspec
+++ b/packages/python3.vm/python3.vm.nuspec
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>didier-stevens-suite.vm</id>
+    <id>python3.vm</id>
     <version>0.0.0.20231019</version>
-    <authors>Didier Stevens</authors>
-    <description>Tools collection by Didier Stevens</description>
+    <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
+    <authors>Mandiant</authors>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="python3.vm" />
+      <dependency id="python3" version="[3.10.0, 3.11.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/python3.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  # Re-add shim path to the top of the path to ensure it is found before Python libraries
+  $shimPath = Join-Path $Env:ChocolateyInstall "bin" -Resolve
+  [Environment]::SetEnvironmentVariable("Path", "$shimPath;$Env:Path", "Machine")
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -318,6 +318,7 @@ class UsesInvalidCategory(Lint):
         "notepadplusplus.vm",
         "notepadpp.plugin.",
         "npcap.vm",
+        "python3.vm",
         "x64dbgpy.vm",
     ]
 

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -39,7 +39,7 @@ foreach ($package in $packages) {
 }
 
 
-$exclude_tests = @("flarevm.installer.vm", "python3.vm", "installer.vm")
+$exclude_tests = @("flarevm.installer.vm", "installer.vm")
 
 $failures = New-Object Collections.Generic.List[string]
 $failed = 0


### PR DESCRIPTION
Add python3.vm, a metapackage that install python3 and re-adds chocolate shim path to the top of the path. This package is to be requested by all packages needing python3 to ensure they all install the same version and that the paths is being updated.

Closes https://github.com/mandiant/VM-Packages/issues/686
Partially addresses https://github.com/mandiant/VM-Packages/issues/686