### PR TITLE
[create_package_template] Improve template

### DIFF
--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -113,11 +113,8 @@ try {{
   $category = '{category}'
   $shimPath = '{shim_path}'
 
-  $shortcutDir = Join-Path ${{Env:TOOL_LIST_DIR}} $category
-  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
   $executablePath = Join-Path ${{Env:ChocolateyInstall}} $shimPath -Resolve
   VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -runAsAdmin
-  VM-Assert-Path $shortcut
 }} catch {{
   VM-Write-Log-Exception $_
 }}


### PR DESCRIPTION
Improve metapackage template in `create_package_template.py` by removing unnecessary and unused code. Note `VM-Install-Shortcut` already executes `VM-Assert-Path $shortcut` to verify that the shortcut has been created.

The CI would fail any package created with the previous template as the linter would complain about unused variables.