### PR TITLE
Merge Install-Raw-Github-Repo and Install-From-Zip

### DIFF
--- a/packages/adconnectdump.vm/adconnectdump.vm.nuspec
+++ b/packages/adconnectdump.vm/adconnectdump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>adconnectdump.vm</id>
-    <version>0.0.0.20230710</version>
+    <version>0.0.0.20240323</version>
     <authors>fox-it</authors>
     <description>This toolkit offers several ways to extract and decrypt stored Azure AD and Active Directory credentials from Azure AD Connect servers.</description>
     <dependencies>

--- a/packages/adconnectdump.vm/tools/chocolateyinstall.ps1
+++ b/packages/adconnectdump.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/fox-it/adconnectdump/archive/3ff6ebe7afac83263dd41857fdec51dcca0012b4.zip'
 $zipSha256 = '6f36659f4d0ef7e20ddea0d7c17f36786c2fa8ca0728e6fd790f3234f408e0e9'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/asreproast.vm/asreproast.vm.nuspec
+++ b/packages/asreproast.vm/asreproast.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>asreproast.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>HarmJ0y</authors>
     <description>Project that retrieves crackable hashes from KRB5 AS-REP responses for users without kerberoast preauthentication enabled.</description>
     <dependencies>

--- a/packages/asreproast.vm/tools/chocolateyinstall.ps1
+++ b/packages/asreproast.vm/tools/chocolateyinstall.ps1
@@ -8,4 +8,4 @@ $zipUrl = 'https://codeload.github.com/HarmJ0y/ASREPRoast/zip/1c94ef12038df1378f
 $zipSha256 = '3e90bb0755f9076e74ad749a188ad99b9dc11f197d4366a8eaa4f056953e4cab'
 $powershellCommand = "Import-Module .\ASREPRoast.ps1; Get-Help Invoke-ASREPRoast"
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
+++ b/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound-custom-queries.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>hausec</authors>
     <description>Custom Query list for the Bloodhound GUI based off my cheatsheet</description>
     <dependencies>

--- a/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
+++ b/packages/bloodhound-custom-queries.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/hausec/Bloodhound-Custom-Queries/archive/7ef9099665aa82238bfd57d7a11c09cd4dd9381b.zip'
 $zipSha256 = '78a71b9797506200b4c86bdad6799ba8c3519171353ce329dff5ff4fc703ddb0'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/c3.vm/c3.vm.nuspec
+++ b/packages/c3.vm/c3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>c3.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>WithSecureLabs</authors>
     <description>C3 (Custom Command and Control) is a tool that allows Red Teams to rapidly develop and utilise esoteric command and control channels (C2). It's a framework that extends other red team tooling, such as the commercial Cobalt Strike (CS) product via ExternalC2.</description>
     <dependencies>

--- a/packages/c3.vm/tools/chocolateyinstall.ps1
+++ b/packages/c3.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Command & Control'
 $zipUrl = 'https://github.com/WithSecureLabs/C3/archive/e1b9922d199e45e222001a3afe47757349f24e7a.zip'
 $zipSha256 = '8dd29ed32c2a38312b617c430ff84019da8bd434e3704b778f031aaa859c4e8e'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/certify.vm/certify.vm.nuspec
+++ b/packages/certify.vm/certify.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>certify.vm</id>
-    <version>1.1.0.20230713</version>
+    <version>1.1.0.20240323</version>
     <authors>HarmJ0y, leechristensen</authors>
     <description>Certify is a C# tool to enumerate and abuse misconfigurations in Active Directory Certificate Services (AD CS).</description>
     <dependencies>

--- a/packages/certify.vm/tools/chocolateyinstall.ps1
+++ b/packages/certify.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/GhostPack/Certify/archive/fb297ad30476cfdba745b9062171cd7ac145a16d.zip'
 $zipSha256 = '4827485203eb08271e953bbd5816e95bf8b0b897ae0937c798525afe7ed5b9e0'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240409</version>
+    <version>0.0.0.20240410</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/covenant.vm/covenant.vm.nuspec
+++ b/packages/covenant.vm/covenant.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>covenant.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>cobbr</authors>
     <description>Covenant is a .NET command and control framework that aims to highlight the attack surface of .NET, make the use of offensive .NET tradecraft easier, and serve as a collaborative command and control platform for red teamers.</description>
     <dependencies>

--- a/packages/covenant.vm/tools/chocolateyinstall.ps1
+++ b/packages/covenant.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Command & Control'
 $zipUrl = 'https://github.com/cobbr/Covenant/archive/5decc3ccfab04e6e881ed00c9de649740dac8ad1.zip'
 $zipSha256 = '53f532e350b7a43b0dab8e21a5298587b9a2f498c46bed77d443dea32525b525'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/credninja.vm/credninja.vm.nuspec
