### PR TITLE
Fix shortcuts in didier-stevens-beta.vm

### DIFF
--- a/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
+++ b/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-beta.vm</id>
-    <version>0.0.0.20231221</version>
+    <version>0.0.0.20240122</version>
     <authors>Didier Stevens</authors>
     <description>Beta versions of Didier Stevens's software</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20231221" />
       <dependency id="python3.vm" />
     </dependencies>
   </metadata>

--- a/packages/didier-stevens-beta.vm/tools/chocolateyinstall.ps1
+++ b/packages/didier-stevens-beta.vm/tools/chocolateyinstall.ps1
@@ -17,15 +17,16 @@ try {
     $toolDir = Get-Item "${Env:RAW_TOOLS_DIR}\Beta-*"
     VM-Assert-Path $toolDir
 
-    # Add shortcut for commonly used office tools
+    # Add shortcut for commonly used office python tools
     ForEach ($toolName in @('onedump')) {
-      $executablePath = Join-Path $toolDir "$toolName.py"
-      VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments "--help"
+      $executablePath = (Get-Command python).Source
+      $filePath = Join-Path $toolDir "$toolName.py"
+      $arguments = $filePath + " --help"
+      VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $arguments
     }
 
     # Add tools to Path
-    $path = [Environment]::GetEnvironmentVariable("Path", "Machine") + [IO.Path]::PathSeparator + $toolDir
-    [Environment]::SetEnvironmentVariable("Path", $path, "Machine")
+    VM-Add-To-Path $toolDir
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
Somewhat related to https://github.com/mandiant/VM-Packages/issues/675

This fixes the shortcuts created for the `didier-stevens-beta.vm` package so that each shortcut properly executes with python.