### PR TITLE
Add Arsenal Image Mounter

### DIFF
--- a/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
+++ b/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>arsenalimagemounter.vm</id>
+    <version>3.10.262</version>
+    <authors>Arsenal Recon</authors>
+    <description>Mounts the contents of disk images as complete disks in Windows.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="dotnet-6.0-desktopruntime" version="[6.0.25]" />
+      <dependency id="arsenalimagemounter" version="[3.10.262]" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
+++ b/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'ArsenalImageMounter'
+  $category = 'Utilities'
+  $shimPath = "\bin\${toolName}.exe"
+
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
+  $executablePath = Join-Path ${Env:ChocolateyInstall} $shimPath -Resolve
+  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin
+  VM-Assert-Path $shortcut
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/arsenalimagemounter.vm/tools/chocolateyuninstall.ps1
+++ b/packages/arsenalimagemounter.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'ArsenalImageMounter'
+$category = 'Utilities'
+
+VM-Remove-Tool-Shortcut $toolName $category


### PR DESCRIPTION
Add of Arsenal Image Mounter, a tool mount disk images on Windows.

N.B. : It was the last one in my TODO