### PR TITLE
Improve VM-Clean-Up

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20231221</version>
+    <version>0.0.0.20240104</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1245,6 +1245,19 @@ public class Shell {
     }
 }
 
+# Remove a directory and if not possible as many of its subfolder and files as possible
+function VM-Remove-Dir {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string[]]$item
+    )
+    Remove-Item -Path $item -Recurse -Force -ErrorAction Continue
+    if (!$? -and $item.PSIsContainer) {
+        Get-ChildItem -Path $item -Force | ForEach-Object {
+            VM-Remove-Dir $item
+        }
+    }
+}
 
 # Usage example:
 # VM-Remove-DesktopFiles -excludeFolders "Labs", "Demos" -excludeFiles "MICROSOFT Windows 10 License Terms.txt", "Labs.zip"
@@ -1286,6 +1299,9 @@ function VM-Remove-DesktopFiles {
             }
         }
     }
+
+    # Remove as much of PS_Transcripts as possible
+    VM-Remove-Dir "PS_Transcripts"
 }
 
 function VM-Clear-TempAndCache {

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1338,6 +1338,9 @@ function VM-Clean-Up {
 
     Write-Host "[+] Clearing up free space. This may take a few minutes..." -ForegroundColor Green
     VM-Clear-FreeSpace
+
+    Write-Host "[+] Clear PowerShell History" -ForegroundColor Green
+    Remove-Item (Get-PSReadlineOption).HistorySavePath -Force -ea 0
 }
 
 function VM-Add-To-Path {

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1257,8 +1257,9 @@ function VM-Remove-DesktopFiles {
         [Parameter(Mandatory=$false)]
         [string[]]$excludeFiles
     )
-    # Ensure that the "PS_Transcripts" folder and the Tools folder (if located on the desktop) are not deleted.
-    $defaultExcludedFolders = @("PS_Transcripts", ${Env:TOOL_LIST_DIR})
+    # Ensure that the "Recycle Bin" folder, the "PS_Transcripts" folder,
+    # and the Tools folder (if located on the desktop) are not deleted.
+    $defaultExcludedFolders = @("Recycle Bin", "PS_Transcripts", ${Env:TOOL_LIST_DIR})
     # Ensure that the "fakenet_logs" shortcut is not deleted.
     $defaultExcludedFiles = @("fakenet_logs.lnk")
     $excludeFolders = $excludeFolders + $defaultExcludedFolders
@@ -1327,6 +1328,9 @@ function VM-Clean-Up {
 
     Write-Host "[+] Clearing Temp and Cache..." -ForegroundColor Green
     VM-Clear-TempAndCache
+
+    Write-Host "[+] Clearing Recycle Bin" -ForegroundColor Green
+    Clear-RecycleBin -Force
 
     Write-Host "[+] Running Disk Cleanup..." -ForegroundColor Green
     VM-Write-Log "INFO" "Performing Disk Cleanup."


### PR DESCRIPTION
- Exclude `Recycle Bin` in `VM-Remove-DesktopFiles` as it keeps the files
deleted from the Desktop, which is a confusing behavior. Instead clean
the recycle bin explicitly in `VM-Clean-Up`.
- Delete saved PowerShell history in `VM-Clean-Up` by deleting the file
that contains it.
- Remove as much of `PS_Transcripts` as possible in
`VM-Remove-DesktopFiles` (called by `VM-Clean-Up`).

Closes https://github.com/mandiant/VM-Packages/issues/755