### PR TITLE
Improve zip download code

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231020</version>
+    <version>0.0.0.20231027</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -329,17 +329,10 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [string] $executableName, # Executable name, needed if different from "$toolName.exe"
         [Parameter(Mandatory=$false)]
-        [switch] $withoutBinFile, # Tool should not be installed as a bin file
-        [Parameter(Mandatory=$false)]
-        [string] $unzipLocation
+        [switch] $withoutBinFile # Tool should not be installed as a bin file
     )
     try {
-        if ($unzipLocation) {
-            $toolDir = Join-Path $unzipLocation $toolName
-        } else {
-            $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
-            $unzipLocation = $toolDir
-        }
+        $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
         # Remove files from previous zips for upgrade
         VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
@@ -353,7 +346,7 @@ function VM-Install-From-Zip {
         # Download and unzip
         $packageArgs = @{
             packageName    = ${Env:ChocolateyPackageName}
-            unzipLocation  = $unzipLocation
+            unzipLocation  = $toolDir
             url            = $zipUrl
             checksum       = $zipSha256
             checksumType   = 'sha256'


### PR DESCRIPTION
- simplify code that handles upgrades: By unzipping directly in the tools directory, chocolatey takes care of
maintaining the files to delete on an update. 
- We introduced unziplocation as a parameter for VM-Install-From-Zip in https://github.com/mandiant/VM-Packages/pull/597 as we were planing to use it for psnotify.vm, but we realized that it is better not to use the helper for this package. So this argument is unused. Remove it to make it easier to maintain the function.

If we merge this PR, the code of this two functions is very similar, which is not surprising as a GitHub-Raw install is the same as installing a Zip. Any thoughts about merging this two functions?

Closes https://github.com/mandiant/VM-Packages/issues/672