### PR TITLE
Fix gowitness by updating dependency

### DIFF
--- a/packages/gowitness.vm/gowitness.vm.nuspec
+++ b/packages/gowitness.vm/gowitness.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gowitness.vm</id>
-    <version>2.5.1</version>
+    <version>2.5.1.20240112</version>
     <authors>sensepost</authors>
     <description>Website screenshot utility written in Golang, that uses Chrome Headless to generate screenshots of web interfaces using the command line, with a handy report viewer to process results.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="googlechrome" />
+      <dependency id="googlechrome.vm" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This package is failing to install in our daily. It install locally correctly after updating the dependency to the new googlechrome.vm.