### PR TITLE
Fix variable name in VM-Install-Shortcut

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240119</version>
+    <version>0.0.0.20240123</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -302,7 +302,7 @@ function VM-Install-Shortcut{
             IconLocation     = $iconLocation
         }
         if ($runAsAdmin) {
-            $packageArgs.RunAsAdmin = $true
+            $shortcutArgs.RunAsAdmin = $true
         }
 
         Install-ChocolateyShortcut @shortcutArgs


### PR DESCRIPTION
Small fix to an oversight in recent update to `VM-Install-Shortcut`.