### PR TITLE
Remove cd command in VM-Install-Shortcut

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240119</version>
+    <version>0.0.0.20240123</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -292,7 +292,7 @@ function VM-Install-Shortcut{
 
         $executableCmd  = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
         # Change to executable dir, print command to execute, and execute command
-        $executableArgs = "/K `"cd `"$executableDir`" && echo $executableDir^> $executablePath $arguments && `"$executablePath`" $arguments`""
+        $executableArgs = "/K `"echo $executableDir^> $executablePath $arguments && `"$executablePath`" $arguments`""
 
         $shortcutArgs = @{
             ShortcutFilePath = $shortcut


### PR DESCRIPTION
This fixes what was referenced here: https://github.com/mandiant/VM-Packages/issues/676#issuecomment-1877578921

After some testing, it looks like we do not need the `cd C:\Users\User\Desktop` piece of the command as we will already be in there due to `WorkingDirectory` being set there for `Install-ChocolateyShortcut`.