### PR TITLE
Major Update to RegCool

### DIFF
--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>1.361.0.20240228</version>
+    <version>2.0.0.20240408</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'RegCool'
 $category = 'Registry'
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
-$zipSha256 = '9b15369b688a5cabcf86f6ecc725d99678a60bf0c370bfd1b0d9cccf2eee9003'
+$zipSha256 = '7bf7ba799059b4ec4035c504de6ea27ea2e9440379b4ec25d09cb58f17ce609b'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false


### PR DESCRIPTION
This PR updates `RegCool` to the latest release (v2.0 that was released on April 8, 2024).