### PR TITLE
[CI] Use dynamic badges for daily run failures

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,11 +16,15 @@ jobs:
       max-parallel: 1
       matrix:
         os: [windows-2019, windows-2022]
+        include:
+          - os: windows-2022
+            os_name: Win22
+          - os: windows-2019
+            os_name: Win19
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Build and test all packages
-        id: test
         run: scripts/test/test_install.ps1 -all -max_tries 3
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
@@ -36,9 +40,35 @@ jobs:
         run: python scripts/utils/generate_daily_results.py ${{ github.repository }} ${{ github.sha }} ${{ github.run_number }} ${{ github.run_id }} ${{ matrix.os }}
       - name: Commit changes
         if: always()
+        working-directory: wiki
         run: |
-          cd wiki
           git config user.email 'vm-packages@mandiant.com'
           git config user.name 'vm-packages'
           git commit -am 'Add daily results'
           git push
+      - name: Get badge info
+        if: always()
+        run: |
+          pwd
+          $json = Get-Content -Raw "success_failure.json" | ConvertFrom-Json
+          $failure = $json.failure
+          $total = $json.total
+          $message = "$failure/$total"
+          # Celebrate that there are not failures
+          if (-not $failure) { $message += " 🎉" }
+          echo "failure=$failure" >> $env:GITHUB_ENV
+          echo "message=$message" >> $env:GITHUB_ENV
+      - name: Update dynamic badge gist
+        if: always()
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.REPO_TOKEN }}
+          gistID: 7d6b2592948d916eb5529350308f01d1
+          filename: ${{ matrix.os }}_daily_badge.svg
+          label: "failures ${{ matrix.os_name }}"
+          message: "${{ env.message }}"
+          # Use orange if only 1 package fails and red if more than 1 fail
+          maxColorRange: 1.25
+          minColorRange: 0
+          invertColorRange: true
+          valColorRange: ${{ env.failure }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](packages)
+[![Daily run failures Windows 2022](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2022_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
+[![Daily run failures Windows 2019](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2019_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
-[![Daily run](https://github.com/mandiant/VM-packages/workflows/daily/badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 
 # Virtual Machine Packages
 


### PR DESCRIPTION
Use dynamic badges to display the number of failures and total tested packages in the Windows 2019 and 2022 daily jobs. The dynamic badge is implemented using gists in our bot account that are updated in the `daily.yml` workflow.

#### Screenshots of examples of how it looks like:
![Screenshot 2024-02-21 at 17 54 08](https://github.com/mandiant/VM-Packages/assets/16052290/ae240726-147c-4fa3-becd-f39df1bd632f)
![Screenshot 2024-02-21 at 17 55 38](https://github.com/mandiant/VM-Packages/assets/16052290/4c8092dc-44e4-4e47-b467-b0f4b233e53f)
