### PR TITLE
[installer] Fix creation of Admin Command Prompt

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20240110</version>
+    <version>0.0.0.20240304</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -42,7 +42,7 @@ try {
         $shortcutDir = ${Env:RAW_TOOLS_DIR}
         $shortcut = Join-Path $shortcutDir "$toolName.lnk"
         $workingDir  = Join-Path ${Env:UserProfile} "Desktop"
-        $target = "$executablePath /k `"$workingDir`""
+        $target = "$executablePath /k `"cd $workingDir`""
 
         Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $target -RunAsAdmin
         VM-Assert-Path $shortcut


### PR DESCRIPTION
Fix argument in the creation of Admin Command Prompt (added to FLARE-VM taskbar) that fails the installation of `installer.vm`. The bug was introduced in https://github.com/mandiant/VM-Packages/pull/818, but it was not used until the version was fixed 5 days ago in https://github.com/mandiant/VM-Packages/pull/925.

Fixes https://github.com/mandiant/flare-vm/issues/573