### PR TITLE
[VM-Clean-Up] Sort Desktop icons by type

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240123</version>
+    <version>0.0.0.20240220</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1288,6 +1288,16 @@ public class Shell {
     }
 }
 
+# Sort Desktop icons by item type using WScript.Shell to replicate the manual steps
+function VM-Sort-Desktop-Icons {
+    VM-Write-Log "INFO" "Sorting Desktop icons"
+    (New-Object -ComObject Shell.Application).toggleDesktop();
+    Start-Sleep -Milliseconds 100;
+    $objShell = New-Object -ComObject WScript.Shell;
+    $objShell.SendKeys("^a {F5}+{F10}oi");
+    Start-Sleep -Milliseconds 100;
+}
+
 # Usage example:
 # VM-Remove-DesktopFiles -excludeFolders "Labs", "Demos" -excludeFiles "MICROSOFT Windows 10 License Terms.txt", "Labs.zip"
 # The function is run against both the Current User and 'Public' desktops due to some cases where desktop icons showing on
@@ -1327,6 +1337,8 @@ function VM-Remove-DesktopFiles {
             }
         }
     }
+
+    VM-Sort-Desktop-Icons
 }
 
 function VM-Clear-TempAndCache {


### PR DESCRIPTION
Introduce `VM-Sort-Desktop-Icons` to sort Desktop icons by type using `WScript.Shell` to replicate the manual steps using the keyboard. This function is called from `VM-Remove-DesktopFiles` (called from `VM-Clean-Up`) to avoid leaving empty spaces after removing Desktop icons.

I would appreciate if someone could also test this code locally. Note you don't need to install the whole FLARe-VM or even the modified package to test the changes. It is enough to copy the functions `VM-Remove-DesktopFiles` and `VM-Remove-DesktopFiles` from the modified `packages/common.vm/tools/vm.common/vm.common.psm1`.

I am using Windows 10 and I am not sure if this code works in Windows 11 and we should prevent from running it in Windows 11 (or add a version for Windows 11). Note this code has to be run manually (by running `VM-Clean-Up` that the FLARE team is using to automate FLARE-VM builds) and is not part of the installer.

Closes https://github.com/mandiant/VM-Packages/issues/902