### PR TITLE
Set Windows Terminal as pinned console

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240321</version>
+    <version>0.0.0.20240402</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -281,12 +281,12 @@ function VM-Install-Shortcut{
     # Set the default icon to be the executable's icon
     if (-Not $iconLocation) {$iconLocation = $executablePath}
 
-    if ($consoleApp -or $powershell) {
-        if (-not $executableDir) {
-            $executableDir = Join-Path ${Env:UserProfile} "Desktop"
-        }
-        VM-Assert-Path $executableDir
+    if (-not $executableDir) {
+        $executableDir = Join-Path ${Env:UserProfile} "Desktop"
+    }
+    VM-Assert-Path $executableDir
 
+    if ($consoleApp -or $powershell) {
         if ($consoleApp) {
             $executableCmd = Join-Path ${Env:WinDir} "system32\cmd.exe" -Resolve
             # Change to executable dir, print command to execute, and execute command
@@ -307,19 +307,19 @@ function VM-Install-Shortcut{
         if ($runAsAdmin) {
             $shortcutArgs.RunAsAdmin = $true
         }
-
         Install-ChocolateyShortcut @shortcutArgs
 
     } else {
         $shortcutArgs = @{
             ShortcutFilePath = $shortcut
             TargetPath       = $executablePath
+            Arguments        = $arguments
+            WorkingDirectory = $executableDir
             IconLocation     = $iconLocation
         }
         if ($runAsAdmin) {
             $shortcutArgs.RunAsAdmin = $true
         }
-
         Install-ChocolateyShortcut @shortcutArgs
     }
     VM-Assert-Path $shortcut
@@ -707,7 +707,9 @@ function VM-Add-To-Right-Click-Menu {
         [ValidateSet("file", "directory")]
         [string] $type="file",
         [Parameter(Mandatory=$false)]
-        [string] $extension
+        [string] $extension,
+        [Parameter(Mandatory=$false)]
+        [switch] $background
     )
     try {
         if ($extension) {
@@ -717,7 +719,10 @@ function VM-Add-To-Right-Click-Menu {
           if ($type -eq "file") {
               $key = "*"
           } else {
-              $key = "directory"
+              $key = "Directory"
+              if ($background) {
+                $key += "\Background"
+              }
           }
         }
         $key_path = "HKCR:\$key\shell\$menuKey"
@@ -755,7 +760,9 @@ function VM-Remove-From-Right-Click-Menu {
         [ValidateSet("file", "directory")]
         [string] $type="file",
         [Parameter(Mandatory=$false)]
-        [string] $extension
+        [string] $extension,
+        [Parameter(Mandatory=$false)]
+        [switch] $background
     )
     try {
         if ($extension) {
@@ -765,7 +772,10 @@ function VM-Remove-From-Right-Click-Menu {
           if ($type -eq "file") {
               $key = "*"
           } else {
-              $key = "directory"
+              $key = "Directory"
+              if ($background) {
+                $key += "\Background"
+              }
           }
         }
         $key_path = "HKCR:\$key\shell\$menuKey"

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>debloat.vm</id>
-    <version>0.0.0.20240321</version>
+    <version>0.0.0.20240327</version>
     <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -140,8 +140,6 @@
         <registry-item name="Disable Windows Update Automatic Download" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" value="AUOptions" type="DWord" data="2" />
         <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
         <registry-item name="Disable Microsoft Connectivity Test (msftconnecttest.com)" path="HKLM:\SYSTEM\CurrentControlSet\services\NlaSvc\Parameters\Internet" value="EnableActiveProbing" type="DWord" data="0" />
-        <registry-item name="Enable opening cmd from context menu - Default" path="Registry::HKEY_CLASSES_ROOT\Directory\Background\shell\ctx_cmd" value="(Default)" type="String" data="Cmd Here" />
-        <registry-item name="Enable opening cmd from context menu - Command" path="Registry::HKEY_CLASSES_ROOT\Directory\Background\shell\ctx_cmd\command" value="(Default)" type="String" data="&quot;cmd.exe&quot; &quot;pushd &quot;%V&quot;&quot;" />
     </registry-items>
     <path-items>
         <!--

--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20240321</version>
+    <version>0.0.0.20240402</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -35,18 +35,6 @@ try {
     ## Configure taskbar with custom Start Layout if it exists.
     $customLayout = Join-Path ${Env:VM_COMMON_DIR} "CustomStartLayout.xml"
     if (Test-Path $customLayout) {
-        # Create an Admin Command Prompt shortcut and it to pin to taskbar (analogous to how the Windows Dev VM does this).
-        $toolName = 'Admin Command Prompt'
-
-        $executablePath = Join-Path ${Env:SystemRoot} 'system32\cmd.exe'
-        $shortcutDir = ${Env:RAW_TOOLS_DIR}
-        $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-        $workingDir  = Join-Path ${Env:UserProfile} "Desktop"
-        $arguments = "/k `"cd `"$workingDir`"`""
-
-        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -Arguments $arguments -RunAsAdmin
-        VM-Assert-Path $shortcut
-
         Import-StartLayout -LayoutPath $customLayout -MountPath "C:\"
         Stop-Process -Name explorer -Force  # This restarts the explorer process so that the new taskbar is displayed.
     } else {

--- a/packages/windows-terminal.vm/tools/chocolateyinstall.ps1
+++ b/packages/windows-terminal.vm/tools/chocolateyinstall.ps1
@@ -28,9 +28,32 @@ try {
   # GitHub ZIP files typically unzip to a single folder that contains the tools.
   $dirList = Get-ChildItem $toolDir -Directory
   $toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
-
+  $workingDir = Join-Path ${Env:UserProfile} "Desktop"
+  $arguments = "-p `"Command Prompt`" -d `"$workingDir`""   # Working directory doesn't work for admin shortcuts, so use -d flag for it.
   $executablePath = Join-Path $toolDir $executableName -Resolve
-  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -runAsAdmin
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -arguments $arguments -runAsAdmin
+
+  # Create a basic settings.json file so Windows Terminal always opens with elevated privileges
+  $settingsPath = "${Env:LOCALAPPDATA}\Microsoft\Windows Terminal\settings.json"
+  $settingsFileDir = Split-Path $settingsPath
+  New-Item -ItemType Directory -Force -Path $settingsFileDir
+  $defaultSettings = @"
+{
+  "`$schema": "https://aka.ms/terminal-settings-schema-v1.1",
+  "profiles": {
+    "defaults": {
+      "elevate": true
+    }
+  }
+}
+"@
+  $defaultSettings | Out-File $settingsPath -Encoding Utf8
+
+  # Add right click for Windows Terminal
+  $command = "`"$executablePath`" -p `"Command Prompt`" -d `"%V`""
+  $label = "Open Terminal here"
+  $icon = "$executablePath"
+  VM-Add-To-Right-Click-Menu -menuKey $toolName -menuLabel $label -command $command -menuIcon $icon -type "directory" -background
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/windows-terminal.vm/tools/chocolateyuninstall.ps1
+++ b/packages/windows-terminal.vm/tools/chocolateyuninstall.ps1
@@ -5,3 +5,4 @@ $toolName = 'Windows Terminal'
 $category = 'Productivity Tools'
 
 VM-Uninstall $toolName $category
+VM-Remove-From-Right-Click-Menu -menuKey $toolName -type "directory" -background

--- a/packages/windows-terminal.vm/windows-terminal.vm.nuspec
+++ b/packages/windows-terminal.vm/windows-terminal.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>windows-terminal.vm</id>
-    <version>1.19.10573.20240305</version>
+    <version>1.19.10573.20240402</version>
     <authors>Microsoft</authors>
     <description>Windows Terminal is a new, modern, feature-rich, productive terminal application for command-line users.</description>
     <dependencies>


### PR DESCRIPTION
This sets Windows Terminal as the pinned console. It will also require merging the PR (https://github.com/mandiant/flare-vm/pull/580) in `flare-vm` that modifies the `CustomStartLayout.xml` to pin Windows Terminal instead of the command prompt.

I also had to modify `VM-Install-Shortcut` to allow for regular shortcuts to also include arguments with their execution, which was required for an admin Windows Terminal to be able to start in a directory that we want, since the "Working Directory" does not work for shortcuts that are set to run as admin.