### PR TITLE
category: Rename 'Android/Java' to fix bug

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_metapackage.yml
+++ b/.github/ISSUE_TEMPLATE/new_metapackage.yml
@@ -64,7 +64,7 @@ body:
         - Hex Editors
         - Information Gathering
         - InnoSetup
-        - Java/Android
+        - Java & Android
         - Javascript
         - Lateral Movement
         - Networking

--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -83,7 +83,7 @@ body:
         - Hex Editors
         - Information Gathering
         - InnoSetup
-        - Java/Android
+        - Java & Android
         - Javascript
         - Lateral Movement
         - Networking

--- a/categories.txt
+++ b/categories.txt
@@ -12,7 +12,7 @@ Forensic
 Hex Editors
 Information Gathering
 InnoSetup
-Java/Android
+Java & Android
 Javascript
 Lateral Movement
 Networking

--- a/packages/apktool.vm/apktool.vm.nuspec
+++ b/packages/apktool.vm/apktool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>apktool.vm</id>
-    <version>2.9.0</version>
+    <version>2.9.0.20231024</version>
     <authors>Connor Tumbleson, Ryszard Wisniewski</authors>
     <description>A tool for reverse engineering 3rd party, closed, binary Android apps.</description>
     <dependencies>

--- a/packages/apktool.vm/tools/chocolateyinstall.ps1
+++ b/packages/apktool.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'apktool'
-  $category = 'Java/Android'
+  $category = 'Java & Android'
   $shimPath = 'bin\apktool.exe'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/apktool.vm/tools/chocolateyuninstall.ps1
+++ b/packages/apktool.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'apktool'
-$category = 'Java/Android'
+$category = 'Java & Android'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/bytecodeviewer.vm/bytecodeviewer.vm.nuspec
+++ b/packages/bytecodeviewer.vm/bytecodeviewer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bytecodeviewer.vm</id>
-    <version>2.11.2.20231006</version>
+    <version>2.11.2.20231024</version>
     <authors>Konloch</authors>
     <description>A lightweight user-friendly Java/Android Bytecode Viewer, Decompiler and more.</description>
     <dependencies>

--- a/packages/bytecodeviewer.vm/tools/chocolateyinstall.ps1
+++ b/packages/bytecodeviewer.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Bytecode Viewer'
-$category = 'Java/Android'
+$category = 'Java & Android'
 
 $exeUrl = 'https://github.com/Konloch/bytecode-viewer/releases/download/v2.11.2/Bytecode-Viewer-2.11.2.jar'
 $exeSha256 = '536ad387424106083f76cd0cb7c051a22aff21f08663ba2539c11f1ddef9147f'

--- a/packages/bytecodeviewer.vm/tools/chocolateyuninstall.ps1
+++ b/packages/bytecodeviewer.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Bytecode Viewer'
-$category = 'Java/Android'
+$category = 'Java & Android'
 
 VM-Uninstall $toolName $category

--- a/packages/dex2jar.vm/dex2jar.vm.nuspec
+++ b/packages/dex2jar.vm/dex2jar.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dex2jar.vm</id>
-    <version>2.3.0.20231006</version>
+    <version>2.3.0.20231024</version>
     <authors>@pxb1988</authors>
     <description>Tools to work with android .dex and java .class files.</description>
     <dependencies>

--- a/packages/dex2jar.vm/tools/chocolateyinstall.ps1
+++ b/packages/dex2jar.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'd2j-dex2jar'
-$category = 'Java/Android'
+$category = 'Java & Android'
 
 $zipUrl = 'https://github.com/pxb1988/dex2jar/releases/download/v2.3/dex2jar-v2.zip'
 $zipSha256 = 'd0507b6277193476ae29351905b5fa9b20d1a9a5ce119b46d87e5b188edf859e'

--- a/packages/dex2jar.vm/tools/chocolateyuninstall.ps1
+++ b/packages/dex2jar.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'd2j-dex2jar'
-$category = 'Java/Android'
+$category = 'Java & Android'
 
 VM-Uninstall $toolName $category


### PR DESCRIPTION
The `Java/Android` category is creating a subfolder `Android` inside of the `Java` category and this is not the desired result. Rename to `Java & Android` to fix the issue.