### PR TITLE
Improve 7zip-15-05.vm

### DIFF
--- a/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
+++ b/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>7zip-15-05.vm</id>
-    <version>15.05.0.20230926</version>
+    <version>15.05.0.20231220</version>
     <authors>Igor Pavlov</authors>
     <description>7-Zip file archiver. This version is able to extract NSIS scripts.</description>
     <dependencies>

--- a/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
@@ -2,9 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $toolName = '7zip'
-  $category = 'Utilities'
-
+  $toolName = '7z'
   $url = 'https://sourceforge.net/projects/sevenzip/files/7-Zip/15.05/7z1505.exe/download'
   $checksum = 'fa99d29283d9a6c501b70d2755cd06cf5bc3dd8e48acc73926b6e0f389885120'
   $url64 = 'https://sourceforge.net/projects/sevenzip/files/7-Zip/15.05/7z1505-x64.exe/download'
@@ -23,15 +21,7 @@ try {
   Install-ChocolateyPackage @packageArgs
 
   $toolDir = Join-Path ${Env:ProgramFiles} '7-Zip' -Resolve
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-
-  $executablePath = Join-Path $toolDir "7zFM.exe" -Resolve
-  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-
-  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-  VM-Assert-Path $shortcut
-
-  $7zExecutablePath = Join-Path $toolDir "7z.exe" -Resolve
+  $7zExecutablePath = Join-Path $toolDir "$toolName.exe" -Resolve
   Install-BinFile -Name $toolName -Path $7zExecutablePath
 
   # Add 7z unzip with password "infected" to the right menu for the most common extensions.

--- a/packages/7zip-15-05.vm/tools/chocolateyuninstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyuninstall.ps1
@@ -1,11 +1,7 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = '7zip'
-$category = 'Utilities'
-
-# Remove tool shortcut
-VM-Remove-Tool-Shortcut $toolName $category
+$toolName = '7z'
 
 # Remove binary from PATH
 Uninstall-BinFile -Name $toolName

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -308,10 +308,12 @@ class UsesInvalidCategory(Lint):
     EXCLUSIONS = [
         ".ollydumpex.vm",
         ".scyllahide.vm",
+        "7zip-15-05.vm",
         "common.vm",
         "debloat.vm",
         "flarevm.installer.vm",
         "ida.plugin.capa.vm",
+        "idafree.vm",
         "installer.vm",
         "libraries.python2.vm",
         "libraries.python3.vm",
@@ -321,7 +323,6 @@ class UsesInvalidCategory(Lint):
         "openjdk.vm",
         "python3.vm",
         "x64dbgpy.vm",
-        "idafree.vm",
     ]
 
     root_path = os.path.abspath(os.path.join(__file__, "../../.."))


### PR DESCRIPTION
At the moment `7zip` is on path, change it by `7z`.


@vm-packages do we agree on removing 7zip from the Utilities folder? I tend to think we don't need a shortcut for this tool as it is not really an analysis tool and it is already added to the right menu. But it can be used for things like extracting NSIS scripts. So it can be considered an analysis tool as well.

Closes https://github.com/mandiant/VM-Packages/issues/756