### PR TITLE
installer.vm: Add custom layout for taskbar pinning.

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20231020</version>
+    <version>0.0.0.20231121</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>


### PR DESCRIPTION
This is a first stab at resolving https://github.com/mandiant/flare-vm/issues/512. This works in tandem with https://github.com/mandiant/flare-vm/pull/531

It adds the creation of an `Admin Command Prompt` shortcut into the `Tools/Utilities` directory so that we are able pin that, and also sets a custom Start Layout template which pins the items from the list to the taskbar.

The main current shortfalls are:
- File Explorer does not point to Tools directory
  - This requires access to a known shortcut location. It may be possible to use `Get-ChildItem -Path ${Env:TOOL_LIST_DIR}`. Further testing is needed.
- IDA shortcut currently points to IDA Free and not automatically set for any IDA Pro installation


One notable thing to mention: If an executable does not exist when the custom template is set, it **_does not_** create a broken shortcut in its place. It simply leaves it out.
- This is useful if we want to add an `IDA Pro` shortcut in our default template, because it will not create any issues if `IDA Pro` does not exist when the template is set, but it will pin it when it is installed and either a restart or logout/login occurs (or just a restart of `explorer.exe`)

Closes https://github.com/mandiant/flare-vm/issues/512