### PR TITLE
[taskbar shortcut] Open cmd in Desktop

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20231213</version>
+    <version>0.0.0.20230110</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -42,8 +42,9 @@ try {
         $shortcutDir = ${Env:RAW_TOOLS_DIR}
         $shortcut = Join-Path $shortcutDir "$toolName.lnk"
         $workingDir  = Join-Path ${Env:UserProfile} "Desktop"
+        $target = "$executablePath /k `"$workingDir`""
 
-        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin -WorkingDirectory $workingDir
+        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $target -RunAsAdmin
         VM-Assert-Path $shortcut
 
         Import-StartLayout -LayoutPath $customLayout -MountPath "C:\"


### PR DESCRIPTION
Working directory only works if cmd is not launched as Admin. As we need to launch is as admin, change to the Desktop location explicitly.