### PR TITLE
Add iconLocation arg for non-console app

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240118</version>
+    <version>0.0.0.20240119</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -311,6 +311,7 @@ function VM-Install-Shortcut{
         $shortcutArgs = @{
             ShortcutFilePath = $shortcut
             TargetPath       = $executablePath
+            IconLocation     = $iconLocation
         }
         if ($runAsAdmin) {
             $shortcutArgs.RunAsAdmin = $true


### PR DESCRIPTION
Small oversight. Forgot to add `iconLocation` to the arguments for creating a shortcut for the non-console app path.