### PR TITLE
Add frida to VM-Packages to fix #960

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20240130</version>
+    <version>0.0.0.20240325</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -31,4 +31,6 @@
     <module name="vivisect"/>
     <module name="XLMMacroDeobfuscator"/>
     <module name="yara-python"/>
+    <module name="frida"/>
+    <module name="frida-tools"/>
 </modules>


### PR DESCRIPTION
Tested as follows:
```
libraries.python3.vm v0.0.0.20240130 (forced)
libraries.python3.vm package files upgrade completed. Performing other installation steps.
[+] Attempting to install Python3 module: acefile
        [+] Installed Python 3.10 module: acefile
[+] Attempting to install Python3 module: art
        [+] Installed Python 3.10 module: art
[+] Attempting to install Python3 module: binwalk
        [+] Installed Python 3.10 module: binwalk
[+] Attempting to install Python3 module: capstone-windows
        [+] Installed Python 3.10 module: capstone-windows
[+] Attempting to install Python3 module: dissect
        [+] Installed Python 3.10 module: dissect
[+] Attempting to install Python3 module: dncil
        [+] Installed Python 3.10 module: dncil
[+] Attempting to install Python3 module: dnfile
        [+] Installed Python 3.10 module: dnfile
[+] Attempting to install Python3 module: flare-capa
        [+] Installed Python 3.10 module: flare-capa
[+] Attempting to install Python3 module: hexdump
        [+] Installed Python 3.10 module: hexdump
[+] Attempting to install Python3 module: ldapdomaindump
        [+] Installed Python 3.10 module: ldapdomaindump
[+] Attempting to install Python3 module: lznt1
        [+] Installed Python 3.10 module: lznt1
[+] Attempting to install Python3 module: mkyara
        [+] Installed Python 3.10 module: mkyara
[+] Attempting to install Python3 module: msoffcrypto-tool
        [+] Installed Python 3.10 module: msoffcrypto-tool
[+] Attempting to install Python3 module: olefile
        [+] Installed Python 3.10 module: olefile
[+] Attempting to install Python3 module: oletools
        [+] Installed Python 3.10 module: oletools
[+] Attempting to install Python3 module: pefile
        [+] Installed Python 3.10 module: pefile
[+] Attempting to install Python3 module: psutil
        [+] Installed Python 3.10 module: psutil
[+] Attempting to install Python3 module: pyasn1
        [+] Installed Python 3.10 module: pyasn1
[+] Attempting to install Python3 module: pycryptodome
        [+] Installed Python 3.10 module: pycryptodome
[+] Attempting to install Python3 module: pyftpdlib
        [+] Installed Python 3.10 module: pyftpdlib
[+] Attempting to install Python3 module: pyOpenSSL
        [+] Installed Python 3.10 module: pyOpenSSL
[+] Attempting to install Python3 module: pyreadline3
        [+] Installed Python 3.10 module: pyreadline3
[+] Attempting to install Python3 module: pythonnet
        [+] Installed Python 3.10 module: pythonnet
[+] Attempting to install Python3 module: requests
        [+] Installed Python 3.10 module: requests
[+] Attempting to install Python3 module: stringsifter
        [+] Installed Python 3.10 module: stringsifter
[+] Attempting to install Python3 module: uncompyle6
        [+] Installed Python 3.10 module: uncompyle6
[+] Attempting to install Python3 module: unicorn
        [+] Installed Python 3.10 module: unicorn
[+] Attempting to install Python3 module: unpy2exe
        [+] Installed Python 3.10 module: unpy2exe
[+] Attempting to install Python3 module: vivisect
        [+] Installed Python 3.10 module: vivisect
[+] Attempting to install Python3 module: XLMMacroDeobfuscator
        [+] Installed Python 3.10 module: XLMMacroDeobfuscator
[+] Attempting to install Python3 module: yara-python
        [+] Installed Python 3.10 module: yara-python
[+] Attempting to install Python3 module: frida
        [+] Installed Python 3.10 module: frida
[+] Attempting to install Python3 module: frida-tools
        [+] Installed Python 3.10 module: frida-tools
 The upgrade of libraries.python3.vm was successful.
  Software install location not explicitly set, it could be in package or
  default install location of installer.

Chocolatey upgraded 21/21 packages.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Upgraded:
 - chocolatey-compatibility.extension v1.0.0
 - chocolatey-core.extension v1.4.0
 - chocolatey-dotnetfx.extension v1.0.1
 - chocolatey-visualstudio.extension v1.11.1
 - chocolatey-windowsupdate.extension v1.0.5
 - dotnetfx v4.8.0.20220524
 - KB2919355 v1.0.20160915
 - KB2919442 v1.0.20160915
 - KB2999226 v1.0.20181019
 - KB3033929 v1.0.5
 - KB3035131 v1.0.3
 - libraries.python3.vm v0.0.0.20240130
 - python3 v3.10.11
 - python3.vm v0.0.0.20231019
 - python310 v3.10.11
 - vcbuildtools.vm v0.0.0.20240217
 - vcredist140 v14.38.33135
 - vcredist2015 v14.0.24215.20170201
 - visualstudio2017buildtools v15.9.58
 - visualstudio2017-workload-vctools v1.3.3
 - visualstudio-installer v2.0.3

SUCCESS:2
FAILURE:0

Writing success/failure/total and failing packages to success_failure.json
PS C:\VM-Packages > C:\Python310\Scripts\frida.exe --version
16.2.1
FLARE-VM 03/25/2024 02:51:59
PS C:\VM-Packages >
```