### PR TITLE
Fix fakenet logs

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231201</version>
+    <version>0.0.0.20231218</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1247,7 +1247,7 @@ public class Shell {
 
 
 # Usage example:
-# VM-Remove-DesktopFiles -excludeFolders "PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs" -excludeFiles "example.txt", "important.doc"
+# VM-Remove-DesktopFiles -excludeFolders "Labs", "Demos" -excludeFiles "MICROSOFT Windows 10 License Terms.txt", "Labs.zip"
 # The function is run against both the Current User and 'Public' desktops due to some cases where desktop icons showing on
 # Current user Desktop that are only located in Public/Desktop.
 function VM-Remove-DesktopFiles {
@@ -1259,8 +1259,8 @@ function VM-Remove-DesktopFiles {
     )
     # Ensure that the "PS_Transcripts" folder and the Tools folder (if located on the desktop) are not deleted.
     $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR})
-    # Ensure that the "fakenet_logs" shortcut and the "MICROSOFT Windows 10 License Terms.txt" file are not deleted.
-    $defaultExcludedFiles = @("fakenet_logs.lnk", "MICROSOFT Windows 10 License Terms.txt")
+    # Ensure that the "fakenet_logs" shortcut is not deleted.
+    $defaultExcludedFiles = @("fakenet_logs.lnk")
     $excludeFolders = $excludeFolders + $defaultExcludedFolders
     $excludeFiles = $excludeFiles  + $defaultExcludedFiles
     $userAccounts = @(

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1257,9 +1257,10 @@ function VM-Remove-DesktopFiles {
         [Parameter(Mandatory=$false)]
         [string[]]$excludeFiles
     )
-    # Ensure that the "PS_Transcripts" and "fakenet_logs" folders, as well as the Tools Folder (if located on the desktop) are not to be deleted.
-    $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR}, "fakenet_logs")
-    $defaultExcludedFiles = @("MICROSOFT Windows 10 License Terms.txt")
+    # Ensure that the "PS_Transcripts" folder and the Tools folder (if located on the desktop) are not deleted.
+    $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR})
+    # Ensure that the "fakenet_logs" shortcut and the "MICROSOFT Windows 10 License Terms.txt" file are not deleted.
+    $defaultExcludedFiles = @("fakenet_logs.lnk", "MICROSOFT Windows 10 License Terms.txt")
     $excludeFolders = $excludeFolders + $defaultExcludedFolders
     $excludeFiles = $excludeFiles  + $defaultExcludedFiles
     $userAccounts = @(


### PR DESCRIPTION
`VM-Remove-DesktopFiles` deletes `fakenet_logs` because it is a shortcut and we are excluding folders with that name. Exclude it as a file instead.

Do not exclude the `MICROSOFT Windows 10 License Terms.txt` file by default for more flexibility. We originally decided to add this file as having at least one file by default simplified the implementation and made the linter happy. Now that we have added `fakenet_logs.lnk`, this file can be removed.

Improve the documentation of `VM-Remove-DesktopFiles` to add real examples we are using.

Fixes https://github.com/mandiant/VM-Packages/issues/794