### PR TITLE
vcbuildtools.vm: Stop updating dependency

### DIFF
--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20231019</version>
+    <version>0.0.0.20231020</version>
     <description>Metapackage that requires the dependencies below:
 - visualstudio2017buildtools
 - visualstudio2017-workload-vctools
@@ -10,7 +10,7 @@
     <authors>Mandiant, Microsoft</authors>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="visualstudio2017buildtools" version="[15.9.58]" />
+      <dependency id="visualstudio2017buildtools" version="[15.9.58, 15.9.59)" />
       <dependency id="visualstudio2017-workload-vctools" version="[1.3.3]" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Stop updating visualstudio2017buildtools automatically. This dependency gets updated often and it is tricky to test the update. Use date range to avoid the bot tries to update it.