### PR TITLE
Improve files deleted in VM-Remove-DesktopFiles/VM-Clean-Up

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231116</version>
+    <version>0.0.0.20231123</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1247,7 +1247,7 @@ public class Shell {
 
 
 # Usage example:
-# VM-Remove-DesktopFiles -excludeFolders "PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs" -excludeFiles "example.txt", "important.doc"
+# VM-Remove-DesktopFiles -excludeFolders ${Env:TOOL_LIST_DIR}, "fakenet_logs" -excludeFiles "example.txt", "important.doc"
 # The function is run against both the Current User and 'Public' desktops due to some cases where desktop icons showing on
 # Current user Desktop that are only located in Public/Desktop.
 function VM-Remove-DesktopFiles {
@@ -1257,8 +1257,8 @@ function VM-Remove-DesktopFiles {
         [Parameter(Mandatory=$false)]
         [string[]]$excludeFiles
     )
-    # Ensure that the "PS_Transcripts" and "fakenet_logs" folders, as well as the Tools Folder (if located on the desktop) are not to be deleted.
-    $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs")
+    # Ensure that the "fakenet_logs" folders, as well as the Tools Folder (if located on the desktop) are not to be deleted.
+    $defaultExcludedFolders = @(${Env:TOOL_LIST_DIR}, "fakenet_logs")
     $defaultExcludedFiles = @("MICROSOFT Windows 10 License Terms.txt")
     $excludeFolders = $excludeFolders + $defaultExcludedFolders
     $excludeFiles = $excludeFiles  + $defaultExcludedFiles

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1267,7 +1267,8 @@ function VM-Remove-DesktopFiles {
         [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::CommonDesktopDirectory) # Public desktop
     )
     foreach ($userDesktopPath in $userAccounts) {
-        Get-ChildItem -Path $userDesktopPath | ForEach-Object {
+        # Use -Force to get hidden files (such as desktop.ini)
+        Get-ChildItem -Path $userDesktopPath -Force | ForEach-Object {
             $item = $_
             try{
                 if ($item.PSIsContainer -and ($item.Name -notin $excludeFolders -and $item.FullName -notin $excludeFolders)) {


### PR DESCRIPTION
Improve files deleted in `VM-Remove-DesktopFiles` (called from `VM-Clean-Up`):
- Use `-Force` in `Get-ChildItem` to delete hidden files (such as `desktop.ini`) in `VM-Remove-DesktopFiles`. 
- We originally decided to prevent that `PS_Transcripts` is deleted in https://github.com/mandiant/VM-Packages/pull/747. But after installing FLARE-VM I would like to delete the files generated by the installation in the `PS_Transcripts` directory. Remove the protection, allowing to delete this folder. It is still possible to keep it using the `excludedFolders` function argument.

@mandiant/commando-vm do you know if there is a reason not to delete `desktop.ini` files? I think they have appeared in FLARE-VM since we introduce the debloat and new installer (probably because we now show hidden files).