### PR TITLE
Fix sysinternals (and avoid that it breaks again!)

### DIFF
--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,12 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>2023.11.13</version>
+    <version>0.0.0.20240112</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
-    <description>Sysinternals suite of troubleshooting tools.</description>
+    <description>Sysinternals suite.</description>
     <dependencies>
-      <dependency id="common.vm" />
-      <dependency id="sysinternals" version="[2023.11.13]" />
+      <dependency id="common.vm" version="0.0.0.20240111" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
@@ -1,34 +1,20 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} 'sysinternals'
-
-# Remove our shims
-Get-ChildItem -Path "$toolDir\*" -Include '*.exe' | ForEach-Object { Uninstall-BinFile -Name $([System.IO.Path]::GetFileNameWithoutExtension($_)) -ea 0 }
-
-###
-# First category
+$toolName = 'sysinternals'
 $category = 'Utilities'
-VM-Remove-Tool-Shortcut 'sysinternals' $category
-VM-Remove-Tool-Shortcut 'procexp' $category
-VM-Remove-Tool-Shortcut 'procmon' $category
 
-###
-# Second category
-$category = 'Reconnaissance'
-VM-Remove-Tool-Shortcut 'ADExplorer' $category
+VM-Remove-Tool-Shortcut $toolName $category
+# Remove tools shortcuts
+$shortcuts = @{
+'Utilities' = @('procexp', 'procmon')
+'Reconnaissance' = @('ADExplorer')
+}
+ForEach ($category in $shortcuts.GetEnumerator()) {
+    ForEach ($toolName in $category.value) {
+        VM-Remove-Tool-Shortcut $toolName $category.key
+    }
+}
 
-###
-# Restore dependency's tools
-# Location of dependency's tools (all sysinternal tools)
-$chocoToolDir = Join-Path ${Env:ChocolateyInstall} 'lib\sysinternals\tools'
-
-# Move items back to original location
-Get-ChildItem -Path "$toolDir\*" -Exclude '*.ps1' | Move-Item -Destination $chocoToolDir -Force -ea 0
-
-# Re-establish old shims
-Get-ChildItem -Path "$chocoToolDir\*" -Include '*.exe' | ForEach-Object { Install-BinFile -Name $([System.IO.Path]::GetFileNameWithoutExtension($_)) -Path $_.FullName -ea 0 }
-
-###
-# Remove tool directory
-Remove-Item $toolDir -Recurse -Force -ea 0
+$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
+Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null


### PR DESCRIPTION
Re-write sysinternal.vm using `VM-Assert-Signature` to use the tools signature instead of the metapackage. The metapackage uses the downloaded zip hash, that breaks with every update, breaking our package.

@vm-packages I would appreciate some local testing. 😉 

Closes https://github.com/mandiant/VM-Packages/issues/469