### PR TITLE
Add better shortcut icons for .py and .bat

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240220</version>
+    <version>0.0.0.20240304</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -282,6 +282,7 @@ function VM-Install-Shortcut{
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
     $shortcut = Join-Path $shortcutDir "$toolName.lnk"
 
+    # Set the default icon to be the executable's icon
     if (-Not $iconLocation) {$iconLocation = $executablePath}
 
     if ($consoleApp) {
@@ -320,6 +321,19 @@ function VM-Install-Shortcut{
         Install-ChocolateyShortcut @shortcutArgs
     }
     VM-Assert-Path $shortcut
+
+    # If the targets is a .bat file, change the shortcut icon to Windows default
+    $extension = [System.IO.Path]::GetExtension($executablePath)
+    if ($extension -eq ".bat") {
+        $Shell = New-Object -ComObject ("WScript.Shell")
+        $Shortcut = $Shell.CreateShortcut($shortcut)
+
+        $IconArrayIndex = -68 # This is the specific icon that Windows uses for .bat files by default
+        $IconLocation = "C:\WINDOWS\system32\imageres.dll"
+        $Shortcut.IconLocation = "$IconLocation,$IconArrayIndex"
+
+        $Shortcut.Save()
+    }
 }
 
 # This functions returns $toolDir (outputed by Install-ChocolateyZipPackage) and $executablePath


### PR DESCRIPTION
This fixes https://github.com/mandiant/VM-Packages/issues/675

I tested `.bat` with: https://github.com/mandiant/VM-Packages/blob/79c35a70707ea79f01559eceb76eac000e029bd4/packages/dex2jar.vm

And `.py` with: https://github.com/mandiant/VM-Packages/tree/main/packages/didier-stevens-suite.vm