### PR TITLE
Refactor 010editor

### DIFF
--- a/packages/010editor.vm/010editor.vm.nuspec
+++ b/packages/010editor.vm/010editor.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>010editor.vm</id>
-    <version>14.0</version>
+    <version>14.0.0.20231204</version>
     <description>Professional text and hex editor with Binary Templates technology.</description>
     <authors>SweetScape</authors>
     <dependencies>

--- a/packages/010editor.vm/tools/chocolateyinstall.ps1
+++ b/packages/010editor.vm/tools/chocolateyinstall.ps1
@@ -18,7 +18,7 @@ try {
     checksumType  = 'sha256'
     checksum      = $checksum
     checksum64    = $checksum64
-    silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NOICONS'
+    silentArgs    = '/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /NOICONS /MERGETASKS="!desktopicon"'
   }
   Install-ChocolateyPackage @packageArgs
 
@@ -32,12 +32,6 @@ try {
   VM-Assert-Path $shortcut
 
   Install-BinFile -Name $toolName -Path $executablePath
-
-  # Delete Desktop shortcut
-  $shortcut_desktop = Join-Path ${Env:UserProfile} "Desktop\010 Editor.lnk"
-  if (Test-Path $shortcut_desktop) {
-    Remove-Item $shortcut_desktop -Force -ea 0 | Out-Null
-  }
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
Concerning EXE installer it's possible to use `/MERGETASKS="!desktopicon"` to avoid creating shortcut on Desktop.

In addition, I was wondering why did you set you own package instead of employing [010editor](https://community.chocolatey.org/packages/010editor) with METAPACKAGE ?

> You may consider to add `https://jrsoftware.org/ishelp/topic_setupcmdline.htm` to documentation it's very useful to create package with EXE installer.