### PR TITLE
Fix Cmd Here Formatting

### DIFF
--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>debloat.vm</id>
-    <version>0.0.0.20231218</version>
+    <version>0.0.0.20240123</version>
     <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -142,7 +142,7 @@
         <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
         <registry-item name="Disable Microsoft Connectivity Test (msftconnecttest.com)" path="HKLM:\SYSTEM\CurrentControlSet\services\NlaSvc\Parameters\Internet" value="EnableActiveProbing" type="DWord" data="0" />
         <registry-item name="Enable opening cmd from context menu - Default" path="Registry::HKEY_CLASSES_ROOT\Directory\Background\shell\ctx_cmd" value="(Default)" type="String" data="Cmd Here" />
-        <registry-item name="Enable opening cmd from context menu - Command" path="Registry::HKEY_CLASSES_ROOT\Directory\Background\shell\ctx_cmd\command" value="(Default)" type="String" data="cmd.exe /s /k pushd &quot;%V&quot;" />
+        <registry-item name="Enable opening cmd from context menu - Command" path="Registry::HKEY_CLASSES_ROOT\Directory\Background\shell\ctx_cmd\command" value="(Default)" type="String" data="&quot;cmd.exe&quot; &quot;pushd &quot;%V&quot;&quot;" />
     </registry-items>
     <path-items>
         <!--


### PR DESCRIPTION
Incorrect formatting lead to a `+` appearing at the end of the path when opening a command prompt using the right click `Cmd Here` option.

Fixes https://github.com/mandiant/VM-Packages/issues/862.