+++ b/packages/credninja.vm/credninja.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>credninja.vm</id>
-    <version>2.3</version>
+    <version>2.3.0.20240323</version>
     <authors>raikiasec</authors>
     <description>This tool will tell you if the credentials you dumped are valid on the domain, and if you have local administrator access to a host.</description>
     <dependencies>

--- a/packages/credninja.vm/tools/chocolateyinstall.ps1
+++ b/packages/credninja.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/Raikia/CredNinja/archive/4a13f297851cd6fe88017288e6850ad276078071.zip'
 $zipSha256 = '35b7dfae877c08bd9e50a5b9406eead0687b460db9428b9fe22130cc47b1ec10'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
+++ b/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotnettojscript.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>James Forshaw</authors>
     <description>A tool to generate a JScript which bootstraps an arbitrary .NET Assembly and class.</description>
     <dependencies>

--- a/packages/dotnettojscript.vm/tools/chocolateyinstall.ps1
+++ b/packages/dotnettojscript.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/tyranid/DotNetToJScript/archive/4dbe155912186f9574cb1889386540ba0e80c316.zip'
 $zipSha256 = '12566bdfced108fafba97548c59c07be55988beb1c1e970e62bf40ddaebc4a0a'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/dumpert.vm/dumpert.vm.nuspec
+++ b/packages/dumpert.vm/dumpert.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dumpert.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>outflank</authors>
     <description>This tool demonstrates the use of direct System Calls and API unhooking and combines these techniques in a proof of concept code which can be used to create a LSASS memory dump using Cobalt Strike.</description>
     <dependencies>

--- a/packages/dumpert.vm/tools/chocolateyinstall.ps1
+++ b/packages/dumpert.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/outflanknl/Dumpert/archive/8000ca4c585b0fc317cee69504be22d1ac2ed779.zip'
 $zipSha256 = '1ffbf3332db29e834c779008586c386ebbf1ca21e5c081ae6bba1a033d937bec'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/evilclippy.vm/evilclippy.vm.nuspec
+++ b/packages/evilclippy.vm/evilclippy.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>evilclippy.vm</id>
-    <version>1.3</version>
+    <version>1.3.0.20240323</version>
     <authors>outflank</authors>
     <description>A cross-platform assistant for creating malicious MS Office documents. Can hide VBA macros, stomp VBA code (via P-Code) and confuse macro analysis tools.</description>
     <dependencies>

--- a/packages/evilclippy.vm/tools/chocolateyinstall.ps1
+++ b/packages/evilclippy.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/outflanknl/EvilClippy/archive/refs/tags/v1.3.zip'
 $zipSha256 = '6ff1633de0ce8b99d5cf59a3e3cddf1960d4e7410d1441fd86940db42a7785a7'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/fuzzdb.vm/fuzzdb.vm.nuspec
+++ b/packages/fuzzdb.vm/fuzzdb.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>fuzzdb.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>fuzzdb-project</authors>
     <description>FuzzDB is the most comprehensive open dictionary of fault injection patterns, predictable resource locations, and regex for matching server responses.</description>
     <dependencies>

--- a/packages/fuzzdb.vm/tools/chocolateyinstall.ps1
+++ b/packages/fuzzdb.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Wordlists'
 $zipUrl = 'https://github.com/fuzzdb-project/fuzzdb/archive/5656ab25dc6bb43bae32236fab775658a90d7380.zip'
 $zipSha256 = 'b732136975be06f71e8c8cfa6923a6dfba028b7f8c4cfa21c6280ef5b74aa1fa'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
+++ b/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gadgettojscript.vm</id>
-    <version>2.0.0.20230713</version>
+    <version>2.0.0.20240323</version>
     <authors>med0x2e</authors>
     <description>A tool for generating .NET serialized gadgets that can trigger .NET assembly load/execution when deserialized using BinaryFormatter from JS/VBS/VBA scripts.</description>
     <dependencies>

--- a/packages/gadgettojscript.vm/tools/chocolateyinstall.ps1
+++ b/packages/gadgettojscript.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/med0x2e/GadgetToJScript/archive/98f50984015c29eecb11c6c4ddc3c2cc3a6669da.zip'
 $zipSha256 = '093451115744beec90e7de4efc61857361b56d16a3a31d78182a8c7ef675938b'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/invokedosfuscation.vm/invokedosfuscation.vm.nuspec
+++ b/packages/invokedosfuscation.vm/invokedosfuscation.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>invokedosfuscation.vm</id>
-    <version>1.0</version>
+    <version>1.0.0.20240312</version>
     <authors>danielbohannon</authors>
     <description>Invoke-DOSfuscation is a PowerShell v2.0+ compatible cmd.exe command obfuscation framework.</description>
     <dependencies>

