### PR TITLE
Fix broken situational-awareness-bof by using a URL whose hash doesn't change

### DIFF
--- a/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
+++ b/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>situational-awareness-bof.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240112</version>
     <authors>trustedsec</authors>
     <description>Provides a set of basic situational awareness commands implemented in a Beacon Object File (BOF). This allows you to perform some checks on a host before you begin executing commands that may be more invasive.</description>
     <dependencies>

--- a/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'Situational Awareness BOF'
 $category = 'Reconnaissance'
 
-$zipUrl = 'https://github.com/trustedsec/CS-Situational-Awareness-BOF/archive/refs/heads/master.zip'
-$zipSha256 = 'e3673d7e41ad6d36ca7d6d44821f68238aae9968e062acb6d96fc7663c87bbdb'
+$zipUrl = 'https://codeload.github.com/trustedsec/CS-Situational-Awareness-BOF/zip/9a813b8f31cd397d7b05211e1d5b378c07fd1b8b'
+$zipSha256 = 'b461e5a0dde271ee29c2105f8b064e6c3d38f4996c09478c16bb1f071cee00c1'
 
 VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256


### PR DESCRIPTION
Use a GitHub download URL which includes the commit hash instead of using the `master` branch to avoid that the hash changes breaking the package.