### PR TITLE
Update idafree to use VM-Install-Shortcut

### DIFF
--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>8.3.0.20231129</version>
+    <version>8.3.0.20240119</version>
     <authors>hex-rays</authors>
     <description>Free version of IDA, a powerful Interactive DisAssembler and debugger</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20230925" />
+      <dependency id="common.vm" version="0.0.0.20240119" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,6 @@ Import-Module vm.common -Force -DisableNameChecking
 try {
   $toolName = 'idafree'
   $category = 'Disassemblers'
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $packageArgs = @{
     packageName  = ${Env:ChocolateyPackageName}
@@ -38,10 +37,9 @@ try {
 
   VM-Assert-Path $launcherPath
 
-  $launcherShortcut = Join-Path $shortcutDir "ida.lnk"
   $menuIcon = Join-Path $toolDir "ida.ico" -Resolve
 
-  Install-ChocolateyShortcut -shortcutFilePath $launcherShortcut -targetPath $launcherPath -IconLocation $menuIcon
+  VM-Install-Shortcut -toolName "ida" -category $category -executablePath $launcherPath -IconLocation $menuIcon
 
   # ida64.exe supports both 32 bit and 64 bit in IDA >= 8.2
   VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$menuIcon"


### PR DESCRIPTION
Updated `idafree.vm` to use `VM-Install-Shortcut` now that it supports `-IconLocation`

**NOTE**: This requires https://github.com/mandiant/VM-Packages/pull/849 to be merged first