### PR TITLE
Fix broken memprocfs download link

### DIFF
--- a/packages/memprocfs.vm/memprocfs.vm.nuspec
+++ b/packages/memprocfs.vm/memprocfs.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>memprocfs.vm</id>
-    <version>5.8.17</version>
+    <version>5.9.4</version>
     <authors>Ulf Frisk</authors>
     <description>MemProcFS is an easy and convenient way of viewing physical memory as files in a virtual file system.</description>
     <dependencies>

--- a/packages/memprocfs.vm/tools/chocolateyinstall.ps1
+++ b/packages/memprocfs.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MemProcFS'
 $category = 'Forensic'
 
-$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5_archive/MemProcFS_files_and_binaries_v5.8.17-win_x64-20231128.zip'
-$zipSha256 = '22196c8fdd09db229ed8ee649e56b406a5f8dd43f7728cfe13cd1618aaef7085'
+$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5_archive/MemProcFS_files_and_binaries_v5.9.4-win_x64-20240318.zip'
+$zipSha256 = 'd63b2e3ee2b67abf9e119bd912bb2e595ddba96abf4f8b19255157c889c516ac'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false


### PR DESCRIPTION
The download link of the 5.8.17 version does not exist anymore and has to be replaced with the newest release 5.9.3.
I updated the version in the `nuspec`, the `zipUrl` and `zipSha256`.
I tested it on my own VM and after the changes the package installed with no problems.


(I did not create an Issue because it was in the Daily Failures)