### PR TITLE
Removing hashcat intel check

### DIFF
--- a/packages/hashcat.vm/hashcat.vm.nuspec
+++ b/packages/hashcat.vm/hashcat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hashcat.vm</id>
-    <version>6.2.6</version>
+    <version>6.2.6.20240212</version>
     <authors>Jens Steube (jsteube)</authors>
     <description>Hashcat is a fast password recovery utility.</description>
     <dependencies>

--- a/packages/hashcat.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashcat.vm/tools/chocolateyinstall.ps1
@@ -16,16 +16,6 @@ try {
     # Get the processor information
     $processor = Get-CimInstance Win32_Processor
 
-
-    # Check if the manufacturer is Intel
-    if ($processor.Manufacturer -eq "GenuineIntel") {
-        Write-Output "Intel processor detected for hashcat."
-    } else {
-        Write-Output "Non-Intel processor detected. Hashcat will not work"
-        throw "Non-Intel processor detected."
-    }
-
-
     # Download the zip file
     $packageArgs = @{
         packageName   = ${Env:ChocolateyPackageName}


### PR DESCRIPTION
Removed the compatibility check; this can be handled by the installation process and the profiles used. Fixes #742 and #653. Also comes up in #877.

Hashcat should support a variety of systems and the check was not complex enough to accurately determine compatibility.

It does not seem trivial to get OpenCL on an ARM Windows system, however, I think this can be up to the user or a future fix to meet the compatibility.