### PR TITLE
[sysinternals.vm] Add tools to PATH & fix exception order

### DIFF
--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>0.0.0.20240112</version>
+    <version>0.0.0.20240306</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite.</description>
     <dependencies>

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -28,6 +28,8 @@ try {
 }
 
 try {
+    # Add sysinternals tools to path
+    Install-ChocolateyPath $toolDir
     # Add shortcut to sysinternals folder
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
     $shortcut = Join-Path $shortcutDir 'sysinternals.lnk'

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -22,9 +22,9 @@ try {
         VM-Assert-Signature $_.FullName
     }
 } catch {
-  VM-Write-Log-Exception $_
-  # Remove files with invalid signature
-  Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
+    # Remove files with invalid signature
+    Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
+    VM-Write-Log-Exception $_
 }
 
 try {


### PR DESCRIPTION
- Sysinternals tools are not added to PATH since we rewrote the package to use signatures instead of checking the hash. This also affects `VM-Clean-Up`. 
- Fix exception order & indentation, as I think tools need to removed before re-raising the exception.


Closes https://github.com/mandiant/VM-Packages/issues/943