### PR TITLE
Use VM-Add-To-Path function

### DIFF
--- a/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
+++ b/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-suite.vm</id>
-    <version>0.0.0.20231213</version>
+    <version>0.0.0.20231221</version>
     <authors>Didier Stevens</authors>
     <description>Tools collection by Didier Stevens</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20231221" />
       <dependency id="python3.vm" />
     </dependencies>
   </metadata>

--- a/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
+++ b/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
@@ -24,8 +24,7 @@ try {
     }
 
     # Add tools to Path
-    $path = [Environment]::GetEnvironmentVariable("Path", "Machine") + [IO.Path]::PathSeparator + $toolDir
-    [Environment]::SetEnvironmentVariable("Path", $path, "Machine")
+    VM-Add-To-Path $toolDir
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
This PR updates the package to use the new function `VM-Add-To-Path` which adds a path to the Machine Environment Variable Path and was added in `common.vm` https://github.com/mandiant/VM-Packages/pull/806 (which will need to be merged before checks in this PR will be successful).