### PR TITLE
Fix broken rubeus by using a URL whose hash doesn't change

### DIFF
--- a/packages/rubeus.vm/rubeus.vm.nuspec
+++ b/packages/rubeus.vm/rubeus.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rubeus.vm</id>
-    <version>2.2.3</version>
+    <version>2.3.1</version>
     <authors>harmj0y</authors>
     <description>Rubeus is a C# toolset for raw Kerberos interaction and abuses.</description>
     <dependencies>

--- a/packages/rubeus.vm/tools/chocolateyinstall.ps1
+++ b/packages/rubeus.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'Rubeus'
 $category = 'Credential Access'
 
-$zipUrl = 'https://github.com/GhostPack/Rubeus/archive/refs/heads/master.zip'
-$zipSha256 = 'DC61768AF588A5FCC1CEDC491E8DF81BC652A96A1A032741034E40B75EC404F2'
+$zipUrl = 'https://codeload.github.com/GhostPack/Rubeus/zip/baf34c7dcffb37cb96c92e402bab389229f1ec35'
+$zipSha256 = 'a857b776e8f86a8f94da74beb6449fede16286aba129373a9899641aab078390'
 
 VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256


### PR DESCRIPTION
Use a GitHub download URL which includes the commit hash instead of using the `master` branch to avoid that the hash changes breaking the package.