### PR TITLE
Add openjdk.vm

### DIFF
--- a/packages/bytecodeviewer.vm/bytecodeviewer.vm.nuspec
+++ b/packages/bytecodeviewer.vm/bytecodeviewer.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bytecodeviewer.vm</id>
-    <version>2.11.2.20231024</version>
+    <version>2.11.2.20231025</version>
     <authors>Konloch</authors>
     <description>A lightweight user-friendly Java/Android Bytecode Viewer, Decompiler and more.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="javaruntime" version="[8.0.231]" />
+      <dependency id="openjdk.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dex2jar.vm/dex2jar.vm.nuspec
+++ b/packages/dex2jar.vm/dex2jar.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dex2jar.vm</id>
-    <version>2.3.0.20231024</version>
+    <version>2.3.0.20231025</version>
     <authors>@pxb1988</authors>
     <description>Tools to work with android .dex and java .class files.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="openjdk" version="[21.0.0]" />
+      <dependency id="openjdk.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ghidra.vm/ghidra.vm.nuspec
+++ b/packages/ghidra.vm/ghidra.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ghidra.vm</id>
-    <version>10.3.3.20230920</version>
+    <version>10.3.3.20231025</version>
     <authors>National Security Agency</authors>
     <description>A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.</description>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="ghidra" version="[10.3.3]" />
-      <dependency id="openjdk" version="[21.0.0]" />
+      <dependency id="openjdk.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/openjdk.vm/openjdk.vm.nuspec
+++ b/packages/openjdk.vm/openjdk.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>openjdk.vm</id>
+    <version>21.0.1</version>
+    <authors>Oracle</authors>
+    <description>Metapackage for OpenJDK to ensure all packages use the same OpenJDK version.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="openjdk" version="[21.0.1]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/openjdk.vm/tools/chocolateyinstall.ps1
+++ b/packages/openjdk.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  # Execute .jar files with javaw.exe by default
+  $javaw_path = "$Env:ProgramFiles\OpenJDK\jdk-21.0.1\bin\javaw.exe"
+  VM-Assert-Path $javaw_path
+  cmd /c assoc .jar=jarfile
+  cmd /c ftype jarfile=`"$javaw_path`" -jar `"%1`" %*
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -318,6 +318,7 @@ class UsesInvalidCategory(Lint):
         "notepadplusplus.vm",
         "notepadpp.plugin.",
         "npcap.vm",
+        "openjdk.vm",
         "python3.vm",
         "x64dbgpy.vm",
     ]


### PR DESCRIPTION
Metapackage for OpenJDK to ensure all packages use the same OpenJDK version. The package also ensure that .jar files are executed with javaw.exe by default. Note that we are getting rid of javaruntime, which has a restrictive license (related: https://github.com/mandiant/VM-Packages/issues/722).

Partially addresses https://github.com/mandiant/VM-Packages/issues/673