### PR TITLE
[pesieve] Use shortcut helper & console app

### DIFF
--- a/packages/pesieve.vm/pesieve.vm.nuspec
+++ b/packages/pesieve.vm/pesieve.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pesieve.vm</id>
-    <version>0.3.9</version>
+    <version>0.3.9.20240305</version>
     <authors>hasherezade</authors>
     <description>pe-sieve recognizes and dumps variety of implants within the scanned process.</description>
     <dependencies>

--- a/packages/pesieve.vm/tools/chocolateyinstall.ps1
+++ b/packages/pesieve.vm/tools/chocolateyinstall.ps1
@@ -6,11 +6,8 @@ try {
   $category = 'Memory'
   $shimPath = 'bin\pe-sieve.exe'
 
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
   $executablePath = Join-Path ${Env:ChocolateyInstall} $shimPath -Resolve
-  Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin
-  VM-Assert-Path $shortcut
+  VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -RunAsAdmin
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
Change pe-sieve to use `VM-Install-Shortcut` to create the shortcut for consistency with other tools. Add the `consoleApp` option to keep the console open after executing pe-sieve.