### PR TITLE
Remove Cmd Here from Registry

### DIFF
--- a/packages/map.vm/map.vm.nuspec
+++ b/packages/map.vm/map.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>map.vm</id>
-    <version>0.0.0.20230723</version>
+    <version>0.0.0.20240410</version>
     <authors>David Zimmer</authors>
     <description>Handful of small utility type applications useful for analyzing malicious code.</description>
     <dependencies>

--- a/packages/map.vm/tools/chocolateyinstall.ps1
+++ b/packages/map.vm/tools/chocolateyinstall.ps1
@@ -28,3 +28,13 @@ try {
 } catch {
   VM-Write-Log-Exception $_
 }
+
+# Try to remove right click registry keys, but do not fail the package if it fails.
+$ErrorActionPreference = 'Continue'
+
+$cmdHereRegistryPath1 = "HKLM:\SOFTWARE\Classes\Directory\background\shell\ctx_cmd"
+$cmdHereRegistryPath2 = "HKLM:\SOFTWARE\Classes\Folder\shell\Cmd Here"
+
+ForEach ($regKey in @($cmdHereRegistryPath1, $cmdHereRegistryPath2)) {
+  Remove-Item -Path $regKey -Recurse -Force
+}


### PR DESCRIPTION
This removes the registry keys for Right Click -> `Cmd Here` that get registered automatically during installation of `map.vm`.

We have moved towards using `Windows-Terminal` for our default "Right Click Cmd Here" option, and this causes a conflict.