### PR TITLE
[installer] Fix creation of Admin Command Prompt

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20240304</version>
+    <version>0.0.0.20240305</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -42,9 +42,9 @@ try {
         $shortcutDir = ${Env:RAW_TOOLS_DIR}
         $shortcut = Join-Path $shortcutDir "$toolName.lnk"
         $workingDir  = Join-Path ${Env:UserProfile} "Desktop"
-        $target = "$executablePath /k `"cd $workingDir`""
+        $arguments = "/k `"cd `"$workingDir`"`""
 
-        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $target -RunAsAdmin
+        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -Arguments $arguments -RunAsAdmin
         VM-Assert-Path $shortcut
 
         Import-StartLayout -LayoutPath $customLayout -MountPath "C:\"


### PR DESCRIPTION
Fix argument in the creation of the Admin Command Prompt shortcut (added to the FLARE-VM taskbar) that fails the installation of `installer.vm`. The bug was introduced in https://github.com/mandiant/VM-Packages/pull/818, but it was not used until the version was fixed 5 days ago in https://github.com/mandiant/VM-Packages/pull/925.

I tried to fix this issue in https://github.com/mandiant/VM-Packages/pull/931 :see_no_evil: I should have tested that properly. Sorry for that. I have tested this change locally (by using our `test_install.ps1` script removing the `installer.vm` exception).

Fixes https://github.com/mandiant/flare-vm/issues/573