### PR TITLE
Add nodejs.vm

### DIFF
--- a/packages/nodejs.vm/nodejs.vm.nuspec
+++ b/packages/nodejs.vm/nodejs.vm.nuspec
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>malware-jail.vm</id>
+    <id>nodejs.vm</id>
     <version>0.0.0.20231020</version>
-    <authors>Hynek Petrak</authors>
-    <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
+    <authors>Node.js Foundation</authors>
+    <description>Metapackage for Node.js to ensure all packages use the same Node.js version.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="nodejs.vm" />
+      <dependency id="nodejs" version="[20.7.0, 20.8.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pkg-unpacker.vm</id>
-    <version>1.0.0.20231019</version>
+    <version>1.0.0.20231020</version>
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="nodejs" version="[21.0.0]" />
+      <dependency id="nodejs.vm" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Add nodejs.vm, a metapackage that install that installs Node.js. This package is to be requested by all packages needing nodejs to ensure they all install the same version.

Partially addresses https://github.com/mandiant/VM-Packages/issues/673