### PR TITLE
De-ConsoleApp Windump

### DIFF
--- a/packages/windump.vm/tools/chocolateyinstall.ps1
+++ b/packages/windump.vm/tools/chocolateyinstall.ps1
@@ -32,7 +32,7 @@ try {
         $executablePath = Join-Path $toolDir "\x64\$toolName.exe" -Resolve
     }
 
-    VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $true
+    VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath
     Install-BinFile -Name $toolName -Path $executablePath
 } catch {
     VM-Write-Log-Exception $_

--- a/packages/windump.vm/windump.vm.nuspec
+++ b/packages/windump.vm/windump.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>windump.vm</id>
-    <version>0.3.20250219</version>
+    <version>0.3.0.20250815</version>
     <authors>Riverbed Technology and hsluoyz</authors>
     <description>Windows version of tcpdump, the command line network analyzer for UNIX</description>
     <dependencies>


### PR DESCRIPTION
This will make `Windump` not a "consoleapp" anymore. It still functions normally, but gives the added benefit of allowing an easier way to find `Windump` when trying to add it to `Procdot` settings.