### PR TITLE
Fix shortcuts in didier-stevens-suite.vm

### DIFF
--- a/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
+++ b/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-suite.vm</id>
-    <version>0.0.0.20231221</version>
+    <version>0.0.0.20240122</version>
     <authors>Didier Stevens</authors>
     <description>Tools collection by Didier Stevens</description>
     <dependencies>

--- a/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
+++ b/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
@@ -17,10 +17,12 @@ try {
     $toolDir = Get-Item "${Env:RAW_TOOLS_DIR}\DidierStevensSuite-*"
     VM-Assert-Path $toolDir
 
-    # Add shortcut for commonly used PDF tools
+    # Add shortcut for commonly used python PDF tools
     ForEach ($toolName in @('pdfid', 'pdf-parser')) {
-      $executablePath = Join-Path $toolDir "$toolName.py"
-      VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments "--help"
+      $executablePath = (Get-Command python).Source
+      $filePath = Join-Path $toolDir "$toolName.py"
+      $arguments = $filePath + " --help"
+      VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $arguments
     }
 
     # Add tools to Path


### PR DESCRIPTION
Somewhat related to https://github.com/mandiant/VM-Packages/issues/675

This fixes the shortcuts created for the `didier-stevens-suite.vm` package so that each shortcut properly executes with python.