### PR TITLE
[CI] Use dynamic badge for package number

### DIFF
--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -10,19 +10,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Update packages number badge in README
+      - name: Count packages
         run: |
           # Counts all packages in /packages including installer.vm
           num_packages=$(ls packages | wc -l)
-          sed -i "s/badge\/packages-[0-9]*-blue\.svg/badge\/packages-$num_packages-blue.svg/" README.md
-      - name: Commit changes
-        run: |
-          git config user.email 'vm-packages@mandiant.com'
-          git config user.name 'vm-packages'
-          # Do not fail the action if packages number doesn't change
-          git add -A
-          git diff-index --quiet HEAD || git commit -am '[README] Update package number badge'
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+          echo "num_packages=$num_packages" >> $GITHUB_ENV
+      - name: Update dynamic badge gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          auth: ${{ secrets.REPO_TOKEN }}
+          gistID: 0e28118f551692f3401ac669e1d6761d
+          filename: packages_badge.svg
+          label: packages
+          message: ${{ env.num_packages }}
+          color: blue

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Packages](https://img.shields.io/badge/packages-212-blue.svg)](packages)
+[![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](packages)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 [![Daily run](https://github.com/mandiant/VM-packages/workflows/daily/badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 


### PR DESCRIPTION
The static badge with the packages number in the README needs to be updated via commits to the main branch. This is noisy in the commit history and requires to modify the main branch protections to disable _Require status checks to pass before merging_. 
![Screenshot 2024-02-21 at 12 51 49](https://github.com/mandiant/VM-Packages/assets/16052290/8519f239-641c-451e-8959-cafc1800365a)



VM-Packages relies on the linter and the windows-2022 test to push packages to MyGet. Relaxing the protections may break this workflow, so I think it is a bad to relax the protections just to update a badge.

A much better solution is to replace the static badge by a dynamic badge which uses a gist in out bot account and update this gist in the `sync_badge.yml` workflow every time a PR is merged.

![Screenshot 2024-02-21 at 12 51 25](https://github.com/mandiant/VM-Packages/assets/16052290/347fd351-ca76-4416-8931-19bb17075688)
