### PR TITLE
[bug] Correct version in installer.vm

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20230110</version>
+    <version>0.0.0.20240110</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>


### PR DESCRIPTION
I used the wrong year (typo) when last updating the installer, which means that this version of the installer is not being used as it is not the higher version. I'll remove version `0.0.0.20230110` from MyGet. 

Related: https://github.com/mandiant/VM-Packages/issues/659