### PR TITLE
Fix version of dependencies

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240305</version>
+    <version>0.0.0.20240321</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>debloat.vm</id>
-    <version>0.0.0.20240123</version>
+    <version>0.0.0.20240321</version>
     <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -38,10 +38,9 @@
         <app name="Microsoft.XboxIdentityProvider"/>
         <app name="Microsoft.XboxSpeechToTextOverlay"/>
         <app name="Microsoft.YourPhone"/>
-        <app name="Microsoft.ZuneMusic"/>
-        <app name="Microsoft.ZuneVideo"/>
-        <app name="SpotifyAB.SpotifyMusic"/>
-        <app name="Disney.37853FC22B2CE"/>
+        <app name="*Zune*"/>
+        <app name="*Spotify*"/>
+        <app name="*Disney*"/>
     </apps>
     <services>
         <!--

--- a/packages/net-reactor-slayer.vm/net-reactor-slayer.vm.nuspec
+++ b/packages/net-reactor-slayer.vm/net-reactor-slayer.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>net-reactor-slayer.vm</id>
-    <version>6.4.0.20230621</version>
+    <version>6.4.0.20240331</version>
     <authors>SychicBoy</authors>
     <description>NETReactorSlayer is an open source (GPLv3) deobfuscator and unpacker for Eziriz .NET Reactor.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="net-reactor-slayer" version="[6.4.0]" />
+      <dependency id="net-reactor-slayer" version="[6.4.0.0]" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/netcat.vm/netcat.vm.nuspec
+++ b/packages/netcat.vm/netcat.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>netcat.vm</id>
-    <version>1.12.0</version>
+    <version>1.12</version>
     <authors>Hobbit</authors>
     <description>Netcat is a networking utility for reading from and writing to network connections using TCP or UDP.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="netcat" version="[1.12.0]" />
+      <dependency id="netcat" version="[1.12]" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/openvpn.vm/openvpn.vm.nuspec
+++ b/packages/openvpn.vm/openvpn.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>openvpn.vm</id>
-    <version>2.6.9</version>
+    <version>2.6.10.20240413</version>
     <authors>OpenVPN Technologies Inc</authors>
     <description>OpenVPN is a full-featured open source SSL VPN solution that accommodates a wide range of configurations.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="openvpn" version="[2.6.9.1]" />
+      <dependency id="openvpn" version="[2.6.10.001]" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20240217</version>
+    <version>0.0.0.20240331</version>
     <description>Metapackage that requires the dependencies below:
 - visualstudio2017buildtools
 - visualstudio2017-workload-vctools
@@ -10,7 +10,7 @@
     <authors>Mandiant, Microsoft</authors>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="visualstudio2017buildtools" version="[15.9.58, 15.9.59)" />
+      <dependency id="visualstudio2017buildtools" version="[15.9.58.0, 15.9.59.0)" />
       <dependency id="visualstudio2017-workload-vctools" version="[1.3.3]" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Some dependencies have minor typo in their version or use non-existent version.
Typo:
- nasm
- openvpn
Not full version:
- netcat
- net-reactor-slayer
- vcbuildtools
Non existent / not verified version:
- vcredist140
- dotnet-6.0-sdk
