### PR TITLE
pkg-unpacker.vm: Prevent npm warn to fail package

### DIFF
--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pkg-unpacker.vm</id>
-    <version>1.0.0.20231020</version>
+    <version>1.0.0.20231027</version>
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>

--- a/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
+++ b/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
@@ -9,11 +9,13 @@ try {
     $powershellCommand = "Write-Output '> node unpack.js'; node unpack.js"
 
     $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
-
-    # Get absolute path as npm is not in path until Powershell is restarted
-    $npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
-    # Install tool dependencies with npm
-    Set-Location $toolDir; & "$npmPath" install | Out-Null
 } catch {
   VM-Write-Log-Exception $_
 }
+
+# Prevent npm warn/notice to fail the package
+$ErrorActionPreference = 'Continue'
+# Get absolute path as npm is not in path until Powershell is restarted
+$npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
+# Install tool dependencies with npm
+Set-Location $toolDir; & "$npmPath" install | Out-Null


### PR DESCRIPTION
Prevent npm warn/notice to fail the package, similarly as we do in malware-jail. Our CI is not detecting this bug, but the package fails to install locally for me.