--- a/packages/invokedosfuscation.vm/tools/chocolateyinstall.ps1
+++ b/packages/invokedosfuscation.vm/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $zipSha256 = '60b78094731fc8f54333193e840cb847ac4018c6ca1ccc36c107cda533016791'
 
 $powershellCommand = 'Import-Module .\Invoke-DOSfuscation.psd1; Invoke-DOSfuscation'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/invokeobfuscation.vm/invokeobfuscation.vm.nuspec
+++ b/packages/invokeobfuscation.vm/invokeobfuscation.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>invokeobfuscation.vm</id>
-    <version>1.8.2</version>
+    <version>1.8.2.20240312</version>
     <authors>cobbr, 4d4c, mvle, danielbohannon</authors>
     <description>Invoke-Obfuscation is a PowerShell v2.0+ compatible PowerShell command and script obfuscator.</description>
     <dependencies>

--- a/packages/invokeobfuscation.vm/tools/chocolateyinstall.ps1
+++ b/packages/invokeobfuscation.vm/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $zipSha256 = '24149efe341b4bfc216dea22ece4918abcbe0655d3d1f3c07d1965fac5b4478e'
 
 $powershellCommand = 'Import-Module ./Invoke-Obfuscation.psd1; Invoke-Obfuscation'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/keethief.vm/keethief.vm.nuspec
+++ b/packages/keethief.vm/keethief.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>keethief.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>tifkin_, harmj0y</authors>
     <description>Allows for the extraction of KeePass 2.X key material from memory, as well as the backdooring and enumeration of the KeePass trigger system.</description>
     <dependencies>

--- a/packages/keethief.vm/tools/chocolateyinstall.ps1
+++ b/packages/keethief.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/GhostPack/KeeThief/archive/04f3fbc0ba87dbcd9011ad40a1382169dc5afd59.zip'
 $zipSha256 = '2fe020645855564ce1d0236c3e83e8d66a09c91c00d95a40b88cbe9ffd5ca204'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/malware-jail.vm/malware-jail.vm.nuspec
+++ b/packages/malware-jail.vm/malware-jail.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>malware-jail.vm</id>
-    <version>0.0.0.20231020</version>
+    <version>0.0.0.20240323</version>
     <authors>Hynek Petrak</authors>
     <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
     <dependencies>

