### PR TITLE
[CI] Update actions to use immutable release and non deprecated version of Node

### DIFF
--- a/.github/actions/upload-logs/action.yml
+++ b/.github/actions/upload-logs/action.yml
@@ -5,13 +5,13 @@ runs:
   using: "composite"
   steps:
     - name: Upload VM logs to artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: always()
       with:
         name: log-VM-${{ matrix.os }}.zip
         path: C:\ProgramData\_VM\log.txt
     - name: Upload chocolatey logs to artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       if: always()
       with:
         name: logs-choco-${{ matrix.os }}.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Get changed files
         id: files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
         with:
           filter: '*.nuspec'
       - name: Build and test all modified packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           # fetch all history for all branches
           fetch-depth: 0
@@ -29,7 +29,7 @@ jobs:
         os: [windows-2019, windows-2022]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Get changed files
         id: files
         uses: Ana06/get-changed-files@v2.2.0

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -60,7 +60,7 @@ jobs:
           echo "message=$message" >> $env:GITHUB_ENV
       - name: Update dynamic badge gist
         if: always()
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.REPO_TOKEN }}
           gistID: 7d6b2592948d916eb5529350308f01d1

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,7 +23,7 @@ jobs:
             os_name: Win19
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test all packages
         run: scripts/test/test_install.ps1 -all -max_tries 3
       - name: Upload logs to artifacts
@@ -31,7 +31,7 @@ jobs:
         if: always()
       - name: Checkout wiki code
         if: always()
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki

--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/upload-logs
         if: always()
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         if: steps.test.outcome == 'success'
         with:
           title: ':robot: Add ${{env.pkg_name}}.vm'

--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           labels: send PR
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Parse issue
         uses: stefanbuck/github-issue-parser@v2
         id: issue-parser

--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Parse issue
-        uses: stefanbuck/github-issue-parser@v2
+        uses: stefanbuck/github-issue-parser@1e5bdee70d4b3e066a33aa0669ab782943825f94 # v3.1.0
         id: issue-parser
         with:
           template-path: .github/ISSUE_TEMPLATE/new_package.yml

--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.label.name == 'send PR'
     steps:
       - name: Remove 'send PR' label
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: send PR
       - name: Checkout code

--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -16,7 +16,7 @@ jobs:
           num_packages=$(ls packages | wc -l)
           echo "num_packages=$num_packages" >> $GITHUB_ENV
       - name: Update dynamic badge gist
-        uses: schneegans/dynamic-badges-action@v1.7.0
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.REPO_TOKEN }}
           gistID: 0e28118f551692f3401ac669e1d6761d

--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Count packages
         run: |
           # Counts all packages in /packages including installer.vm

--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -57,7 +57,7 @@ jobs:
         uses: ./.github/actions/upload-logs
         if: always()
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         with:
           title: ':robot: Package update'
           body: 'Automated package update'

--- a/.github/workflows/update_package.yml
+++ b/.github/workflows/update_package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install python dependency 'requests'
         run: pip install requests
       - name: Set git up


### PR DESCRIPTION
Update actions to use an immutable release by using a full length commit SHA to mitigate security risk: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Update actions to its latest version. Some of them where using a deprecated version of Node: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20 Now all use Node 20 with the exception of `actions-ecosystem/action-remove-labels`, which is using the old Note 12 and is being forced by GH to run in th deprecated Node 16: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12 It should be updated to Node 20 (https://github.com/actions-ecosystem/action-remove-labels/issues/413#issuecomment-1969516668), but it seems to still work fine.