### PR TITLE
Add metapackage for vcredist140 dependency

### DIFF
--- a/packages/nmap.vm/nmap.vm.nuspec
+++ b/packages/nmap.vm/nmap.vm.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nmap.vm</id>
-    <version>7.93.20230418.20230614</version>
+    <version>7.93.20230418.20231218</version>
     <authors>Fyodor, Nmap Project</authors>
     <description>Port scanning utility and nc replacement with extended features</description>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="npcap.vm" />
       <dependency id="autohotkey" version="[1.1.36.2]" />
-      <dependency id="vcredist140" version="[14.36.32532]" />
+      <dependency id="vcredist140.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/rpcview.vm/rpcview.vm.nuspec
+++ b/packages/rpcview.vm/rpcview.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rpcview.vm</id>
-    <version>0.3.1.20231115</version>
+    <version>0.3.1.20231218</version>
     <authors>silverf0x</authors>
     <description>RpcView is an open-source tool to explore and decompile all RPC functionalities present on a Microsoft system</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="vcredist140" version="[14.38.33130]" />
+      <dependency id="vcredist140.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/vcredist140.vm/vcredist140.vm.nuspec
+++ b/packages/vcredist140.vm/vcredist140.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>vcredist140.vm</id>
+    <version>0.0.0.20231019</version>
+    <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
+    <authors>Mandiant</authors>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="vcredist140" version="[14.36.32532, 14.37)" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Add metapackage vcredist140.vm for vcredist140, a common dependency. This ensure only one version of vcredist140 is installed and that all tools use the same version.

Closes https://github.com/mandiant/VM-Packages/issues/673