### PR TITLE
Add Signature Verification to Regcool

### DIFF
--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>2.0.0.20240408</version>
+    <version>0.0.0.20240410</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,38 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegCool'
 $category = 'Registry'
+$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
-$zipSha256 = '7bf7ba799059b4ec4035c504de6ea27ea2e9440379b4ec25d09cb58f17ce609b'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false
+try {
+    # Download zip
+    $packageArgs      = @{
+      packageName     = $env:ChocolateyPackageName
+      file            = Join-Path ${Env:TEMP} $toolName
+      url             = $zipUrl
+    }
+    $filePath = Get-ChocolateyWebFile @packageArgs
+
+    # Extract zip
+    Get-ChocolateyUnzip -FileFullPath $filePath -Destination $toolDir
+
+    # Check signature of all unzip files
+    Get-ChildItem -Path "$toolDir\*.{exe,dll}" | ForEach-Object {
+        VM-Assert-Signature $_.FullName
+    }
+} catch {
+    # Remove files with invalid signature
+    Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
+    VM-Write-Log-Exception $_
+}
+
+try {
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+    $shortcut = Join-Path $shortcutDir "$toolname.lnk"
+    $toolPath = Join-Path $toolDir "$toolName.exe"
+    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $toolPath
+    VM-Assert-Path $shortcut
+} catch {
+    VM-Write-Log-Exception $_
+}


### PR DESCRIPTION
This adds signature checks instead of `sha256` checks to `regcool.vm` so that it will not fail the `daily.yml` checks when an update occurs.