--- a/packages/malware-jail.vm/tools/chocolateyinstall.ps1
+++ b/packages/malware-jail.vm/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ try {
     # Install dependencies with npm when running shortcut as we ignore errors below
     $powershellCommand = "npm install; node jailme.js -h -b list"
 
-    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand
 
 } catch {
     VM-Write-Log-Exception $_

--- a/packages/microburst.vm/microburst.vm.nuspec
+++ b/packages/microburst.vm/microburst.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microburst.vm</id>
-    <version>0.0.0.20230320</version>
+    <version>0.0.0.20240323</version>
     <authors>NetSPI</authors>
     <description>MicroBurst includes functions and scripts that support Azure Services discovery, weak configuration auditing, and post exploitation actions such as credential dumping.</description>
     <dependencies>

--- a/packages/microburst.vm/tools/chocolateyinstall.ps1
+++ b/packages/microburst.vm/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $zipSha256 = '72700519c40fac2b01e5362e4d3d1e171e73910f8e9e9859753f26c64f0529d0'
 
 $powershellCommand = 'Import-Module Az, .\Az\MicroBurst-Az.psm1, .\Misc\MicroBurst-Misc.psm1, .\REST\MicroBurst-AzureREST.psm1; Get-Command -Module MicroBurst-Az'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/nanodump.vm/nanodump.vm.nuspec
+++ b/packages/nanodump.vm/nanodump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nanodump.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>fortra</authors>
     <description>A Beacon Object File that creates a minidump of the LSASS process.</description>
     <dependencies>

--- a/packages/nanodump.vm/tools/chocolateyinstall.ps1
+++ b/packages/nanodump.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/fortra/nanodump/archive/c211c5f72b2438afb09d0eb917fe32150be91344.zip'
 $zipSha256 = '461a16ae517aebb65adc37a0da8f8c04fa4836da35a69239dc2f90f8098b5da0'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
+++ b/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>outflank-c2-tool-collection.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>outflank</authors>
     <description>Contains a collection of tools which integrate with Cobalt Strike (and possibly other C2 frameworks) through BOF and reflective DLL loading techniques.</description>
     <dependencies>

--- a/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
+++ b/packages/outflank-c2-tool-collection.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/outflanknl/C2-Tool-Collection/archive/f02df22a206ee329bc582a8427d1aa1e54309d9a.zip'
 $zipSha256 = '825e3372f6caf540ecbc20f31af6f4b9e711bd6ce64fb09d7d151cf4224de3d8'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/payloadsallthethings.vm/payloadsallthethings.vm.nuspec
+++ b/packages/payloadsallthethings.vm/payloadsallthethings.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>payloadsallthethings.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>swisskyrepo</authors>
     <description>A list of useful payloads and bypasses for Web Application Security.</description>
     <dependencies>

--- a/packages/payloadsallthethings.vm/tools/chocolateyinstall.ps1
+++ b/packages/payloadsallthethings.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Wordlists'
 $zipUrl = 'https://github.com/swisskyrepo/PayloadsAllTheThings/archive/cd19bb94096a61ef22d0c9668bc29674fce53fa0.zip'
 $zipSha256 = 'c2adbecb78e01e5d8987ab42b40a30b4a104ee6c2886d8143395645408f9f361'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/petitpotam.vm/petitpotam.vm.nuspec
+++ b/packages/petitpotam.vm/petitpotam.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>petitpotam.vm</id>
-    <version>0.0.0.20230710</version>
+    <version>0.0.0.20240323</version>
     <authors>topotam</authors>
     <description>PoC tool to coerce Windows hosts to authenticate to other machines via MS-EFSRPC EfsRpcOpenFileRaw or other functions</description>
     <dependencies>

--- a/packages/petitpotam.vm/tools/chocolateyinstall.ps1
+++ b/packages/petitpotam.vm/tools/chocolateyinstall.ps1
@@ -7,6 +7,4 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/topotam/PetitPotam/archive/d83ac8f2dd34654628c17490f99106eb128e7d1e.zip'
 $zipSha256 = '5429479879877c2a6263d79c1a83fbcbd0f9f37bf9870c155358d9dc25662862'
 
-$powershellCommand = '.\PetitPotam.exe'
-
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pkg-unpacker.vm</id>
-    <version>1.0.0.20240125</version>
+    <version>1.0.0.20240323</version>
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>

--- a/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
+++ b/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
@@ -8,7 +8,7 @@ try {
     $zipSha256 = '6eed1d492d37ca3934a3bc838c2256719a3e78ccf72ce1b1ca07684519ace16c'
     $powershellCommand = "npm install; node unpack.js"
 
-    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+    $toolDir = VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/powermad.vm/powermad.vm.nuspec
+++ b/packages/powermad.vm/powermad.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powermad.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>Kevin-Robertson</authors>
     <description>Powermad includes a set of functions for exploiting ms-DS-MachineAccountQuota without attaching an actual system to AD</description>
     <dependencies>

--- a/packages/powermad.vm/tools/chocolateyinstall.ps1
+++ b/packages/powermad.vm/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $zipSha256 = 'e01cfdb69f938ecd8c707e81dce2832935bb26e368405f2180b6858bce5b4d73'
 
 $powershellCommand = 'Import-Module .\Powermad.psd1; Get-Command -Module Powermad'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/powersploit.vm/powersploit.vm.nuspec
+++ b/packages/powersploit.vm/powersploit.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powersploit.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>HarmJ0y, 0xe7</authors>
     <description>PowerSploit is a collection of Microsoft PowerShell modules that can be used to aid penetration testers during all phases of an assessment.</description>
     <dependencies>

--- a/packages/powersploit.vm/tools/chocolateyinstall.ps1
+++ b/packages/powersploit.vm/tools/chocolateyinstall.ps1
@@ -8,17 +8,16 @@ $category = 'Exploitation'
 # install powersploit, import module, and list available powersploit modules
 $zipUrl = 'https://github.com/ZeroDayLab/PowerSploit/archive/72a88240ed0c6527f3880a1fb15ea7a19589c2d8.zip'
 $zipSha256 = '4a86b4b92e97fe6f1d76d8d93d9e481c007809db803cc82f4f0ec86ff7186bcf'
-$powershellCommand = 'Import-Module $Env:RAW_TOOLS_DIR\PowerSploit\PowerSploit.psd1; Get-Command -Module PowerSploit'
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+$powershellCommand = 'Import-Module .\PowerSploit.psd1; Get-Command -Module PowerSploit'
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand
 
 # vars for powerview
 $toolName2 = 'PowerView'
 $category2 = 'Reconnaissance'
-$shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category2
-$shortcut = Join-Path $shortcutDir "$toolName2.lnk"
-$targetCmd = Join-Path ${Env:WinDir} "system32\WindowsPowerShell\v1.0\powershell.exe" -Resolve
-$executableArgs = '-NoExit Import-Module $Env:RAW_TOOLS_DIR\PowerSploit\Recon\Recon.psd1; Get-Command -Module Recon'
+$powershellCommand = 'Import-Module .\Recon\Recon.psd1; Get-Command -Module Recon'
 
 # install powerview shortcut and list available powerview modules
-Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $targetCmd -Arguments $executableArgs
-VM-Assert-Path $shortcut
+$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} "\PowerSploit"
+$dirList = Get-ChildItem $toolDir -Directory
+$executablePath = Join-Path $toolDir $dirList[0].Name -Resolve
+VM-Install-Shortcut -toolName $toolName2 -category $category2 -arguments $powershellCommand -executableDir $executablePath -powershell

--- a/packages/powerupsql.vm/powerupsql.vm.nuspec
+++ b/packages/powerupsql.vm/powerupsql.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powerupsql.vm</id>
-    <version>0.0.0.20230710</version>
+    <version>0.0.0.20240323</version>
     <authors>NetSPI</authors>
     <description>PowerUpSQL includes functions that support SQL Server discovery, weak configuration auditing, privilege escalation on scale, and post exploitation actions such as OS command execution.</description>
     <dependencies>

--- a/packages/powerupsql.vm/tools/chocolateyinstall.ps1
+++ b/packages/powerupsql.vm/tools/chocolateyinstall.ps1
@@ -7,6 +7,6 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/NetSPI/PowerUpSQL/archive/2837c7bdda47a07703b7841080024f30a73a7743.zip'
 $zipSha256 = 'fffed1c3f480b40616070e7ebb5bf7e8093e0bb483ce1ef2400f586018439c85'
 
-$powershellCommand = 'Import-Module PowerUpSQL.psd1; Get-Command -Module PowerUpSQL'
+$powershellCommand = 'Import-Module .\PowerUpSQL.psd1; Get-Command -Module PowerUpSQL'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/powerzure.vm/powerzure.vm.nuspec
+++ b/packages/powerzure.vm/powerzure.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powerzure.vm</id>
-    <version>0.0.0.20230320</version>
+    <version>0.0.0.20240323</version>
     <authors>hausec</authors>
     <description>PowerZure is a PowerShell project created to assess and exploit resources within Microsoft’s cloud platform, Azure.</description>
     <dependencies>

--- a/packages/powerzure.vm/tools/chocolateyinstall.ps1
+++ b/packages/powerzure.vm/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $zipSha256 = '76e82df57013980cd6f3dd5b125e405e4ab3308368f2372121581a6a1e4a5a22'
 
 $powershellCommand = 'Import-Module Az, .\PowerZure.psm1; Invoke-PowerZure -h'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -powershellCommand $powershellCommand
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand

--- a/packages/routesixtysink.vm/routesixtysink.vm.nuspec
+++ b/packages/routesixtysink.vm/routesixtysink.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>routesixtysink.vm</id>
-    <version>0.0.0.20230714</version>
+    <version>0.0.0.20240323</version>
     <authors>Dillon Franke, Michael Maturi</authors>
     <description>Route Sixty-Sink is an open source tool that enables defenders and security researchers alike to quickly identify vulnerabilities in any .NET assembly using automated source-to-sink analysis.</description>
     <dependencies>

--- a/packages/routesixtysink.vm/tools/chocolateyinstall.ps1
+++ b/packages/routesixtysink.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/mandiant/route-sixty-sink/archive/59195003c84d75fabf6cc573c233dfb60d631f8a.zip'
 $zipSha256 = '860df7a6f8b8b135e27e731d1cc11a61837a390fc7da46652f82920040802f15'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/rubeus.vm/rubeus.vm.nuspec
+++ b/packages/rubeus.vm/rubeus.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rubeus.vm</id>
-    <version>2.3.1</version>
+    <version>2.3.1.20240323</version>
     <authors>harmj0y</authors>
     <description>Rubeus is a C# toolset for raw Kerberos interaction and abuses.</description>
     <dependencies>

--- a/packages/rubeus.vm/tools/chocolateyinstall.ps1
+++ b/packages/rubeus.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://codeload.github.com/GhostPack/Rubeus/zip/baf34c7dcffb37cb96c92e402bab389229f1ec35'
 $zipSha256 = 'a857b776e8f86a8f94da74beb6449fede16286aba129373a9899641aab078390'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/safetykatz.vm/safetykatz.vm.nuspec
+++ b/packages/safetykatz.vm/safetykatz.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>safetykatz.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>HarmJ0y</authors>
     <description>SafetyKatz is a combination of slightly modified version of @gentilkiwi's Mimikatz project and @subtee's .NET PE Loader.</description>
     <dependencies>

--- a/packages/safetykatz.vm/tools/chocolateyinstall.ps1
+++ b/packages/safetykatz.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/GhostPack/SafetyKatz/archive/715b311f76eb3a4c8d00a1bd29c6cd1899e450b7.zip'
 $zipSha256 = '97ed587a816ef87a310d43dba7b0370ab4cbc1756dbed102e38662abce84a81d'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/seatbelt.vm/seatbelt.vm.nuspec
+++ b/packages/seatbelt.vm/seatbelt.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>seatbelt.vm</id>
-    <version>1.2.0.20230713</version>
+    <version>1.2.0.20240323</version>
     <authors>harmj0y, tifkin_</authors>
     <description>Seatbelt is a C# project that performs a number of security oriented host-survey "safety checks" relevant from both offensive and defensive security perspectives.</description>
     <dependencies>

--- a/packages/seatbelt.vm/tools/chocolateyinstall.ps1
+++ b/packages/seatbelt.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/GhostPack/Seatbelt/archive/96bd958cf45e3d877d842ce20906e1aa5fdc91c8.zip'
 $zipSha256 = '05f6da0d0b77adfae105f2030862882fc8790cf47d98ec053762b9ac99250184'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/seclists.vm/seclists.vm.nuspec
+++ b/packages/seclists.vm/seclists.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>seclists.vm</id>
-    <version>2024.1</version>
+    <version>2024.1.0.20240323</version>
     <authors>danielmiessler</authors>
     <description>SecLists is the security tester's companion. It's a collection of multiple types of lists used during security assessments, collected in one place.</description>
     <dependencies>

--- a/packages/seclists.vm/tools/chocolateyinstall.ps1
+++ b/packages/seclists.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Wordlists'
 $zipUrl = 'https://github.com/danielmiessler/SecLists/archive/refs/tags/2024.1.zip'
 $zipSha256 = '189c9491898c070e3c6e7d51ecc370d96c9b13c9f289dc629ce078b0709780aa'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpdpapi.vm/sharpdpapi.vm.nuspec
+++ b/packages/sharpdpapi.vm/sharpdpapi.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpdpapi.vm</id>
-    <version>1.11.3</version>
+    <version>1.11.3.20240323</version>
     <authors>harmj0y</authors>
     <description>SharpDPAPI is a C# port of some DPAPI functionality from @gentilkiwi's Mimikatz project.</description>
     <dependencies>

--- a/packages/sharpdpapi.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpdpapi.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/GhostPack/SharpDPAPI/archive/02992ff2c5c48f38602b096367c6107857dae8e9.zip'
 $zipSha256 = 'dd0bd7ceedf87a6952c1e6d8c1865f434f316b187c3f783fe176ad323e7b0f81'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpdump.vm/sharpdump.vm.nuspec
+++ b/packages/sharpdump.vm/sharpdump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpdump.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>HarmJ0y</authors>
     <description>SharpDump is a C# port of PowerSploit's Out-Minidump.ps1 functionality.</description>
     <dependencies>

--- a/packages/sharpdump.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpdump.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/GhostPack/SharpDump/archive/41cfcf9b1abed2da79a93c201cbd38fbbe31684c.zip'
 $zipSha256 = 'c7ddbf34fc9546638d05344727c7a07bbdf492f4f2313456ee5097a5dbea942a'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpexec.vm/sharpexec.vm.nuspec
+++ b/packages/sharpexec.vm/sharpexec.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpexec.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>anthemtotheego</authors>
     <description>SharpExec is an offensive security C# tool designed to aid with lateral movement.</description>
     <dependencies>

--- a/packages/sharpexec.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpexec.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Lateral Movement'
 $zipUrl = 'https://github.com/anthemtotheego/SharpExec/archive/852384499de1ab7b56ee93203b31638138a1d313.zip'
 $zipSha256 = 'd032aa7772d8c0d47f30a77381c372cf5d181fea2836c9c85d65eb052785d2df'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpsecdump.vm/sharpsecdump.vm.nuspec
+++ b/packages/sharpsecdump.vm/sharpsecdump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpsecdump.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>G0ldenGunSec</authors>
     <description>.Net port of the remote SAM + LSA Secrets dumping functionality of impacket's secretsdump.py</description>
     <dependencies>

--- a/packages/sharpsecdump.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpsecdump.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Credential Access'
 $zipUrl = 'https://github.com/G0ldenGunSec/SharpSecDump/archive/ef2463688e405fad0fabb001b3d8869db51da0e0.zip'
 $zipSha256 = '10108c1817d21f747e10317ccca14b58d3e060c7c3fe268eccf81ef58e448ae4'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpup.vm/sharpup.vm.nuspec
+++ b/packages/sharpup.vm/sharpup.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpup.vm</id>
-    <version>0.0.0.20230602</version>
+    <version>0.0.0.20240323</version>
     <authors>harmj0y</authors>
     <description>SharpUp is a C# port of various PowerUp functionality for auditing potential privilege escalation paths.</description>
     <dependencies>

--- a/packages/sharpup.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpup.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/GhostPack/SharpUp/archive/7e172961002125417a0f8a8447de0cb579f7d0e8.zip'
 $zipSha256 = '6bf0c25dcd322f3f058d474f827ab3b772cbd7e8ad1a0010a0b8fda3d2a0a761'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpview.vm/sharpview.vm.nuspec
+++ b/packages/sharpview.vm/sharpview.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpview.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>tevora</authors>
     <description>.NET port of PowerView used for information gathering within Active Directory</description>
     <dependencies>

--- a/packages/sharpview.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpview.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/tevora-threat/SharpView/archive/b60456286b41bb055ee7bc2a14d645410cca9b74.zip'
 $zipSha256 = 'b5b2dd91fe22f56fb846d849052fc3205f177cbd067069e6d829e38eea0aca49'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/sharpwmi.vm/sharpwmi.vm.nuspec
+++ b/packages/sharpwmi.vm/sharpwmi.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpwmi.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>HarmJ0y</authors>
     <description>SharpWMI is a C# implementation of various WMI functionality.</description>
     <dependencies>

--- a/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
+++ b/packages/sharpwmi.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/GhostPack/SharpWMI/archive/0600f57aeb4733ba6fec585388af2f1ac4483b58.zip'
 $zipSha256 = '0dbdd04a8a62e16de40373ae416b732cd48fb642ac7b3ff243bb9580249058f5'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
+++ b/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>situational-awareness-bof.vm</id>
-    <version>0.0.0.20240112</version>
+    <version>0.0.0.20240323</version>
     <authors>trustedsec</authors>
     <description>Provides a set of basic situational awareness commands implemented in a Beacon Object File (BOF). This allows you to perform some checks on a host before you begin executing commands that may be more invasive.</description>
     <dependencies>

--- a/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/situational-awareness-bof.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://codeload.github.com/trustedsec/CS-Situational-Awareness-BOF/zip/9a813b8f31cd397d7b05211e1d5b378c07fd1b8b'
 $zipSha256 = 'b461e5a0dde271ee29c2105f8b064e6c3d38f4996c09478c16bb1f071cee00c1'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/spoolsample.vm/spoolsample.vm.nuspec
+++ b/packages/spoolsample.vm/spoolsample.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>spoolsample.vm</id>
-    <version>0.0.0.20230602</version>
+    <version>0.0.0.20240323</version>
     <authors>tifkin_, harmj0y, enigma0x3</authors>
     <description>PoC tool to coerce Windows hosts authenticate to other machines via the MS-RPRN RPC interface.</description>
     <dependencies>

--- a/packages/spoolsample.vm/tools/chocolateyinstall.ps1
+++ b/packages/spoolsample.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/leechristensen/SpoolSample/archive/688971e69cbe9240ea84bdd38f732dd9817110f8.zip'
 $zipSha256 = '1e5f54b9317ac053fe51e373b3e3b830573e2d14612bf4a038750a6c6284fb3d'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/statistically-likely-usernames.vm/statistically-likely-usernames.vm.nuspec
+++ b/packages/statistically-likely-usernames.vm/statistically-likely-usernames.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>statistically-likely-usernames.vm</id>
-    <version>0.0.0.20230711</version>
+    <version>0.0.0.20240323</version>
     <authors>insidetrust</authors>
     <description>This resource contains wordlists for creating statistically likely usernames for use in username-enumeration, simulated password-attacks and other security testing tasks.</description>
     <dependencies>

--- a/packages/statistically-likely-usernames.vm/tools/chocolateyinstall.ps1
+++ b/packages/statistically-likely-usernames.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Wordlists'
 $zipUrl = 'https://github.com/insidetrust/statistically-likely-usernames/archive/fc2321c65a1327a1db363764979e7c23d84dfd37.zip'
 $zipSha256 = 'f52a84310e098d662ae212eccc979cefc1d061aa06aca765a8e0f98a4ece3c0c'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/stracciatella.vm/stracciatella.vm.nuspec
+++ b/packages/stracciatella.vm/stracciatella.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>stracciatella.vm</id>
-    <version>0.7.0.20230713</version>
+    <version>0.7.0.20240323</version>
     <authors>mgeeky</authors>
     <description>Powershell runspace from within C# (aka SharpPick technique) with AMSI, ETW and Script Block Logging disabled.</description>
     <dependencies>

--- a/packages/stracciatella.vm/tools/chocolateyinstall.ps1
+++ b/packages/stracciatella.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/mgeeky/Stracciatella/archive/acc83e21951049ab4998ecd18f5e4fa01e1527da.zip'
 $zipSha256 = 'd9299fca780945becf9907b052112e7149fb2a2d51e28f0e73e8326455f47a82'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/syswhispers2.vm/syswhispers2.vm.nuspec
+++ b/packages/syswhispers2.vm/syswhispers2.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>syswhispers2.vm</id>
-    <version>0.0.0.20230712</version>
+    <version>0.0.0.20240323</version>
     <authors>jthuraisamy</authors>
     <description>SysWhispers helps with evasion by generating header/ASM files implants can use to make direct system calls.</description>
     <dependencies>

--- a/packages/syswhispers2.vm/tools/chocolateyinstall.ps1
+++ b/packages/syswhispers2.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/jthuraisamy/SysWhispers2/archive/05ad0d9ec769fac2776c992d2cb55b09bd604f9a.zip'
 $zipSha256 = '4741ad22fe05a9dc8e89885b37a458c12b286a9de2e3f306b57c7a5ef5f7596e'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/syswhispers3.vm/syswhispers3.vm.nuspec
+++ b/packages/syswhispers3.vm/syswhispers3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>syswhispers3.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>klezVirus</authors>
     <description>SysWhispers helps with evasion by generating header/ASM files implants can use to make direct system calls.</description>
     <dependencies>

--- a/packages/syswhispers3.vm/tools/chocolateyinstall.ps1
+++ b/packages/syswhispers3.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/klezVirus/SysWhispers3/archive/e3d5fc744c2e5c0ae952be0f7dcf498c5a68be4b.zip'
 $zipSha256 = '987d04d404ee86536e04c488037fa9c9caa12d35fefdf9c0bc193d1bfed4c96a'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/trustedsec-remote-ops-bof.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Reconnaissance'
 $zipUrl = 'https://github.com/trustedsec/CS-Remote-OPs-BOF/archive/a7ef2b8551568778c2603a15ea83220188009a79.zip'
 $zipSha256 = '61bf693272484d9f9ea25871ea57489cb24248c014782cacad1c1bb80e90962b'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
+++ b/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>truestedsec-remote-ops-bof.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>trustedsec</authors>
     <description>Addition to Situational Awareness BOFs intended for single task Windows primitives such as creating a task, stopping a service, etc.</description>
     <dependencies>

--- a/packages/unhook-bof.vm/tools/chocolateyinstall.ps1
+++ b/packages/unhook-bof.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Payload Development'
 $zipUrl = 'https://github.com/rsmudge/unhook-bof/archive/fa3c8d8a397719c5f2310334e6549bea541b209c.zip'
 $zipSha256 = '086f7ded18af7b397be78f63a7b4879bb1a6722f4b192d0139a02863332089ef'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/unhook-bof.vm/unhook-bof.vm.nuspec
+++ b/packages/unhook-bof.vm/unhook-bof.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>unhook-bof.vm</id>
-    <version>0.0.0.20230713</version>
+    <version>0.0.0.20240323</version>
     <authors>rsmudge, physics-sec</authors>
     <description>This is a Beacon Object File to refresh DLLs and remove their hooks. The code is from Cylance's Universal Unhooking research.</description>
     <dependencies>

--- a/packages/whisker.vm/tools/chocolateyinstall.ps1
+++ b/packages/whisker.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,5 @@ $category = 'Exploitation'
 $zipUrl = 'https://github.com/eladshamir/Whisker/archive/0bc2a0acc4a92b49c69d873f7ac565340a5f3291.zip'
 $zipSha256 = 'b181b639f2d18fb37e045d27cbe522e7b97aaa85c30dc0cb9bc75eaf6b939f9a'
 
-VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256
+# This tool does not have a `.exe` associated with it, so this links it to the directory
+VM-Install-Raw-GitHub-Repo $toolName $category $zipUrl $zipSha256 -withoutBinFile -innerFolder $true

--- a/packages/whisker.vm/whisker.vm.nuspec
+++ b/packages/whisker.vm/whisker.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>whisker.vm</id>
-    <version>0.0.0.20230714</version>
+    <version>0.0.0.20240323</version>
     <authors>Elad Shamir</authors>
     <description>Whisker is a C# tool for taking over Active Directory user and computer accounts by manipulating their msDS-KeyCredentialLink attribute, effectively adding "Shadow Credentials" to the target account.</description>
     <dependencies>


### PR DESCRIPTION
This fixes https://github.com/mandiant/VM-Packages/issues/749

I updated a couple of commands that were not working in their current state.

Most packages needed `-innerFolder` added to them.

I updated the way we use `-withoutBinFile`. The current way we used it forced the tool to have `.exe`, which doesn't always make sense, especially when the flag is for 'without a binary file'. I take this to mean that the tool does -not- have any `.exe` associated with it (or we do not want the `.exe` associated with the shortcut), which was the case for many tools that are used in CommandoVM. By separating it into its own if statement, I think it brings more clarity into how we are using it and its intent.

All changed tools have been tested and work just as the original way they were set as, before any changes, other than ones previously broken, which are now fixed.