### PR TITLE
Improve Clean Up

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240104</version>
+    <version>0.0.0.20240105</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1346,7 +1346,7 @@ function VM-Clean-Up {
     VM-Clear-TempAndCache
 
     Write-Host "[+] Clearing Recycle Bin" -ForegroundColor Green
-    Clear-RecycleBin -Force
+    Clear-RecycleBin -Force -ErrorAction Continue
 
     Write-Host "[+] Running Disk Cleanup..." -ForegroundColor Green
     VM-Write-Log "INFO" "Performing Disk Cleanup."


### PR DESCRIPTION
- Do not try to delete PS_Transcripts from PowerShell as we can easily delete it from cmd after closing all PowerShell consoles with the command:
  ```
  rmdir /s /q "%UserProfile%\Desktop\PS_Transcripts"
  ```
  The previous solution was complicated and didn't work properly.
- `Clear-RecycleBin` fails sometimes due to the following bug: https://github.com/PowerShell/PowerShell/issues/6743 This bug has been fixed in PowerShell >= 7, but we support PowerShell >= 5.
- Simplify error logging in `VM-Remove-DesktopFiles`.