### PR TITLE
Update complete message allowing non-interactive installation

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20240305</version>
+    <version>0.0.0.20240321</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -194,55 +194,11 @@ public class VMBackground
         VM-Write-Log-Exception $_
     }
 
-    # Show dialog that install has been complete
-    Add-Type -AssemblyName System.Windows.Forms
-    Add-Type -AssemblyName System.Drawing
-    # Create form
-    $form = New-Object System.Windows.Forms.Form
-    $form.Text = "$Env:VMname Installation Complete"
-    $form.TopMost = $true
-    $form.StartPosition = [System.Windows.Forms.FormStartPosition]::CenterScreen
-    $iconPath = Join-Path $Env:VM_COMMON_DIR "vm.ico"
-    if (Test-Path $iconPath) {
-        $form.Icon = New-Object System.Drawing.Icon($iconPath)
-    }
-    # Create a FlowLayoutPanel
-    $flowLayout = New-Object System.Windows.Forms.FlowLayoutPanel
-    $flowLayout.FlowDirection = [System.Windows.Forms.FlowDirection]::TopDown
-    $flowLayout.Dock = [System.Windows.Forms.DockStyle]::Fill
-    $flowLayout.AutoSize = $true
-    # Create label
-    $label = New-Object System.Windows.Forms.Label
-    $label.Text = @"
-Install Complete!
-
-Please review %VM_COMMON_DIR%\log.txt for any errors.
-
-For any package related issues, please submit to github.com/mandiant/vm-packages
-
-For any install related issues, please submit to the VM repo
-
-Thank you!
-"@
-    $label.AutoSize = $true
-    $label.Font = New-Object System.Drawing.Font("Microsoft Sans Serif", 10, [System.Drawing.FontStyle]::Regular)
-    # Create button
-    $button = New-Object System.Windows.Forms.Button
-    $button.Text = "Finish"
-    $button.DialogResult = [System.Windows.Forms.DialogResult]::OK
-    $button.AutoSize = $true
-    $button.Font = New-Object System.Drawing.Font("Microsoft Sans Serif", 10, [System.Drawing.FontStyle]::Regular)
-    $button.Anchor = [System.Windows.Forms.AnchorStyles]::None
-    # Add controls to the FlowLayoutPanel
-    $flowLayout.Controls.Add($label)
-    $flowLayout.Controls.Add($button)
-    # Add the FlowLayoutPanel to the form
-    $form.Controls.Add($flowLayout)
-    # Auto-size form to fit content
-    $form.AutoSize = $true
-    $form.AutoSizeMode = [System.Windows.Forms.AutoSizeMode]::GrowAndShrink
-    # Show dialog
-    $form.ShowDialog()
+    VM-Write-Log "INFO" "[*] Install Complete!"
+    VM-Write-Log "INFO" "[*] Please review %VM_COMMON_DIR%\log.txt for any errors."
+    VM-Write-Log "INFO" "[*] For any package related issues, please submit to github.com/mandiant/vm-packages"
+    VM-Write-Log "INFO" "[*] For any install related issues, please submit to the VM repo"
+    VM-Write-Log "INFO" "[*] Thank you!"
 
 } catch {
     VM-Write-Log-Exception $_


### PR DESCRIPTION
Dialog box requires human interaction when the installation completes. During an unattended installation, the Powershell script will hang forever without signalling the right exit code.

`Write-Host` will not force human interaction allowing fully automated installation.

This aims to fix the issue I have encoutered/reported in https://github.com/mandiant/VM-Packages/issues/955