### PR TITLE
Add pdbresym.vm

### DIFF
--- a/packages/pdbresym.vm/pdbresym.vm.nuspec
+++ b/packages/pdbresym.vm/pdbresym.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pdbresym.vm</id>
+    <version>1.3.3</version>
+    <authors>Stephen Eckels</authors>
+    <description>Download PDBs</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="vcredist140.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbresym.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'PDBReSym'
+  $category = 'Utilities'
+
+  $zipUrl = 'https://github.com/mandiant/STrace/releases/download/v1.3.3/PDBReSym.zip'
+  $zipSha256 = '803dfc0321581bc39001f050cdafe672e9e3247e96ffd42606fda3d641f0fd57'
+
+  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -arguments "--help")[-1]
+
+  # Iterate through C:\Windows\System32 downloading all PDBs concurrently
+  VM-Write-Log "INFO" "Iterating through C:\Windows\System32 downloading PDBs to C:\symbols"
+  & $executablePath cachesyms
+  # The downloaded symbols are store into C:\symbols
+  VM-Assert-Path "C:\symbols"
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/pdbresym.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pdbresym.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'PDBReSym'
+$category = 'Utilities'
+
+# Uninstalling only removes the tool not the downloaded symbols
+VM-Uninstall $toolName $category


### PR DESCRIPTION
Install PDBReSym and run `PDBReSym cachesyms` to iterate through `C:\Windows\System32` downloading all PDBs concurrently. The downloaded symbols are store into `C:\symbols`.

@stevemk14ebr and @schrodyn please take a look :wink: 

Closes https://github.com/mandiant/VM-Packages/issues/688