### PR TITLE
Clean up categories for better organization

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_metapackage.yml
+++ b/.github/ISSUE_TEMPLATE/new_metapackage.yml
@@ -50,39 +50,34 @@ body:
       label: Category
       description: Which category should this tool be installed to?
       options:
-        - Active Directory
-        - Cloud
         - Command & Control
         - Credential Access
         - Debuggers
         - Delphi
         - Disassemblers
         - dotNet
-        - Evasion
+        - Documents
         - Exploitation
+        - File Information
         - Forensic
         - Hex Editors
-        - Information Gathering
         - InnoSetup
         - Java & Android
         - Javascript
         - Lateral Movement
+        - Memory
         - Networking
-        - Office
         - Packers
-        - Password Attacks
         - Payload Development
-        - PDF
         - PE
         - Persistence
-        - PowerShell
         - Privilege Escalation
-        - Python
+        - Productivity Tools
         - Reconnaissance
-        - Text Editors
+        - Registry
+        - Shellcode
         - Utilities
-        - VB
-        - Vulnerability Analysis
+        - Visual Basic
         - Web Application
         - Wordlists
   - type: input

--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -69,39 +69,34 @@ body:
       label: Category
       description: Which category should this tool be installed to?
       options:
-        - Active Directory
-        - Cloud
         - Command & Control
         - Credential Access
         - Debuggers
         - Delphi
         - Disassemblers
         - dotNet
-        - Evasion
+        - Documents
         - Exploitation
+        - File Information
         - Forensic
         - Hex Editors
-        - Information Gathering
         - InnoSetup
         - Java & Android
         - Javascript
         - Lateral Movement
+        - Memory
         - Networking
-        - Office
         - Packers
-        - Password Attacks
         - Payload Development
-        - PDF
         - PE
         - Persistence
-        - PowerShell
         - Privilege Escalation
-        - Python
+        - Productivity Tools
         - Reconnaissance
-        - Text Editors
+        - Registry
+        - Shellcode
         - Utilities
-        - VB
-        - Vulnerability Analysis
+        - Visual Basic
         - Web Application
         - Wordlists
   - type: input

--- a/categories.txt
+++ b/categories.txt
@@ -1,35 +1,31 @@
-Active Directory
-Cloud
 Command & Control
 Credential Access
 Debuggers
 Delphi
 Disassemblers
+Documents
 dotNet
-Evasion
 Exploitation
+File Information
 Forensic
 Hex Editors
-Information Gathering
 InnoSetup
 Java & Android
 Javascript
 Lateral Movement
+Memory
 Networking
-Office
 Packers
-Password Attacks
 Payload Development
-PDF
 PE
 Persistence
 PowerShell
 Privilege Escalation
-Python
+Productivity Tools
 Reconnaissance
-Text Editors
+Registry
+Shellcode
 Utilities
-VB
-Vulnerability Analysis
+Visual Basic
 Web Application
 Wordlists

--- a/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
+++ b/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>arsenalimagemounter.vm</id>
-    <version>3.11.279.20240222</version>
+    <version>3.11.279.20240226</version>
     <authors>Arsenal Recon</authors>
     <description>Mounts the contents of disk images as complete disks in Windows.</description>
     <dependencies>

--- a/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
+++ b/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'ArsenalImageMounter'
-  $category = 'Utilities'
+  $category = 'Forensic'
   $shimPath = "\bin\${toolName}.exe"
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/arsenalimagemounter.vm/tools/chocolateyuninstall.ps1
+++ b/packages/arsenalimagemounter.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'ArsenalImageMounter'
-$category = 'Utilities'
+$category = 'Forensic'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/blobrunner.vm/blobrunner.vm.nuspec
+++ b/packages/blobrunner.vm/blobrunner.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>blobrunner.vm</id>
-    <version>0.0.5</version>
+    <version>0.0.5.20240217</version>
     <authors>OALabs</authors>
     <description>BlobRunner is a simple tool to quickly debug shellcode extracted during malware analysis.</description>
     <dependencies>

--- a/packages/blobrunner.vm/tools/chocolateyinstall.ps1
+++ b/packages/blobrunner.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'blobrunner'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 $zipUrl = 'https://github.com/OALabs/BlobRunner/releases/download/v0.0.5/blobrunner.zip'
 $zipSha256 = '369ed39086e40fe9ae5404b52cafe0a9b747abb11f2d33d73e5a51097d0ae2a4'

--- a/packages/blobrunner.vm/tools/chocolateyuninstall.ps1
+++ b/packages/blobrunner.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'blobrunner'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category

--- a/packages/blobrunner64.vm/blobrunner64.vm.nuspec
+++ b/packages/blobrunner64.vm/blobrunner64.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>blobrunner64.vm</id>
-    <version>0.0.5</version>
+    <version>0.0.5.20240217</version>
     <authors>OALabs</authors>
     <description>BlobRunner is a simple tool to quickly debug shellcode extracted during malware analysis.</description>
     <dependencies>

--- a/packages/blobrunner64.vm/tools/chocolateyinstall.ps1
+++ b/packages/blobrunner64.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'blobrunner64'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 $zipUrl = 'https://github.com/OALabs/BlobRunner/releases/download/v0.0.5/blobrunner64.zip'
 $zipSha256 = '325e3e26ccdce53cdd8b6665c7ed7d1765fc1c56cd088a5b4433593682c9f503'

--- a/packages/blobrunner64.vm/tools/chocolateyuninstall.ps1
+++ b/packages/blobrunner64.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'blobrunner64'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category

