### PR TITLE
[CI] Update packages number badge in README

### DIFF
--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -1,0 +1,26 @@
+name: Updates packages number badge on README
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update_badge:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Update packages number badge in README
+        run: |
+          # Counts all packages in /packages including installer.vm
+          num_packages=$(ls packages | wc -l)
+          sed -i "s/badge\/packages-[0-9]*-blue\.svg/badge\/packages-$num_packages-blue.svg/" README.md
+      - name: Commit changes
+        run: |
+          git config user.email 'vm-packages@mandiant.com'
+          git config user.name 'vm-packages'
+          # Do not fail the action if packages number doesn't change
+          git add -A
+          git diff-index --quiet HEAD || git commit -am '[README] Update package number badge'
+      - name: Push changes
+        uses: ad-m/github-push-action@master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Packages](https://img.shields.io/badge/packages->100-blue.svg)](packages)
+[![Packages](https://img.shields.io/badge/packages-212-blue.svg)](packages)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 [![Daily run](https://github.com/mandiant/VM-packages/workflows/daily/badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 


### PR DESCRIPTION
Automatically update the number of packages in the badge in the README when merging a PR. Note this is a bit noisy and requires skipping branch protections for our bot, but it is the only way to get an updated exact number in the README badge. We have been doing it in this way in capa for a long time.

Closes https://github.com/mandiant/VM-Packages/issues/455