### PR TITLE
Ensure VM-Remove-DesktopFiles deletes as many files as possible

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231123</version>
+    <version>0.0.0.20231124</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1247,7 +1247,7 @@ public class Shell {
 
 
 # Usage example:
-# VM-Remove-DesktopFiles -excludeFolders ${Env:TOOL_LIST_DIR}, "fakenet_logs" -excludeFiles "example.txt", "important.doc"
+# VM-Remove-DesktopFiles -excludeFolders "PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs" -excludeFiles "example.txt", "important.doc"
 # The function is run against both the Current User and 'Public' desktops due to some cases where desktop icons showing on
 # Current user Desktop that are only located in Public/Desktop.
 function VM-Remove-DesktopFiles {
@@ -1257,8 +1257,8 @@ function VM-Remove-DesktopFiles {
         [Parameter(Mandatory=$false)]
         [string[]]$excludeFiles
     )
-    # Ensure that the "fakenet_logs" folders, as well as the Tools Folder (if located on the desktop) are not to be deleted.
-    $defaultExcludedFolders = @(${Env:TOOL_LIST_DIR}, "fakenet_logs")
+    # Ensure that the "PS_Transcripts" and "fakenet_logs" folders, as well as the Tools Folder (if located on the desktop) are not to be deleted.
+    $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs")
     $defaultExcludedFiles = @("MICROSOFT Windows 10 License Terms.txt")
     $excludeFolders = $excludeFolders + $defaultExcludedFolders
     $excludeFiles = $excludeFiles  + $defaultExcludedFiles

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1273,11 +1273,11 @@ function VM-Remove-DesktopFiles {
             try{
                 if ($item.PSIsContainer -and ($item.Name -notin $excludeFolders -and $item.FullName -notin $excludeFolders)) {
                     VM-Write-Log "INFO" "Deleting folder: $($item.FullName)"
-                    Remove-Item -Path $item.FullName -Recurse -Force
+                    Remove-Item -Path $item.FullName -Recurse -Force -ErrorAction Continue
                 }
                 elseif ($item.PSIsContainer -eq $false -and ($item.Name -notin $excludeFiles -and $item.FullName -notin $excludeFiles)) {
                     VM-Write-Log "INFO" "Deleting file: $($item.FullName)"
-                    Remove-Item -Path $item.FullName -Force
+                    Remove-Item -Path $item.FullName -Force -ErrorAction Continue
                 }
             } catch {
                 VM-Write-Log-Exception $_


### PR DESCRIPTION
I tried to add the deleting of `PS_Transcripts` in https://github.com/mandiant/VM-Packages/commit/4ce49588c7d25c8edf9b24dc51d44d5e8f7a0b49. But we can't delete PS_Transcripts while Powershell is open and `VM-Remove-DesktopFiles`/`VM-Clean-Up` are PowerShell functions. I have open https://github.com/mandiant/VM-Packages/issues/755 to discuss if there is another way to achieve this.

This has reveled another important issue: We set `$ErrorActionPreference = 'Stop'` at the beginning of the file,
causing that a problem removing an item automatically stops without deleting other files in `VM-Remove-DesktopFiles` (called from`VM-Clean-Up`). We want to ensure the `catch` in this function is used deleting as many files as possible. Fix this here using `-ErrorAction Continue`. I also think this may be a more general issue we should discuss in https://github.com/mandiant/VM-Packages/issues/753