--- a/packages/burp-free.vm/burp-free.vm.nuspec
+++ b/packages/burp-free.vm/burp-free.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>burp-free.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240217</version>
     <authors>PortSwigger Ltd.</authors>
     <description>Burp Suite Community Edition is PortSwigger's free integrated platform for performing security testing of web applications.</description>
     <dependencies>

--- a/packages/burp-free.vm/tools/chocolateyinstall.ps1
+++ b/packages/burp-free.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'BurpSuiteCommunity'
-  $category = 'Utilities'
+  $category = 'Web Application'
   $shimPath = 'BurpSuiteCommunity\BurpSuiteCommunity.exe'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/burp-free.vm/tools/chocolateyuninstall.ps1
+++ b/packages/burp-free.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'BurpSuiteCommunity'
-$category = 'Utilities'
+$category = 'Web Application'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/cmder.vm/cmder.vm.nuspec
+++ b/packages/cmder.vm/cmder.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cmder.vm</id>
-    <version>1.3.24</version>
+    <version>1.3.24.20240217</version>
     <description>Metapackage for cmder</description>
     <authors>Mandiant, Samuel Vasko</authors>
     <dependencies>

--- a/packages/cmder.vm/tools/chocolateyinstall.ps1
+++ b/packages/cmder.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'cmder'
-  $category = 'Utilities'
+  $category = 'Productivity Tools'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName -Resolve

--- a/packages/cmder.vm/tools/chocolateyuninstall.ps1
+++ b/packages/cmder.vm/tools/chocolateyuninstall.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = 'Continue'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir 'cmder.lnk'
 Remove-Item $shortcut -Force -ea 0 | Out-Null

--- a/packages/cygwin.vm/cygwin.vm.nuspec
+++ b/packages/cygwin.vm/cygwin.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cygwin.vm</id>
-    <version>3.5.0</version>
+    <version>3.5.0.20240217</version>
     <description>Wrapper for cygwin and useful cygwin packages</description>
     <authors>Red Hat Inc.</authors>
     <dependencies>

