### PR TITLE
Add dotnet-6 metapackage

### DIFF
--- a/packages/dotnet-6.vm/dotnet-6.vm.nuspec
+++ b/packages/dotnet-6.vm/dotnet-6.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>dotnet-6.vm</id>
+    <version>0.0.0.20231224</version>
+    <authors>Microsoft</authors>
+    <description>Metapackage for .NET6 to ensure all packages use the same version.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="dotnet-6.0-desktopruntime" version="(6.0.14, 6.0.26]" />
+      <dependency id="dotnet-6.0-runtime" version="(6.0.14, 6.0.26]" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
I have created this metapackage to address #778 request.
I tried to add the `dotnet-6.0-sdk` for sfextract. However, when I install this package it doesn't really install the SDK on my system I had to use `dotnet-6.0-sdk-4xx`. Even, with this package in place when trying to install sfextract I have the following error message :
```text
C:\Users\User\AppData\Local\ChocoCache\6eac32f8-677f-4cec-9471-67015f93f927\restore.csproj : error NU1100: Unable to resolve 'sfextract (>= 2.1.0)' for 'net6.0'.
C:\Users\User\AppData\Local\ChocoCache\6eac32f8-677f-4cec-9471-67015f93f927\restore.csproj : error NU1100: Unable to resolve 'sfextract (>= 2.1.0)' for 'net6.0/any'.
```