### PR TITLE
Add VM-Assert-Signature & use to to add Google Chrome

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240105</version>
+    <version>0.0.0.20240111</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -128,6 +128,23 @@ function VM-Assert-Path {
     }
 }
 
+# Raise an exception if the Signature of $file_path is invalid
+function VM-Assert-Signature {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String] $file_path
+    )
+    $signature_status = (Get-AuthenticodeSignature -FilePath $file_path).Status
+    if ($signature_status -eq 'Valid') {
+        VM-Write-Log "INFO" "Valid signature: $file_path"
+    } else {
+        $err_msg = "Invalid signature: $file_path"
+        VM-Write-Log "ERROR" $err_msg
+        throw $err_msg
+    }
+}
+
 function VM-Get-DiskSize {
     $diskdrive = "${Env:SystemDrive}"
     $driveName = $diskdrive.substring(0, $diskdrive.length-1)

--- a/packages/googlechrome.vm/googlechrome.vm.nuspec
+++ b/packages/googlechrome.vm/googlechrome.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>googlechrome.vm</id>
+    <version>0.0.0.20240111</version>
+    <authors>Google LLC.</authors>
+    <description>Chrome is a popular web browser.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240111" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/googlechrome.vm/tools/chocolateyinstall.ps1
+++ b/packages/googlechrome.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    # Download the installer
+    $packageArgs        = @{
+        packageName     = $env:ChocolateyPackageName
+        file            = Join-Path ${Env:TEMP} 'googlechromeinstaller.msi'
+        url             = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise.msi'
+        url64bit        = 'https://dl.google.com/tag/s/dl/chrome/install/googlechromestandaloneenterprise64.msi'
+    }
+    $filePath = Get-ChocolateyWebFile @packageArgs
+    VM-Assert-Path $filePath
+    VM-Assert-Signature $filePath
+
+    # Install the downloaded installer
+    $packageArgs        = @{
+        packageName     = $env:ChocolateyPackageName
+        file            = $filePath
+        fileType        = 'MSI'
+        silentArgs      = "/quiet /norestart /l*v `"$($env:TEMP)\$($env:chocolateyPackageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+    }
+    Install-ChocolateyInstallPackage @packageArgs
+} catch {
+    VM-Write-Log-Exception $_
+}

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -312,6 +312,7 @@ class UsesInvalidCategory(Lint):
         "common.vm",
         "debloat.vm",
         "flarevm.installer.vm",
+        "googlechrome.vm",
         "ida.plugin.capa.vm",
         "idafree.vm",
         "installer.vm",


### PR DESCRIPTION
Add Google Chrome using the new `VM-Assert-Signature` function to check its signature instead of its hash during the installation. This PR doesn't not address the following issues which should be addressed in a different PR to make the review process easier:
- https://github.com/mandiant/VM-Packages/issues/820
- https://github.com/mandiant/VM-Packages/issues/821
- https://github.com/mandiant/VM-Packages/issues/822
- https://github.com/mandiant/VM-Packages/issues/823
- https://github.com/mandiant/VM-Packages/issues/725

Partially addresses https://github.com/mandiant/VM-Packages/issues/469. We need to use `VM-Assert-Signature` for sysinternals.vm` to fully address that issue.