### PR TITLE
Update idafree to use ida_launcher

### DIFF
--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>8.3</version>
+    <version>8.3.0.20231129</version>
     <authors>hex-rays</authors>
     <description>Free version of IDA, a powerful Interactive DisAssembler and debugger</description>
     <dependencies>

--- a/packages/idafree.vm/tools/chocolateyuninstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyuninstall.ps1
@@ -2,16 +2,9 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'idafree'
-$category = 'Disassemblers'
-
-# Remove tool shortcut
-VM-Remove-Tool-Shortcut $toolName $category
 
 # Remove binary from PATH
 Uninstall-BinFile -Name $toolName
 
 # Manually silently uninstall
 VM-Uninstall-With-Uninstaller "IDA Freeware*?8.3" "EXE" "--mode unattended"
-
-VM-Remove-From-Right-Click-Menu $toolName
-VM-Remove-From-Right-Click-Menu $toolName-64

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -321,6 +321,7 @@ class UsesInvalidCategory(Lint):
         "openjdk.vm",
         "python3.vm",
         "x64dbgpy.vm",
+        "idafree.vm",
     ]
 
     root_path = os.path.abspath(os.path.join(__file__, "../../.."))


### PR DESCRIPTION
Split PR from https://github.com/mandiant/VM-Packages/pull/758 so that this PR only includes updates for modifying idafree.vm to add and utilize `ida_launcher.exe` as suggested.