### PR TITLE
[arsenalimagemounter] Do not update dotnet-8

### DIFF
--- a/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
+++ b/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>arsenalimagemounter.vm</id>
-    <version>3.11.279.20240220</version>
+    <version>3.11.279.20240222</version>
     <authors>Arsenal Recon</authors>
     <description>Mounts the contents of disk images as complete disks in Windows.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="dotnet-8.0-desktopruntime" version="[8.0.1]" />
+      <dependency id="dotnet-8.0-desktopruntime" version="[8, 8.0.3)" />
       <dependency id="arsenalimagemounter" version="[3.11.279]" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Allow to use several version of dotnet-8 and use a format that prevents out bot from updating this dependency, similarly as we do in the dotnet-6.vm package. Updating dotnet-8 is noisy and we do not get any feature improvements with it.