### PR TITLE
[CI] Use bot token for better branch protection

### DIFF
--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -24,3 +24,5 @@ jobs:
           git diff-index --quiet HEAD || git commit -am '[README] Update package number badge'
       - name: Push changes
         uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
We need to use our bot token and give the bot permissions to push to main to keep the general protection of the main branch.