--- a/packages/cygwin.vm/tools/chocolateyinstall.ps1
+++ b/packages/cygwin.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'cygwin'
-  $category = 'Utilities'
+  $category = 'Productivity Tools'
 
   # install additional cygwin packages
   $packages = @(

--- a/packages/cygwin.vm/tools/chocolateyuninstall.ps1
+++ b/packages/cygwin.vm/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 ﻿$ErrorActionPreference = 'Continue'
 
 $toolName = 'cygwin'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 
 $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir "$toolName.lnk"

--- a/packages/dcode.vm/dcode.vm.nuspec
+++ b/packages/dcode.vm/dcode.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dcode.vm</id>
-    <version>5.5.21194.20231212</version>
+    <version>5.5.21194.20240217</version>
     <authors>Digital Detective Group</authors>
     <description>Utility for converting data found on desktop and mobile devices into human-readable timestamps.</description>
     <dependencies>

--- a/packages/dcode.vm/tools/chocolateyinstall.ps1
+++ b/packages/dcode.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DCode'
-$category = 'Utilities'
+$category = 'Forensic'
 
 $url = 'https://www.digital-detective.net/download/download.php?downcode=ae2znu5994j1lforlh03'
 $sha256 = 'dbb23d6ea4f572fbaec017fb8acc2a8b62b74fafa81ea4a388966ec14087a9e4'

--- a/packages/dcode.vm/tools/chocolateyuninstall.ps1
+++ b/packages/dcode.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DCode'
-$category = 'Utilities'
+$category = 'Forensic'
 
 VM-Uninstall $toolName $category

--- a/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
+++ b/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-beta.vm</id>
-    <version>0.0.0.20240122</version>
+    <version>0.0.0.20240226</version>
     <authors>Didier Stevens</authors>
     <description>Beta versions of Didier Stevens's software</description>
     <dependencies>

--- a/packages/didier-stevens-beta.vm/tools/chocolateyinstall.ps1
+++ b/packages/didier-stevens-beta.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-    $category = 'Office'
+    $category = 'Documents'
     $zipUrl = 'https://github.com/DidierStevens/Beta/archive/cbb1d5c32d02b4e07128a197c8b8fb6ea597916a.zip'
     $zipSha256 = 'e9d83063f45f8e2791d33de194a46850bd7f1921e755bd4651c769cbcdbd5052'
 

--- a/packages/didier-stevens-beta.vm/tools/chocolateyuninstall.ps1
+++ b/packages/didier-stevens-beta.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 # Remove shortcuts
-$category = 'Office'
+$category = 'Documents'
 ForEach ($toolName in @('onedump')) {
   VM-Remove-Tool-Shortcut $toolName $category
 }

--- a/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
+++ b/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-suite.vm</id>
-    <version>0.0.0.20240122</version>
+    <version>0.0.0.20240226</version>
     <authors>Didier Stevens</authors>
     <description>Tools collection by Didier Stevens</description>
     <dependencies>

--- a/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
+++ b/packages/didier-stevens-suite.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-    $category = 'PDF'
+    $category = 'Documents'
     $zipUrl = 'https://github.com/DidierStevens/DidierStevensSuite/archive/8190354314d6f42c9ddc477a795029dc446176c5.zip'
     $zipSha256 = 'fe37ef5b81810af99820a7360aa26e7fec669432875dd29e38f307880bb53c37'
 

--- a/packages/didier-stevens-suite.vm/tools/chocolateyuninstall.ps1
+++ b/packages/didier-stevens-suite.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 # Remove shortcuts
-$category = 'PDF'
+$category = 'Documents'
 ForEach ($toolName in @('pdfid', 'pdf-parser')) {
   VM-Remove-Tool-Shortcut $toolName $category
 }

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.07.20230925</version>
+    <version>3.07.20240217</version>
     <authors>Hellsp@wn, horsicq</authors>
     <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
     <dependencies>

--- a/packages/die.vm/tools/chocolateyinstall.ps1
+++ b/packages/die.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'die'
-  $category = 'Utilities'
+  $category = 'File Information'
 
   $zipUrl = 'https://github.com/horsicq/DIE-engine/releases/download/3.07/die_win32_portable_3.07.zip'
   $zipSha256 = 'c7f16841df475d6f09d37cf745804c866c823876c4605b5958376402cbb64eca'

--- a/packages/die.vm/tools/chocolateyuninstall.ps1
+++ b/packages/die.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'die'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category
 VM-Remove-From-Right-Click-Menu $toolName

--- a/packages/exeinfope.vm/exeinfope.vm.nuspec
+++ b/packages/exeinfope.vm/exeinfope.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exeinfope.vm</id>
-    <version>0.0.7.20221209</version>
+    <version>0.0.7.20240217</version>
     <authors>A.S.L Soft</authors>
     <description>Displays metadata for a variety of file types and identifies many executable packers</description>
     <dependencies>

--- a/packages/exeinfope.vm/tools/chocolateyinstall.ps1
+++ b/packages/exeinfope.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'exeinfope'
-$category = 'Utilities'
+$category = 'File Information'
 
 $zipUrl = 'https://github.com/ExeinfoASL/ASL/raw/dcaede39806993f5e68ab1c04e650319d3852170/exeinfope.zip'
 $zipSha256 = '7eecd5d2dd37dbbc5169c6c7d179a4f5ac45a179c74a707a7d2d972b63b09fc5'

--- a/packages/exeinfope.vm/tools/chocolateyuninstall.ps1
+++ b/packages/exeinfope.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'exeinfope'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category

--- a/packages/exiftool.vm/exiftool.vm.nuspec
+++ b/packages/exiftool.vm/exiftool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exiftool.vm</id>
-    <version>12.77.0</version>
+    <version>12.77.0.20240217</version>
     <authors>Phil Harvey</authors>
     <description>A tool for reeding and writing file metadata</description>
     <dependencies>

--- a/packages/exiftool.vm/tools/chocolateyinstall.ps1
+++ b/packages/exiftool.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'exiftool'
-    $category = 'Utilities'
+    $category = 'File Information'
     $shimPath = 'bin\exiftool.exe'
 
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/exiftool.vm/tools/chocolateyuninstall.ps1
+++ b/packages/exiftool.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'exiftool'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Remove-Tool-Shortcut $toolName $category
 

--- a/packages/ezviewer.vm/ezviewer.vm.nuspec
+++ b/packages/ezviewer.vm/ezviewer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ezviewer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240226</version>
     <authors>Eric Zimmerman</authors>
     <description>Standalone, zero dependency viewer for .doc, .docx, .xls, .xlsx, .txt, .log, .rtf, .otd, .htm, .html, .mht, .csv, and .pdf. Any non-supported files are shown in a hex editor (with data interpreter!)</description>
     <dependencies>

--- a/packages/ezviewer.vm/tools/chocolateyinstall.ps1
+++ b/packages/ezviewer.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'EZViewer'
-$category = 'Office'
+$category = 'Documents'
 
 $zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/EZViewer.zip'
 $zipSha256 = '86a27bf8f4744d283c33d7321ad8a510e6f4067ec776cfdf1cc4748a0684072d'

--- a/packages/ezviewer.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ezviewer.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'EZViewer'
-$category = 'Office'
+$category = 'Documents'
 
 VM-Uninstall $toolName $category

--- a/packages/file.vm/file.vm.nuspec
+++ b/packages/file.vm/file.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>file.vm</id>
-    <version>0.0.0.20230925</version>
+    <version>0.0.0.20240217</version>
     <description>A Windows port of the Linux `file` utility for checking header magics</description>
     <authors>Nolen Scaiffe</authors>
     <dependencies>

--- a/packages/file.vm/tools/chocolateyinstall.ps1
+++ b/packages/file.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'file'
-    $category = 'Utilities'
+    $category = 'File Information'
 
     $zipUrl = "https://github.com/nscaife/file-windows/releases/download/20170108/file-windows-20170108.zip"
     $zipSha256 = "963147318f96d9345471e1a9a3943def4d95fcb3c1fe020e465ab910d0cda4a3"

--- a/packages/file.vm/tools/chocolateyuninstall.ps1
+++ b/packages/file.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'file'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category
 VM-Remove-From-Right-Click-Menu $toolName

--- a/packages/floss.vm/floss.vm.nuspec
+++ b/packages/floss.vm/floss.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>floss.vm</id>
-    <version>3.0.1</version>
+    <version>3.0.1.20240217</version>
     <description>FLOSS uses advanced static analysis techniques to automatically deobfuscate strings from malware binaries. You can use it just like strings.exe to enhance basic static analysis of unknown binaries.</description>
     <authors>@williballenthin, @mr-tz</authors>
     <dependencies>

--- a/packages/floss.vm/tools/chocolateyinstall.ps1
+++ b/packages/floss.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'FLOSS'
-$category = 'Utilities'
+$category = 'File Information'
 
 $zipUrl = "https://github.com/mandiant/flare-floss/releases/download/v3.0.1/floss-v3.0.1-windows.zip"
 $zipSha256 = "eeed5d8eec831fbc7ca7e2fc2c6a3c548993682a49477ae63335bbdff9d52ae5"

--- a/packages/floss.vm/tools/chocolateyuninstall.ps1
+++ b/packages/floss.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'FLOSS'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category

--- a/packages/goresym.vm/goresym.vm.nuspec
+++ b/packages/goresym.vm/goresym.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>goresym.vm</id>
-    <version>2.4.0.20231203</version>
+    <version>2.4.0.20240217</version>
     <authors>stevemk14ebr</authors>
     <description>Go symbol recovery tool</description>
     <dependencies>

--- a/packages/goresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/goresym.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoReSym'
-$category = 'Utilities'
+$category = 'File Information'
 
 $zipUrl = 'https://github.com/mandiant/GoReSym/releases/download/v2.4/GoReSym-windows.zip'
 $zipSha256 = '6d253e98fce443b5c818e0ae0c0f0a4e3587e0f0f7baf150383ead242e01babd'

--- a/packages/goresym.vm/tools/chocolateyuninstall.ps1
+++ b/packages/goresym.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'GoReSym'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category

--- a/packages/hasher.vm/hasher.vm.nuspec
+++ b/packages/hasher.vm/hasher.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hasher.vm</id>
-    <version>2.0.0.20231207</version>
+    <version>2.0.0.20240226</version>
     <authors>Eric Zimmerman</authors>
     <description>Hash all the things</description>
     <dependencies>

--- a/packages/hasher.vm/tools/chocolateyinstall.ps1
+++ b/packages/hasher.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Hasher'
-$category = 'Utilities'
+$category = 'File Information'
 
 $zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/hasher.zip'
 $zipSha256 = '1693875e5f830e582dc01778cae34e50c1e28d472ced9fe1caeac89843b58cfa'

--- a/packages/hasher.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hasher.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Hasher'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20230925</version>
+    <version>0.0.0.20240217</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>

--- a/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'hashmyfiles'
-  $category = 'Utilities'
+  $category = 'File Information'
 
   $zipUrl = "https://www.nirsoft.net/utils/hashmyfiles.zip"
   $zipUrl_64 = "https://www.nirsoft.net/utils/hashmyfiles-x64.zip"

--- a/packages/hashmyfiles.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hashmyfiles.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'hashmyfiles'
-$category = 'Utilities'
+$category = 'File Information'
 
 VM-Uninstall $toolName $category
 VM-Remove-From-Right-Click-Menu $toolName

--- a/packages/hollowshunter.vm/hollowshunter.vm.nuspec
+++ b/packages/hollowshunter.vm/hollowshunter.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hollowshunter.vm</id>
-    <version>0.3.8.20231115</version>
+    <version>0.3.8.20240217</version>
     <authors>hasherezade</authors>
     <description>Scans all running processes. Recognizes and dumps a variety of potentially malicious implants (replaced/implanted PEs, shellcodes, hooks, in-memory patches).</description>
     <dependencies>

--- a/packages/hollowshunter.vm/tools/chocolateyinstall.ps1
+++ b/packages/hollowshunter.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'hollows_hunter'
-$category = 'PE'
+$category = 'Memory'
 
 $zipUrl = 'https://github.com/hasherezade/hollows_hunter/releases/download/v0.3.8.1/hollows_hunter32.zip'
 $zipSha256 = 'c52859552dbbbf8409b207ebaf2e52ea605ffc6718c907428ef01065c2ed2948'

--- a/packages/hollowshunter.vm/tools/chocolateyuninstall.ps1
+++ b/packages/hollowshunter.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'hollows_hunter'
-$category = 'PE'
+$category = 'Memory'
 
 VM-Uninstall $toolName $category

--- a/packages/isd.vm/isd.vm.nuspec
+++ b/packages/isd.vm/isd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>isd.vm</id>
-    <version>1.5</version>
+    <version>1.5.0.20240217</version>
     <authors>VDisAsm</authors>
     <description>Inno Setup Decompiler</description>
     <dependencies>

--- a/packages/isd.vm/tools/chocolateyuninstall.ps1
+++ b/packages/isd.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Inno Setup Decompiler'
-$category = 'Utilities'
+$category = 'InnoSetup'
 
 VM-Uninstall $toolName $category

--- a/packages/microsoft-windows-terminal.vm/microsoft-windows-terminal.vm.nuspec
+++ b/packages/microsoft-windows-terminal.vm/microsoft-windows-terminal.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-windows-terminal.vm</id>
-    <version>1.19.10302</version>
+    <version>1.19.10302.20240217</version>
     <authors>Microsoft</authors>
     <description>Windows Terminal is a new, modern, feature-rich, productive terminal application for command-line users.</description>
     <dependencies>

--- a/packages/microsoft-windows-terminal.vm/tools/chocolateyinstall.ps1
+++ b/packages/microsoft-windows-terminal.vm/tools/chocolateyinstall.ps1
@@ -3,9 +3,10 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'Microsoft Windows Terminal'
+  $category = 'Productivity Tools'
   $executablePath = '%LocalAppData%\Microsoft\WindowsApps\wt.exe'
 
-  $shortcutDir = ${Env:RAW_TOOLS_DIR}
+  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $shortcut = Join-Path $shortcutDir "$toolName.lnk"
   # Create an admin shortcut that we can pin to the taskbar (analogous to the Admin Command Prompt for cmd.exe).
   Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin

--- a/packages/microsoft-windows-terminal.vm/tools/chocolateyuninstall.ps1
+++ b/packages/microsoft-windows-terminal.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,8 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Microsoft Windows Terminal'
-$shortcutDir = ${Env:RAW_TOOLS_DIR}
+$category = 'Productivity Tools'
+$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir "$toolName.lnk"
 
 Remove-Item $shortcut -Force -ea 0 | Out-Null

--- a/packages/nasm.vm/nasm.vm.nuspec
+++ b/packages/nasm.vm/nasm.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nasm.vm</id>
-    <version>2.16.1</version>
+    <version>2.16.1.20240217</version>
     <authors>NASM Authors</authors>
     <description>Netwide Assembler</description>
     <dependencies>

--- a/packages/nasm.vm/tools/chocolateyinstall.ps1
+++ b/packages/nasm.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'nasm'
-  $category = 'Utilities'
+  $category = 'Productivity Tools'
 
   # Delete Desktop shortcut
   $desktopShortcut = Join-Path ${Env:Public} "Desktop\$toolName.lnk"

--- a/packages/nasm.vm/tools/chocolateyuninstall.ps1
+++ b/packages/nasm.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'nasm'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 
 VM-Remove-Tool-Shortcut $toolName $category
 Uninstall-BinFile -Name $toolName

--- a/packages/offvis.vm/offvis.vm.nuspec
+++ b/packages/offvis.vm/offvis.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>offvis.vm</id>
-    <version>1.0</version>
+    <version>1.0.0.20240226</version>
     <authors>Microsoft</authors>
     <description>The Microsoft Office Visualization Tool (OffVis) is a tool from Microsoft that helps understanding the Microsoft Office binary file format in order to deconstruct .doc-, .xls- and .ppt-based targeted attacks.</description>
     <dependencies>

--- a/packages/offvis.vm/tools/chocolateyinstall.ps1
+++ b/packages/offvis.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'OffVis'
-$category = 'Office'
+$category = 'Documents'
 
 $zipUrl = 'https://download.microsoft.com/download/1/2/7/127ba59a-4fe1-4acd-ba47-513ceef85a85/OffVis.zip'
 $zipSha256 = '8432c2e81ab51bf46fc9a1b17629f4ff7c3902f976132477428b84918be08351'

--- a/packages/offvis.vm/tools/chocolateyuninstall.ps1
+++ b/packages/offvis.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'OffVis'
-$category = 'Office'
+$category = 'Documents'
 
 VM-Uninstall $toolName $category

--- a/packages/onenoteanalyzer.vm/onenoteanalyzer.vm.nuspec
+++ b/packages/onenoteanalyzer.vm/onenoteanalyzer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>onenoteanalyzer.vm</id>
-    <version>0.0.0.20231221</version>
+    <version>0.0.0.20240226</version>
     <authors>neeraj</authors>
     <description>A C# based tool for analyzing malicious OneNote documents.</description>
     <dependencies>

--- a/packages/onenoteanalyzer.vm/tools/chocolateyinstall.ps1
+++ b/packages/onenoteanalyzer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 try {
 
     $toolName = 'OneNoteAnalyzer'
-    $category = 'Office'
+    $category = 'Documents'
 
     $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
     $zipUrl = 'https://github.com/knight0x07/OneNoteAnalyzer/releases/download/OneNoteAnalyzer/OneNoteAnalyzer-withPass.zip'

--- a/packages/onenoteanalyzer.vm/tools/chocolateyuninstall.ps1
+++ b/packages/onenoteanalyzer.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'OneNoteAnalyzer'
-$category = 'Office'
+$category = 'Documents'
 
 VM-Remove-Tool-Shortcut $toolName $category
 VM-Uninstall $toolName $category

--- a/packages/pdfstreamdumper.vm/pdfstreamdumper.vm.nuspec
+++ b/packages/pdfstreamdumper.vm/pdfstreamdumper.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdfstreamdumper.vm</id>
-    <version>0.9.634</version>
+    <version>0.9.634.20240226</version>
     <authors>David Zimmer</authors>
     <description>PDFStreamDumper is a free, open source tool to analyze malicious PDF documents.</description>
     <dependencies>

--- a/packages/pdfstreamdumper.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdfstreamdumper.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'PDFStreamDumper'
-    $category = 'PDF'
+    $category = 'Documents'
 
     $exeUrl = 'http://sandsprite.com/flare_vm/PDFStreamDumper_Setup_C26068186F63DCCE9CC57502BE742C728110EAB07570C319A0D7D10587A6E22D.exe'
     $exeSha256 = 'c26068186f63dcce9cc57502be742c728110eab07570c319a0d7d10587a6e22d'

--- a/packages/pdfstreamdumper.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pdfstreamdumper.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'PDFStreamDumper'
-$category = 'PDF'
+$category = 'Documents'
 
 VM-Uninstall $toolName $category

--- a/packages/pesieve.vm/pesieve.vm.nuspec
+++ b/packages/pesieve.vm/pesieve.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pesieve.vm</id>
-    <version>0.3.8</version>
+    <version>0.3.8.20240217</version>
     <authors>hasherezade</authors>
     <description>pe-sieve recognizes and dumps variety of implants within the scanned process.</description>
     <dependencies>

--- a/packages/pesieve.vm/tools/chocolateyinstall.ps1
+++ b/packages/pesieve.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'pe-sieve'
-  $category = 'Utilities'
+  $category = 'Memory'
   $shimPath = 'bin\pe-sieve.exe'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/pesieve.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pesieve.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'pe-sieve'
-$category = 'Utilities'
+$category = 'Memory'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/powercat.vm/powercat.vm.nuspec
+++ b/packages/powercat.vm/powercat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powercat.vm</id>
-    <version>0.0.0.20230710</version>
+    <version>0.0.0.20240217</version>
     <authors>lukebaggett, besimorhino, nnamon, kjacobsen</authors>
     <description>PowerShell implementation of netcat functionality</description>
     <dependencies>

--- a/packages/powercat.vm/tools/chocolateyinstall.ps1
+++ b/packages/powercat.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'PowerCat'
-$category = 'Utilities'
+$category = 'Networking'
 
 $ps1Url = 'https://raw.githubusercontent.com/besimorhino/powercat/4bea00079084c7dbc52105ce5b5988b036821c92/powercat.ps1'
 $ps1Sha256 = 'c55672b5d2963969abe045fe75db52069d0300691d4f1f5923afeadf5353b9d2'

--- a/packages/powercat.vm/tools/chocolateyuninstall.ps1
+++ b/packages/powercat.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'PowerCat'
-$category = 'Utilities'
+$category = 'Networking'
 
 VM-Uninstall $toolName $category

--- a/packages/processdump.vm/processdump.vm.nuspec
+++ b/packages/processdump.vm/processdump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>processdump.vm</id>
-    <version>2.1.1.20220908</version>
+    <version>2.1.1.20240217</version>
     <authors>glmcdona</authors>
     <description>Process Dump is a Windows reverse-engineering command-line tool to dump malware memory components back to disk for analysis.</description>
     <dependencies>

--- a/packages/processdump.vm/tools/chocolateyinstall.ps1
+++ b/packages/processdump.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = "pd"
-  $category = "Utilities"
+  $category = "Memory"
 
   $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} 'Process-Dump'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/processdump.vm/tools/chocolateyuninstall.ps1
+++ b/packages/processdump.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = "pd"
-$category = "Utilities"
+$category = "Memory"
 
 VM-Remove-Tool-Shortcut ($toolName + "32") $category
 VM-Remove-Tool-Shortcut ($toolName + "64") $category

--- a/packages/reg_export.vm/reg_export.vm.nuspec
+++ b/packages/reg_export.vm/reg_export.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>reg_export.vm</id>
-    <version>1.3</version>
+    <version>1.3.0.20240217</version>
     <authors>Adam Kramer</authors>
     <description>A CLI that exports the raw content of a registry value to a file</description>
     <dependencies>

--- a/packages/reg_export.vm/tools/chocolateyinstall.ps1
+++ b/packages/reg_export.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'reg_export'
-$category = 'Utilities'
+$category = 'Registry'
 
 $exeUrl = 'https://github.com/adamkramer/reg_export/releases/download/v1.3/reg_export.exe'
 $exeSha256 = '0786cf26a63a059986fa7c568c1833825104e52565c17ff777f45d3118a8b274'

--- a/packages/reg_export.vm/tools/chocolateyuninstall.ps1
+++ b/packages/reg_export.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'reg_export'
-$category = 'Utilities'
+$category = 'Registry'
 
 VM-Uninstall $toolName $category

--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>1.361</version>
+    <version>1.361.0.20240228</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegCool'
-$category = 'Utilities'
+$category = 'Registry'
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
 $zipSha256 = '9b15369b688a5cabcf86f6ecc725d99678a60bf0c370bfd1b0d9cccf2eee9003'

--- a/packages/regcool.vm/tools/chocolateyuninstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegCool'
-$category = 'Utilities'
+$category = 'Registry'
 
 VM-Uninstall $toolName $category

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>registry_explorer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240226</version>
     <authors>Eric Zimmerman</authors>
     <description>Registry viewer with searching, multi-hive support, plugins, and more. Handles locked files</description>
     <dependencies>

--- a/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegistryExplorer'
-$category = 'Forensic'
+$category = 'Registry'
 
 $zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/RegistryExplorer.zip'
 $zipSha256 = '50a11bd0a5e44dcea6469b8564eb3f010b9a8faf323ff6481222d391da26887e'

--- a/packages/registry_explorer.vm/tools/chocolateyuninstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegistryExplorer'
-$category = 'Forensic'
+$category = 'Registry'
 
 VM-Uninstall $toolName $category

--- a/packages/regshot.vm/regshot.vm.nuspec
+++ b/packages/regshot.vm/regshot.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regshot.vm</id>
-    <version>1.9.1</version>
+    <version>1.9.1.20240217</version>
     <authors>maddes, regshot, xhmikosr</authors>
     <description>Regshot is a small, free and open-source registry compare utility that allows you to quickly take a snapshot of your registry and then compare it with a second one - done after doing system changes or installing a new software product.</description>
     <dependencies>

--- a/packages/regshot.vm/tools/chocolateyinstall.ps1
+++ b/packages/regshot.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Regshot-x64-Unicode'
-$category = 'Utilities'
+$category = 'Registry'
 
 $zipUrl = 'https://sourceforge.net/projects/regshot/files/regshot/1.9.1-beta/Regshot-1.9.1-beta_r321.7z'
 $zipSha256 = '5933d59f591e1e68ce7819904f8cb1118fc935bdfe89581599d0560ec9b97cd6'

--- a/packages/regshot.vm/tools/chocolateyuninstall.ps1
+++ b/packages/regshot.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Regshot-x64-Unicode'
-$category = 'Utilities'
+$category = 'Registry'
 
 VM-Uninstall $toolName $category

--- a/packages/scdbg.vm/scdbg.vm.nuspec
+++ b/packages/scdbg.vm/scdbg.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scdbg.vm</id>
-    <version>0.0.0.20230723</version>
+    <version>0.0.0.20240217</version>
     <authors>Paul Baecher, Markus Koetter, David Zimmer</authors>
     <description>scdbg is an emulation based shellcode API logger and debugger</description>
     <dependencies>

--- a/packages/scdbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/scdbg.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'scdbg'
-    $category = 'Debuggers'
+    $category = 'Shellcode'
 
     $zipUrl = 'http://sandsprite.com/flare_vm/VS_LIBEMU_7.26.23__D7A7B407A0FB2288655247FF3EDD361E767075B15D2F0554EB9C87BC4476D996.zip'
     $zipSha256 = 'D7A7B407A0FB2288655247FF3EDD361E767075B15D2F0554EB9C87BC4476D996'

--- a/packages/scdbg.vm/tools/chocolateyuninstall.ps1
+++ b/packages/scdbg.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'scdbg'
-$category = 'Debuggers'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category
 

--- a/packages/sclauncher.vm/sclauncher.vm.nuspec
+++ b/packages/sclauncher.vm/sclauncher.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sclauncher.vm</id>
-    <version>0.0.4</version>
+    <version>0.0.4.20240217</version>
     <authors>Josh Stroschein</authors>
     <description>A small program to load 32-bit shellcode and allow for execution or debugging. Can also output PE files from shellcode.</description>
     <dependencies>

--- a/packages/sclauncher.vm/tools/chocolateyinstall.ps1
+++ b/packages/sclauncher.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SCLauncher'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 $exeUrl = 'https://github.com/jstrosch/sclauncher/releases/download/v0.0.4/sclauncher.exe'
 $exeSha256 = '524f56087655c9367e2c58f79fa2bd9c4c6be48e3328cfca3d62285f11335329'

--- a/packages/sclauncher.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sclauncher.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SCLauncher'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category

--- a/packages/sclauncher64.vm/sclauncher64.vm.nuspec
+++ b/packages/sclauncher64.vm/sclauncher64.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sclauncher64.vm</id>
-    <version>0.0.4</version>
+    <version>0.0.4.20240217</version>
     <authors>Josh Stroschein</authors>
     <description>A small program to load 64-bit shellcode and allow for execution or debugging. Can also output PE files from shellcode.</description>
     <dependencies>

--- a/packages/sclauncher64.vm/tools/chocolateyinstall.ps1
+++ b/packages/sclauncher64.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SCLauncher64'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 $exeUrl = 'https://github.com/jstrosch/sclauncher/releases/download/v0.0.4/sclauncher64.exe'
 $exeSha256 = 'c05f654e52a61be7f1a7ae94b0b408796732c145426be0e3de825b241b6054c5'

--- a/packages/sclauncher64.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sclauncher64.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SCLauncher64'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category

--- a/packages/shellcode_launcher.vm/shellcode_launcher.vm.nuspec
+++ b/packages/shellcode_launcher.vm/shellcode_launcher.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>shellcode_launcher.vm</id>
-    <version>0.0.0</version>
+    <version>0.0.0.20240217</version>
     <authors>Jay Smith</authors>
     <description>Shellcode launcher utility</description>
     <dependencies>

--- a/packages/shellcode_launcher.vm/tools/chocolateyinstall.ps1
+++ b/packages/shellcode_launcher.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'shellcode_launcher'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 $exeUrl = 'https://github.com/clinicallyinane/shellcode_launcher/raw/7f55d42a9253c58083d163512e23019df0573420/shellcode_launcher.exe'
 $exeSha256 = 'fc7c0272170b52c907f316d6fde0a9fe39300678d4a629fa6075e47d7f525b67'

--- a/packages/shellcode_launcher.vm/tools/chocolateyuninstall.ps1
+++ b/packages/shellcode_launcher.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'shellcode_launcher'
-$category = 'Utilities'
+$category = 'Shellcode'
 
 VM-Uninstall $toolName $category

--- a/packages/tor-browser.vm/tools/chocolateyinstall.ps1
+++ b/packages/tor-browser.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'Tor Browser'
-  $category = 'Utilities'
+  $category = 'Productivity Tools'
   $shimPath = '\lib\tor-browser\tools\tor-browser\Browser\firefox.exe'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/tor-browser.vm/tools/chocolateyuninstall.ps1
+++ b/packages/tor-browser.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Tor Browser'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/tor-browser.vm/tor-browser.vm.nuspec
+++ b/packages/tor-browser.vm/tor-browser.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>tor-browser.vm</id>
-    <version>13.0.10</version>
+    <version>13.0.10.20240226</version>
     <authors>Tor Project</authors>
     <description>The Tor software protects you by bouncing your communications around a distributed network of relays run by volunteers all around the world.</description>
     <dependencies>

--- a/packages/total-registry.vm/tools/chocolateyinstall.ps1
+++ b/packages/total-registry.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'TotalReg'
-$category = 'Utilities'
+$category = 'Registry'
 
 $exeUrl = 'https://github.com/zodiacon/TotalRegistry/releases/download/v0.9.7.8/TotalReg.exe'
 $exeSha256 = 'ad3db638738eb5433fec88ad6b3954e55f9ce3f8dcba45256d70f78b3d6dff8c'

--- a/packages/total-registry.vm/tools/chocolateyuninstall.ps1
+++ b/packages/total-registry.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'TotalReg'
-$category = 'Utilities'
+$category = 'Registry'
 
 VM-Uninstall $toolName $category

--- a/packages/total-registry.vm/total-registry.vm.nuspec
+++ b/packages/total-registry.vm/total-registry.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>total-registry.vm</id>
-    <version>0.9.7.20240227</version>
+    <version>0.9.7.20240228</version>
     <authors>Pavel Yosifovich</authors>
     <description>Replacement for the Windows built-in Regedit.exe tool with improved features.</description>
     <dependencies>

--- a/packages/vbdec.vm/tools/chocolateyinstall.ps1
+++ b/packages/vbdec.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'vbdec'
-    $category = 'VB'
+    $category = 'Visual Basic'
 
     $exeUrl = 'http://sandsprite.com/flare_vm/VBDEC_Setup_983E127DB204A3E50723E4A30D80EF8C.exe'
     $exeSha256 = 'E6FA33F1D8C51214B1B6E49665F1EDBCBF05399D57CC2A04CED0A74A194ADA63'

--- a/packages/vbdec.vm/tools/chocolateyuninstall.ps1
+++ b/packages/vbdec.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'vbdec'
-$category = 'VB'
+$category = 'Visual Basic'
 
 # Silently uninstall
 VM-Uninstall-With-Uninstaller $toolName "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"

--- a/packages/vbdec.vm/vbdec.vm.nuspec
+++ b/packages/vbdec.vm/vbdec.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vbdec.vm</id>
-    <version>1.0.917</version>
+    <version>1.0.917.20240217</version>
     <authors>vbGamer45, David Zimmer</authors>
     <description>VBDec works as a VB6 disassembler, PCode debugger, structure viewer for all vb6 executables, and can generate IDA scripts to integrate structures and named function offsets.</description>
     <dependencies>

--- a/packages/vcbuildtools.vm/tools/chocolateyinstall.ps1
+++ b/packages/vcbuildtools.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $category = 'Utilities'
+  $category = 'Productivity Tools'
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
   $programFiles = ${Env:ProgramFiles(x86)}

--- a/packages/vcbuildtools.vm/tools/chocolateyuninstall.ps1
+++ b/packages/vcbuildtools.vm/tools/chocolateyuninstall.ps1
@@ -1,5 +1,5 @@
 ﻿$ErrorActionPreference = 'Continue'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 $shortcut = Join-Path $shortcutDir 'Microsoft Visual C++ Build Tools.lnk'
 Remove-Item $shortcut -Force -ea 0 | Out-Null

--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20231020</version>
+    <version>0.0.0.20240217</version>
     <description>Metapackage that requires the dependencies below:
 - visualstudio2017buildtools
 - visualstudio2017-workload-vctools

--- a/packages/visualstudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     $toolName = 'VisualStudio'
-    $category = 'Utilities'
+    $category = 'Productivity Tools'
 
     # Install with choco instead as dependency to provide params to add common components
     # The community package chocolatey-visualstudio.extension 1.11 includes a -DefaultParameterValues parameter

--- a/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'VisualStudio'
-$category = 'Utilities'
+$category = 'Productivity Tools'
 
 VM-Remove-Tool-Shortcut $toolName $category
 

--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1.20230703</version>
+    <version>17.6.1.20240217</version>
     <description>IDE.</description>
     <authors>Microsoft</authors>
     <dependencies>

--- a/packages/vscode.vm/tools/chocolateyinstall.ps1
+++ b/packages/vscode.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $toolName = 'VSCode'
-  $category = 'Text Editors'
+  $category = 'Productivity Tools'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $shortcut = Join-Path $shortcutDir "$toolName.lnk"

--- a/packages/vscode.vm/tools/chocolateyuninstall.ps1
+++ b/packages/vscode.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'VSCode'
-$category = 'Text Editors'
+$category = 'Productivity Tools'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/vscode.vm/vscode.vm.nuspec
+++ b/packages/vscode.vm/vscode.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscode.vm</id>
-    <version>1.85.2.20240223</version>
+    <version>1.85.2.20240226</version>
     <authors>Microsoft</authors>
     <description>VSCode is a modern, open-source code editor.</description>
     <dependencies>

--- a/packages/wireshark.vm/tools/chocolateyinstall.ps1
+++ b/packages/wireshark.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $toolName = 'wireshark'
+  $toolName = 'Wireshark'
   $category = 'Networking'
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/wireshark.vm/tools/chocolateyuninstall.ps1
+++ b/packages/wireshark.vm/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'wireshark'
+$toolName = 'Wireshark'
 $category = 'Networking'
 
 VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/wireshark.vm/wireshark.vm.nuspec
+++ b/packages/wireshark.vm/wireshark.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wireshark.vm</id>
-    <version>4.2.3</version>
+    <version>4.2.3.20240217</version>
     <description>Wireshark lets you capture and interactively browse the traffic running on a computer network.</description>
     <authors>Gerald Combs, Wireshark team</authors>
     <dependencies>


### PR DESCRIPTION
This mostly addresses things in https://github.com/mandiant/VM-Packages/issues/883, but not everything, as I did not remove any of the CommandVM categories as of yet. 

This does fix the following issues:
https://github.com/mandiant/VM-Packages/issues/880
https://github.com/mandiant/VM-Packages/issues/881
https://github.com/mandiant/VM-Packages/issues/882
https://github.com/mandiant/VM-Packages/issues/884
https://github.com/mandiant/VM-Packages/issues/885

I moved `Burp Suite` to `Web Applications`, so that is now being used.

I removed `Text Editors` in place of `Productivity Tools` and `Python` didn't really exist anymore, but it was still an option somewhere, so I removed that as well.

I changed the name for `VB` to be `Visual Basic` just for a little bit more clarity.

I added the following categories: `Memory`, `Shellcode`, `File Information`, `Productivity Tools`, `Registry`

Also a few other fixes/reorganizations.