### PR TITLE
Update common.vm for all affected packages

### DIFF
--- a/packages/adconnectdump.vm/adconnectdump.vm.nuspec
+++ b/packages/adconnectdump.vm/adconnectdump.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>adconnectdump.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>fox-it</authors>
     <description>This toolkit offers several ways to extract and decrypt stored Azure AD and Active Directory credentials from Azure AD Connect servers.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/amcacheparser.vm/amcacheparser.vm.nuspec
+++ b/packages/amcacheparser.vm/amcacheparser.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>amcacheparser.vm</id>
-    <version>1.5.1.20231208</version>
+    <version>1.5.1.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Amcache.hve parser with lots of extra features. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/appcompatcacheparser.vm/appcompatcacheparser.vm.nuspec
+++ b/packages/appcompatcacheparser.vm/appcompatcacheparser.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>appcompatcacheparser.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>AppCompatCache aka ShimCache parser. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/asreproast.vm/asreproast.vm.nuspec
+++ b/packages/asreproast.vm/asreproast.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>asreproast.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>HarmJ0y</authors>
     <description>Project that retrieves crackable hashes from KRB5 AS-REP responses for users without kerberoast preauthentication enabled.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/azurehound.vm/azurehound.vm.nuspec
+++ b/packages/azurehound.vm/azurehound.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>azurehound.vm</id>
-    <version>2.1.8</version>
+    <version>2.1.8.20240411</version>
     <authors>BloodHoundAD</authors>
     <description>AzureHound is the BloodHound data collector for Microsoft Azure.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/blobrunner.vm/blobrunner.vm.nuspec
+++ b/packages/blobrunner.vm/blobrunner.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>blobrunner.vm</id>
-    <version>0.0.5.20240217</version>
+    <version>0.0.5.20240411</version>
     <authors>OALabs</authors>
     <description>BlobRunner is a simple tool to quickly debug shellcode extracted during malware analysis.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/blobrunner64.vm/blobrunner64.vm.nuspec
+++ b/packages/blobrunner64.vm/blobrunner64.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>blobrunner64.vm</id>
-    <version>0.0.5.20240217</version>
+    <version>0.0.5.20240411</version>
     <authors>OALabs</authors>
     <description>BlobRunner is a simple tool to quickly debug shellcode extracted during malware analysis.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
+++ b/packages/bloodhound-custom-queries.vm/bloodhound-custom-queries.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound-custom-queries.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>hausec</authors>
     <description>Custom Query list for the Bloodhound GUI based off my cheatsheet</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/bloodhound.vm/bloodhound.vm.nuspec
+++ b/packages/bloodhound.vm/bloodhound.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bloodhound.vm</id>
-    <version>4.3.1.20230713</version>
+    <version>4.3.1.20240411</version>
     <description>BloodHound uses graph theory to reveal the hidden and often unintended relationships within an Active Directory environment.</description>
     <authors>Andrew Robbins, Rohan Vazarkar, Will Schroeder</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/bstrings.vm/bstrings.vm.nuspec
+++ b/packages/bstrings.vm/bstrings.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bstrings.vm</id>
-    <version>1.5.2.20231208</version>
+    <version>1.5.2.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Find them strings yo. Built in regex patterns. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/c3.vm/c3.vm.nuspec
+++ b/packages/c3.vm/c3.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>c3.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>WithSecureLabs</authors>
     <description>C3 (Custom Command and Control) is a tool that allows Red Teams to rapidly develop and utilise esoteric command and control channels (C2). It's a framework that extends other red team tooling, such as the commercial Cobalt Strike (CS) product via ExternalC2.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/capa.vm/capa.vm.nuspec
+++ b/packages/capa.vm/capa.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>capa.vm</id>
-    <version>7.0.1</version>
+    <version>7.0.1.20240411</version>
     <description>capa detects capabilities in executable files. You run it against a PE file or shellcode and it tells you what it thinks the program can do.</description>
     <authors>@williballenthin, @mr-tz, @Ana06, @mike-hunhoff, @mwilliams31, @MalwareMechanic</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/certify.vm/certify.vm.nuspec
+++ b/packages/certify.vm/certify.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>certify.vm</id>
-    <version>1.1.0.20240323</version>
+    <version>1.1.0.20240411</version>
     <authors>HarmJ0y, leechristensen</authors>
     <description>Certify is a C# tool to enumerate and abuse misconfigurations in Active Directory Certificate Services (AD CS).</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/chainsaw.vm/chainsaw.vm.nuspec
+++ b/packages/chainsaw.vm/chainsaw.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>chainsaw.vm</id>
-    <version>2.8.1</version>
+    <version>2.8.1.20240411</version>
     <authors>WithSecure Labs</authors>
     <description>Chainsaw provides a powerful 'first-response' capability to quickly identify threats within Windows forensic artefacts such as Event Logs and the MFT file.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240410</version>
+    <version>0.0.0.20240411</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -225,10 +225,11 @@ function VM-Install-Raw-GitHub-Repo {
     )
     try {
         if ($withoutBinFile) {
-            VM-Install-From-Zip -toolName $toolName -category $category -zipUrl $zipUrl -zipSha256 $zipSha256 -innerFolder $innerFolder -executableName $executableName -withoutBinFile -powershellCommand $powershellCommand
+            $toolDir = (VM-Install-From-Zip -toolName $toolName -category $category -zipUrl $zipUrl -zipSha256 $zipSha256 -innerFolder $innerFolder -executableName $executableName -withoutBinFile -powershellCommand $powershellCommand)[0]
         } else {
-            VM-Install-From-Zip -toolName $toolName -category $category -zipUrl $zipUrl -zipSha256 $zipSha256 -innerFolder $innerFolder -executableName $executableName -powershellCommand $powershellCommand
+            $toolDir = (VM-Install-From-Zip -toolName $toolName -category $category -zipUrl $zipUrl -zipSha256 $zipSha256 -innerFolder $innerFolder -executableName $executableName -powershellCommand $powershellCommand)[0]
         }
+        return $toolDir
     } catch {
         VM-Write-Log-Exception $_
     }
@@ -320,9 +321,10 @@ function VM-Install-Shortcut{
     }
 }
 
-# This functions returns $toolDir (outputed by Install-ChocolateyZipPackage) and $executablePath
+# This functions returns $toolDir and $executablePath
 function VM-Install-From-Zip {
     [CmdletBinding()]
+    [OutputType([System.Object[]])]
     Param
     (
         [Parameter(Mandatory=$true, Position=0)]
@@ -331,7 +333,7 @@ function VM-Install-From-Zip {
         [string] $category,
         [Parameter(Mandatory=$true, Position=2)]
         [string] $zipUrl,
-        [Parameter(Mandatory=$true, Position=3)]
+        [Parameter(Mandatory=$false, Position=3)]
         [string] $zipSha256,
         [Parameter(Mandatory=$false)]
         [string] $zipUrl_64,
@@ -397,7 +399,7 @@ function VM-Install-From-Zip {
             VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $consoleApp -arguments $arguments
             Install-BinFile -Name $toolName -Path $executablePath
         }
-        return $executablePath
+        return ,@($toolDir, $executablePath)
     } catch {
         VM-Write-Log-Exception $_
     }

--- a/packages/covenant.vm/covenant.vm.nuspec
+++ b/packages/covenant.vm/covenant.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>covenant.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>cobbr</authors>
     <description>Covenant is a .NET command and control framework that aims to highlight the attack surface of .NET, make the use of offensive .NET tradecraft easier, and serve as a collaborative command and control platform for red teamers.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/credninja.vm/credninja.vm.nuspec
+++ b/packages/credninja.vm/credninja.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>credninja.vm</id>
-    <version>2.3.0.20240323</version>
+    <version>2.3.0.20240411</version>
     <authors>raikiasec</authors>
     <description>This tool will tell you if the credentials you dumped are valid on the domain, and if you have local administrator access to a host.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/cryptotester.vm/cryptotester.vm.nuspec
+++ b/packages/cryptotester.vm/cryptotester.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cryptotester.vm</id>
-    <version>1.7.1</version>
+    <version>1.7.1.20240411</version>
     <authors>Michael Gillespie (@demonslay335)</authors>
     <description>Utility tool for performing cryptanalysis with a focus on ransomware cryptography</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/cutter.vm/cutter.vm.nuspec
+++ b/packages/cutter.vm/cutter.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cutter.vm</id>
-    <version>2.3.4.20240305</version>
+    <version>2.3.4.20240411</version>
     <authors>Rizin</authors>
     <description>Cutter is a FOSS dissassembler/decompiler</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="vcredist140.vm" />
     </dependencies>
   </metadata>

--- a/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
+++ b/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>de4dot-cex.vm</id>
-    <version>4.0.0.20230526</version>
+    <version>4.0.0.20240411</version>
     <authors>ViRb3</authors>
     <description>A de4dot fork with full support for vanilla ConfuserEx</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dex2jar.vm/dex2jar.vm.nuspec
+++ b/packages/dex2jar.vm/dex2jar.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dex2jar.vm</id>
-    <version>2.3.0.20231025</version>
+    <version>2.3.0.20240411</version>
     <authors>@pxb1988</authors>
     <description>Tools to work with android .dex and java .class files.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="openjdk.vm" />
     </dependencies>
   </metadata>

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.07.20240217</version>
+    <version>3.07.0.20240411</version>
     <authors>Hellsp@wn, horsicq</authors>
     <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20230925" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dnspyex.vm/dnspyex.vm.nuspec
+++ b/packages/dnspyex.vm/dnspyex.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dnspyex.vm</id>
-    <version>6.5.0</version>
+    <version>6.5.0.20240411</version>
     <authors>0xd4d, ElektroKill</authors>
     <description>dnSpyEx is a unofficial continuation of the dnSpy project which is a debugger and .NET assembly editor. You can use it to edit and debug assemblies even if you don't have any source code available.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dotdumper.vm/dotdumper.vm.nuspec
+++ b/packages/dotdumper.vm/dotdumper.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotdumper.vm</id>
-    <version>1.1</version>
+    <version>1.1.0.20240411</version>
     <authors>ThisIsLibra</authors>
     <description>An automatic unpacker and logger for DotNet Framework targeting files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
+++ b/packages/dotnettojscript.vm/dotnettojscript.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotnettojscript.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>James Forshaw</authors>
     <description>A tool to generate a JScript which bootstraps an arbitrary .NET Assembly and class.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/dumpert.vm/dumpert.vm.nuspec
+++ b/packages/dumpert.vm/dumpert.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dumpert.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>outflank</authors>
     <description>This tool demonstrates the use of direct System Calls and API unhooking and combines these techniques in a proof of concept code which can be used to create a LSASS memory dump using Cobalt Strike.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/evilclippy.vm/evilclippy.vm.nuspec
+++ b/packages/evilclippy.vm/evilclippy.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>evilclippy.vm</id>
-    <version>1.3.0.20240323</version>
+    <version>1.3.0.20240411</version>
     <authors>outflank</authors>
     <description>A cross-platform assistant for creating malicious MS Office documents. Can hide VBA macros, stomp VBA code (via P-Code) and confuse macro analysis tools.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/evtxecmd.vm/evtxecmd.vm.nuspec
+++ b/packages/evtxecmd.vm/evtxecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>evtxecmd.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Event log (evtx) parser with standardized CSV, XML, and json output! Custom maps, locked file support, and more!</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/exeinfope.vm/exeinfope.vm.nuspec
+++ b/packages/exeinfope.vm/exeinfope.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exeinfope.vm</id>
-    <version>0.0.7.20240217</version>
+    <version>0.0.7.20240411</version>
     <authors>A.S.L Soft</authors>
     <description>Displays metadata for a variety of file types and identifies many executable packers</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
+++ b/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>extreme_dumper.vm</id>
-    <version>4.0.0.20240219</version>
+    <version>4.0.0.20240411</version>
     <authors>wwh1004</authors>
     <description>.NET Assembly Dumper from memory of processes.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ezviewer.vm/ezviewer.vm.nuspec
+++ b/packages/ezviewer.vm/ezviewer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ezviewer.vm</id>
-    <version>2.0.0.20240226</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Standalone, zero dependency viewer for .doc, .docx, .xls, .xlsx, .txt, .log, .rtf, .otd, .htm, .html, .mht, .csv, and .pdf. Any non-supported files are shown in a hex editor (with data interpreter!)</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/file.vm/file.vm.nuspec
+++ b/packages/file.vm/file.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>file.vm</id>
-    <version>0.0.0.20240217</version>
+    <version>0.0.0.20240411</version>
     <description>A Windows port of the Linux `file` utility for checking header magics</description>
     <authors>Nolen Scaiffe</authors>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20230925" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/floss.vm/floss.vm.nuspec
+++ b/packages/floss.vm/floss.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>floss.vm</id>
-    <version>3.0.1.20240217</version>
+    <version>3.0.1.20240411</version>
     <description>FLOSS uses advanced static analysis techniques to automatically deobfuscate strings from malware binaries. You can use it just like strings.exe to enhance basic static analysis of unknown binaries.</description>
     <authors>@williballenthin, @mr-tz</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/fuzzdb.vm/fuzzdb.vm.nuspec
+++ b/packages/fuzzdb.vm/fuzzdb.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>fuzzdb.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>fuzzdb-project</authors>
     <description>FuzzDB is the most comprehensive open dictionary of fault injection patterns, predictable resource locations, and regex for matching server responses.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
+++ b/packages/gadgettojscript.vm/gadgettojscript.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gadgettojscript.vm</id>
-    <version>2.0.0.20240323</version>
+    <version>2.0.0.20240411</version>
     <authors>med0x2e</authors>
     <description>A tool for generating .NET serialized gadgets that can trigger .NET assembly load/execution when deserialized using BinaryFormatter from JS/VBS/VBA scripts.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/garbageman.vm/garbageman.vm.nuspec
+++ b/packages/garbageman.vm/garbageman.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>garbageman.vm</id>
-    <version>0.2.4</version>
+    <version>0.2.4.20240411</version>
     <authors>alphillips-lab</authors>
     <description>A set of tools designed for .NET heap analysis.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet5-desktop-runtime" version="5.0.6" />
     </dependencies>
   </metadata>

--- a/packages/gobuster.vm/gobuster.vm.nuspec
+++ b/packages/gobuster.vm/gobuster.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gobuster.vm</id>
-    <version>3.5.0.20230713</version>
+    <version>3.5.0.20240411</version>
     <description>Directory/file and DNS busting tool written in Go</description>
     <authors>OJ Reeves</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/goresym.vm/goresym.vm.nuspec
+++ b/packages/goresym.vm/goresym.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>goresym.vm</id>
-    <version>2.4.0.20240217</version>
+    <version>2.4.0.20240411</version>
     <authors>stevemk14ebr</authors>
     <description>Go symbol recovery tool</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/hasher.vm/hasher.vm.nuspec
+++ b/packages/hasher.vm/hasher.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hasher.vm</id>
-    <version>2.0.0.20240226</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Hash all the things</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="netfx-4.8" version="[4.8.0.20220524]" />
     </dependencies>
   </metadata>

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20240217</version>
+    <version>0.0.0.20240411</version>
     <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
     <authors>Nir Sofer</authors>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20230925" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/hayabusa.vm/hayabusa.vm.nuspec
+++ b/packages/hayabusa.vm/hayabusa.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hayabusa.vm</id>
-    <version>2.11.0</version>
+    <version>2.11.0.20240411</version>
     <authors>Yamato Security</authors>
     <description>Windows event log fast forensics timeline generator and threat hunting tool</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/hollowshunter.vm/hollowshunter.vm.nuspec
+++ b/packages/hollowshunter.vm/hollowshunter.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hollowshunter.vm</id>
-    <version>0.3.9</version>
+    <version>0.3.9.20240411</version>
     <authors>hasherezade</authors>
     <description>Scans all running processes. Recognizes and dumps a variety of potentially malicious implants (replaced/implanted PEs, shellcodes, hooks, in-memory patches).</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
+++ b/packages/ida.diaphora.vm/ida.diaphora.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.diaphora.vm</id>
-    <version>3.1.2</version>
+    <version>3.1.2.20240411</version>
     <authors>joxeankoret</authors>
     <description>Diaphora is a program diffing tool that works as an IDA plugin.</description>
     <dependencies>
-      <!-- This package uses new arguments of VM-Install-From-Zip introduced in common.vm version 0.0.0.20230615 -->
-      <dependency id="common.vm" version="0.0.0.20230615" />
+      <!-- This package uses new arguments of VM-Install-From-Zip introduced in common.vm version 0.0.0.20240411 -->
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ifpstools.vm/ifpstools.vm.nuspec
+++ b/packages/ifpstools.vm/ifpstools.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ifpstools.vm</id>
-    <version>2.0.2.20231203</version>
+    <version>2.0.2.20240411</version>
     <authors>Wack0, Jonson Tan</authors>
     <description>IFPSTools.NET: tools for working with RemObject PascalScript compiled bytecode files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/innoextract.vm/innoextract.vm.nuspec
+++ b/packages/innoextract.vm/innoextract.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>innoextract.vm</id>
-    <version>1.9.0.20231203</version>
+    <version>1.9.0.20240411</version>
     <authors>Daniel Scharrer</authors>
     <description>A tool to extract Inno Setup installers.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/inveigh.vm/inveigh.vm.nuspec
+++ b/packages/inveigh.vm/inveigh.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>inveigh.vm</id>
-    <version>2.0.10.20231203</version>
+    <version>2.0.10.20240411</version>
     <authors>Kevin-Robertson, joncave, kant2002</authors>
     <description>Inveigh is a cross-platform .NET IPv4/IPv6 machine-in-the-middle tool for penetration testers.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/invokedosfuscation.vm/invokedosfuscation.vm.nuspec
+++ b/packages/invokedosfuscation.vm/invokedosfuscation.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>invokedosfuscation.vm</id>
-    <version>1.0.0.20240312</version>
+    <version>1.0.0.20240411</version>
     <authors>danielbohannon</authors>
     <description>Invoke-DOSfuscation is a PowerShell v2.0+ compatible cmd.exe command obfuscation framework.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/invokeobfuscation.vm/invokeobfuscation.vm.nuspec
+++ b/packages/invokeobfuscation.vm/invokeobfuscation.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>invokeobfuscation.vm</id>
-    <version>1.8.2.20240312</version>
+    <version>1.8.2.20240411</version>
     <authors>cobbr, 4d4c, mvle, danielbohannon</authors>
     <description>Invoke-Obfuscation is a PowerShell v2.0+ compatible PowerShell command and script obfuscator.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/jlecmd.vm/jlecmd.vm.nuspec
+++ b/packages/jlecmd.vm/jlecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jlecmd.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Jump List parser</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/jumplist_explorer.vm/jumplist_explorer.vm.nuspec
+++ b/packages/jumplist_explorer.vm/jumplist_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jumplist_explorer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>GUI based Jump List viewer</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/keethief.vm/keethief.vm.nuspec
+++ b/packages/keethief.vm/keethief.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>keethief.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>tifkin_, harmj0y</authors>
     <description>Allows for the extraction of KeePass 2.X key material from memory, as well as the backdooring and enumeration of the KeePass trigger system.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/lecmd.vm/lecmd.vm.nuspec
+++ b/packages/lecmd.vm/lecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>lecmd.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Parse lnk files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/logfileparser.vm/logfileparser.vm.nuspec
+++ b/packages/logfileparser.vm/logfileparser.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>logfileparser.vm</id>
-    <version>2.0.0.20231204</version>
+    <version>2.0.0.20240411</version>
     <authors>Joakim Schicht</authors>
     <description>Decode and dump lots of transaction information from the $LogFile on NTFS.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/malware-jail.vm/malware-jail.vm.nuspec
+++ b/packages/malware-jail.vm/malware-jail.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>malware-jail.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>Hynek Petrak</authors>
     <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="nodejs.vm" />
     </dependencies>
   </metadata>

--- a/packages/memprocfs.vm/memprocfs.vm.nuspec
+++ b/packages/memprocfs.vm/memprocfs.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>memprocfs.vm</id>
-    <version>5.9.4</version>
+    <version>5.9.4.20240411</version>
     <authors>Ulf Frisk</authors>
     <description>MemProcFS is an easy and convenient way of viewing physical memory as files in a virtual file system.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dokan.vm" />
     </dependencies>
   </metadata>

--- a/packages/mft_explorer.vm/mft_explorer.vm.nuspec
+++ b/packages/mft_explorer.vm/mft_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mft_explorer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Graphical $MFT viewer</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/mftecmd.vm/mftecmd.vm.nuspec
+++ b/packages/mftecmd.vm/mftecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mftecmd.vm</id>
-    <version>1.2.2.20240321</version>
+    <version>1.2.2.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>$MFT, $Boot, $J, $SDS, $I30, and $LogFile (coming soon) parser. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/microburst.vm/microburst.vm.nuspec
+++ b/packages/microburst.vm/microburst.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microburst.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>NetSPI</authors>
     <description>MicroBurst includes functions and scripts that support Azure Services discovery, weak configuration auditing, and post exploitation actions such as credential dumping.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="az.powershell" />
     </dependencies>
   </metadata>

--- a/packages/nanodump.vm/nanodump.vm.nuspec
+++ b/packages/nanodump.vm/nanodump.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nanodump.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>fortra</authors>
     <description>A Beacon Object File that creates a minidump of the LSASS process.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/networkminer.vm/networkminer.vm.nuspec
+++ b/packages/networkminer.vm/networkminer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>networkminer.vm</id>
-    <version>2.8.1</version>
+    <version>2.8.1.20240411</version>
     <authors>Netresec</authors>
     <description>NetworkMiner is an open source Network Forensic Analysis Tool for Windows, but also works in Linux or Mac OS X. NetworkMiner can be used as a passive network sniffer in order to detect operating systems, sessions, hostnames, open ports etc. without putting any traffic on the network. NetworkMiner can also parse PCAP files for off-line analysis and to reassemble transmitted files and certificates from PCAP files.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/offvis.vm/offvis.vm.nuspec
+++ b/packages/offvis.vm/offvis.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>offvis.vm</id>
-    <version>1.0.0.20240226</version>
+    <version>1.0.0.20240411</version>
     <authors>Microsoft</authors>
     <description>The Microsoft Office Visualization Tool (OffVis) is a tool from Microsoft that helps understanding the Microsoft Office binary file format in order to deconstruct .doc-, .xls- and .ppt-based targeted attacks.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet3.5" />
     </dependencies>
   </metadata>

--- a/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
+++ b/packages/outflank-c2-tool-collection.vm/outflank-c2-tool-collection.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>outflank-c2-tool-collection.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>outflank</authors>
     <description>Contains a collection of tools which integrate with Cobalt Strike (and possibly other C2 frameworks) through BOF and reflective DLL loading techniques.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/payloadsallthethings.vm/payloadsallthethings.vm.nuspec
+++ b/packages/payloadsallthethings.vm/payloadsallthethings.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>payloadsallthethings.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>swisskyrepo</authors>
     <description>A list of useful payloads and bypasses for Web Application Security.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/peanatomist.vm/peanatomist.vm.nuspec
+++ b/packages/peanatomist.vm/peanatomist.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>peanatomist.vm</id>
-    <version>0.2.11931.20230825</version>
+    <version>0.2.11931.20240411</version>
     <authors>RamMerLabs</authors>
     <description>PE Analysis tool providing detailed information</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pecmd.vm/pecmd.vm.nuspec
+++ b/packages/pecmd.vm/pecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pecmd.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Prefetch parser</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/peid.vm/peid.vm.nuspec
+++ b/packages/peid.vm/peid.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>peid.vm</id>
-    <version>0.95.0.20221115</version>
+    <version>0.95.0.20240411</version>
     <description>PEiD detects most common packers, cryptors and compilers for PE files.</description>
     <authors>snaker, Qwerton, Jibz, xineohP</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pestudio.vm/pestudio.vm.nuspec
+++ b/packages/pestudio.vm/pestudio.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pestudio.vm</id>
-    <version>9.58</version>
+    <version>9.58.0.20240411</version>
     <authors>Marc Ochsenmeier</authors>
     <description>The goal of pestudio is to spot artifacts of executable files in order to ease and accelerate Malware Initial Assessment.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/petitpotam.vm/petitpotam.vm.nuspec
+++ b/packages/petitpotam.vm/petitpotam.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>petitpotam.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>topotam</authors>
     <description>PoC tool to coerce Windows hosts to authenticate to other machines via MS-EFSRPC EfsRpcOpenFileRaw or other functions</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pkg-unpacker.vm</id>
-    <version>1.0.0.20240323</version>
+    <version>1.0.0.20240411</version>
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="nodejs.vm" />
     </dependencies>
   </metadata>

--- a/packages/pma-labs.vm/pma-labs.vm.nuspec
+++ b/packages/pma-labs.vm/pma-labs.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pma-labs.vm</id>
-    <version>0.0.0.20230626</version>
+    <version>0.0.0.20240411</version>
     <authors>Michael Sikorski</authors>
     <description>Binaries for the book Practical Malware Analysis</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/powermad.vm/powermad.vm.nuspec
+++ b/packages/powermad.vm/powermad.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powermad.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>Kevin-Robertson</authors>
     <description>Powermad includes a set of functions for exploiting ms-DS-MachineAccountQuota without attaching an actual system to AD</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/powersploit.vm/powersploit.vm.nuspec
+++ b/packages/powersploit.vm/powersploit.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powersploit.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>HarmJ0y, 0xe7</authors>
     <description>PowerSploit is a collection of Microsoft PowerShell modules that can be used to aid penetration testers during all phases of an assessment.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/powerupsql.vm/powerupsql.vm.nuspec
+++ b/packages/powerupsql.vm/powerupsql.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powerupsql.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>NetSPI</authors>
     <description>PowerUpSQL includes functions that support SQL Server discovery, weak configuration auditing, privilege escalation on scale, and post exploitation actions such as OS command execution.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/powerzure.vm/powerzure.vm.nuspec
+++ b/packages/powerzure.vm/powerzure.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powerzure.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>hausec</authors>
     <description>PowerZure is a PowerShell project created to assess and exploit resources within Microsoft’s cloud platform, Azure.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="az.powershell" />
     </dependencies>
   </metadata>

--- a/packages/rbcmd.vm/rbcmd.vm.nuspec
+++ b/packages/rbcmd.vm/rbcmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rbcmd.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Recycle Bin artifact (INFO2/$I) parser</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/recentfilecacheparser.vm/recentfilecacheparser.vm.nuspec
+++ b/packages/recentfilecacheparser.vm/recentfilecacheparser.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>recentfilecacheparser.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>RecentFileCache parser</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/recmd.vm/recmd.vm.nuspec
+++ b/packages/recmd.vm/recmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>recmd.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Powerful command line Registry tool searching, multi-hive support, plugins, and more</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>0.0.0.20240410</version>
+    <version>0.0.0.20240411</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>registry_explorer.vm</id>
-    <version>2.0.0.20240226</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Registry viewer with searching, multi-hive support, plugins, and more. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/regshot.vm/regshot.vm.nuspec
+++ b/packages/regshot.vm/regshot.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regshot.vm</id>
-    <version>1.9.1.20240217</version>
+    <version>1.9.1.20240411</version>
     <authors>maddes, regshot, xhmikosr</authors>
     <description>Regshot is a small, free and open-source registry compare utility that allows you to quickly take a snapshot of your registry and then compare it with a second one - done after doing system changes or installing a new software product.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/rla.vm/rla.vm.nuspec
+++ b/packages/rla.vm/rla.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rla.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Replay transaction logs and update Registry hives so they are no longer dirty. Useful when tools do not know how to handle transaction logs</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/routesixtysink.vm/routesixtysink.vm.nuspec
+++ b/packages/routesixtysink.vm/routesixtysink.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>routesixtysink.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>Dillon Franke, Michael Maturi</authors>
     <description>Route Sixty-Sink is an open source tool that enables defenders and security researchers alike to quickly identify vulnerabilities in any .NET assembly using automated source-to-sink analysis.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/rpcview.vm/rpcview.vm.nuspec
+++ b/packages/rpcview.vm/rpcview.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rpcview.vm</id>
-    <version>0.3.1.20231218</version>
+    <version>0.3.1.20240411</version>
     <authors>silverf0x</authors>
     <description>RpcView is an open-source tool to explore and decompile all RPC functionalities present on a Microsoft system</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="vcredist140.vm" />
     </dependencies>
   </metadata>

--- a/packages/rubeus.vm/rubeus.vm.nuspec
+++ b/packages/rubeus.vm/rubeus.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rubeus.vm</id>
-    <version>2.3.1.20240323</version>
+    <version>2.3.1.20240411</version>
     <authors>harmj0y</authors>
     <description>Rubeus is a C# toolset for raw Kerberos interaction and abuses.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
+++ b/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>rundotnetdll.vm</id>
-    <version>2.2.0.20231203</version>
+    <version>2.2.0.20240411</version>
     <description>A simple utility to list all methods of a given .NET Assembly and to invoke them.</description>
     <authors>Antonio Parata</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/safetykatz.vm/safetykatz.vm.nuspec
+++ b/packages/safetykatz.vm/safetykatz.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>safetykatz.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>HarmJ0y</authors>
     <description>SafetyKatz is a combination of slightly modified version of @gentilkiwi's Mimikatz project and @subtee's .NET PE Loader.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sbecmd.vm/sbecmd.vm.nuspec
+++ b/packages/sbecmd.vm/sbecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sbecmd.vm</id>
-    <version>2.0.0.20240321</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>ShellBags Explorer, command line edition, for exporting shellbag data</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/scdbg.vm/scdbg.vm.nuspec
+++ b/packages/scdbg.vm/scdbg.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>scdbg.vm</id>
-    <version>0.0.0.20240217</version>
+    <version>0.0.0.20240411</version>
     <authors>Paul Baecher, Markus Koetter, David Zimmer</authors>
     <description>scdbg is an emulation based shellcode API logger and debugger</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sdb_explorer.vm/sdb_explorer.vm.nuspec
+++ b/packages/sdb_explorer.vm/sdb_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sdb_explorer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Shim database GUI</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/seatbelt.vm/seatbelt.vm.nuspec
+++ b/packages/seatbelt.vm/seatbelt.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>seatbelt.vm</id>
-    <version>1.2.0.20240323</version>
+    <version>1.2.0.20240411</version>
     <authors>harmj0y, tifkin_</authors>
     <description>Seatbelt is a C# project that performs a number of security oriented host-survey "safety checks" relevant from both offensive and defensive security perspectives.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/seclists.vm/seclists.vm.nuspec
+++ b/packages/seclists.vm/seclists.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>seclists.vm</id>
-    <version>2024.1.0.20240323</version>
+    <version>2024.1.0.20240411</version>
     <authors>danielmiessler</authors>
     <description>SecLists is the security tester's companion. It's a collection of multiple types of lists used during security assessments, collected in one place.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/setdllcharacteristics.vm/setdllcharacteristics.vm.nuspec
+++ b/packages/setdllcharacteristics.vm/setdllcharacteristics.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>setdllcharacteristics.vm</id>
-    <version>0.0.1</version>
+    <version>0.0.1.20240411</version>
     <authors>Didier Stevens</authors>
     <description>A CLI tool for manipulating ASLR, DEP, and check signature flags of PE files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpdpapi.vm/sharpdpapi.vm.nuspec
+++ b/packages/sharpdpapi.vm/sharpdpapi.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpdpapi.vm</id>
-    <version>1.11.3.20240323</version>
+    <version>1.11.3.20240411</version>
     <authors>harmj0y</authors>
     <description>SharpDPAPI is a C# port of some DPAPI functionality from @gentilkiwi's Mimikatz project.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpdump.vm/sharpdump.vm.nuspec
+++ b/packages/sharpdump.vm/sharpdump.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpdump.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>HarmJ0y</authors>
     <description>SharpDump is a C# port of PowerSploit's Out-Minidump.ps1 functionality.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpexec.vm/sharpexec.vm.nuspec
+++ b/packages/sharpexec.vm/sharpexec.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpexec.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>anthemtotheego</authors>
     <description>SharpExec is an offensive security C# tool designed to aid with lateral movement.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharphound.vm/sharphound.vm.nuspec
+++ b/packages/sharphound.vm/sharphound.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharphound.vm</id>
-    <version>2.3.3</version>
+    <version>2.3.3.20240411</version>
     <authors>specterops</authors>
     <description>SharpHound is an Active Directory ingester tool for BloodHound.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpsecdump.vm/sharpsecdump.vm.nuspec
+++ b/packages/sharpsecdump.vm/sharpsecdump.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpsecdump.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>G0ldenGunSec</authors>
     <description>.Net port of the remote SAM + LSA Secrets dumping functionality of impacket's secretsdump.py</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpup.vm/sharpup.vm.nuspec
+++ b/packages/sharpup.vm/sharpup.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpup.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>harmj0y</authors>
     <description>SharpUp is a C# port of various PowerUp functionality for auditing potential privilege escalation paths.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpview.vm/sharpview.vm.nuspec
+++ b/packages/sharpview.vm/sharpview.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpview.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>tevora</authors>
     <description>.NET port of PowerView used for information gathering within Active Directory</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sharpwmi.vm/sharpwmi.vm.nuspec
+++ b/packages/sharpwmi.vm/sharpwmi.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sharpwmi.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>HarmJ0y</authors>
     <description>SharpWMI is a C# implementation of various WMI functionality.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/shellbags_explorer.vm/shellbags_explorer.vm.nuspec
+++ b/packages/shellbags_explorer.vm/shellbags_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>shellbags_explorer.vm</id>
-    <version>2.0.0.20231208</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>GUI for browsing shellbags data. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
+++ b/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>situational-awareness-bof.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>trustedsec</authors>
     <description>Provides a set of basic situational awareness commands implemented in a Beacon Object File (BOF). This allows you to perform some checks on a host before you begin executing commands that may be more invasive.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/spoolsample.vm/spoolsample.vm.nuspec
+++ b/packages/spoolsample.vm/spoolsample.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>spoolsample.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>tifkin_, harmj0y, enigma0x3</authors>
     <description>PoC tool to coerce Windows hosts authenticate to other machines via the MS-RPRN RPC interface.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sqlecmd.vm/sqlecmd.vm.nuspec
+++ b/packages/sqlecmd.vm/sqlecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sqlecmd.vm</id>
-    <version>1.0.0.20231208</version>
+    <version>1.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Find and process SQLite files according to your needs with maps!</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/srumecmd.vm/srumecmd.vm.nuspec
+++ b/packages/srumecmd.vm/srumecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>srumecmd.vm</id>
-    <version>0.5.1.20231208</version>
+    <version>0.5.1.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Process SRUDB.dat and (optionally) SOFTWARE hive for network, process, and energy info!</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/statistically-likely-usernames.vm/statistically-likely-usernames.vm.nuspec
+++ b/packages/statistically-likely-usernames.vm/statistically-likely-usernames.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>statistically-likely-usernames.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>insidetrust</authors>
     <description>This resource contains wordlists for creating statistically likely usernames for use in username-enumeration, simulated password-attacks and other security testing tasks.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/stracciatella.vm/stracciatella.vm.nuspec
+++ b/packages/stracciatella.vm/stracciatella.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>stracciatella.vm</id>
-    <version>0.7.0.20240323</version>
+    <version>0.7.0.20240411</version>
     <authors>mgeeky</authors>
     <description>Powershell runspace from within C# (aka SharpPick technique) with AMSI, ETW and Script Block Logging disabled.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/streamdivert.vm/streamdivert.vm.nuspec
+++ b/packages/streamdivert.vm/streamdivert.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>streamdivert.vm</id>
-    <version>1.1</version>
+    <version>1.1.0.20240411</version>
     <authors>jellever</authors>
     <description>StreamDivert has the ability to relay all incoming SMB connections to port 445 to another server, or only relay specific incoming SMB connections from a specific set of source IP's to another server.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sumecmd.vm/sumecmd.vm.nuspec
+++ b/packages/sumecmd.vm/sumecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sumecmd.vm</id>
-    <version>0.5.2.20231208</version>
+    <version>0.5.2.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Process Microsoft User Access Logs found under "C:\Windows\System32\LogFiles\SUM"</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/systeminformer.vm/systeminformer.vm.nuspec
+++ b/packages/systeminformer.vm/systeminformer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>systeminformer.vm</id>
-    <version>3.0.7353</version>
+    <version>3.0.7353.20240411</version>
     <authors>winsiderss</authors>
     <description>A free, powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/syswhispers2.vm/syswhispers2.vm.nuspec
+++ b/packages/syswhispers2.vm/syswhispers2.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>syswhispers2.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>jthuraisamy</authors>
     <description>SysWhispers helps with evasion by generating header/ASM files implants can use to make direct system calls.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/syswhispers3.vm/syswhispers3.vm.nuspec
+++ b/packages/syswhispers3.vm/syswhispers3.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>syswhispers3.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>klezVirus</authors>
     <description>SysWhispers helps with evasion by generating header/ASM files implants can use to make direct system calls.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/teamfiltration.vm/teamfiltration.vm.nuspec
+++ b/packages/teamfiltration.vm/teamfiltration.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>teamfiltration.vm</id>
-    <version>3.5.0.20230713</version>
+    <version>3.5.0.20240411</version>
     <authors>Flangvik</authors>
     <description>TeamFiltration is a cross-platform framework for enumerating, spraying, exfiltrating, and backdooring O365 AAD accounts.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/timeline_explorer.vm/timeline_explorer.vm.nuspec
+++ b/packages/timeline_explorer.vm/timeline_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>timeline_explorer.vm</id>
-    <version>2.0.0.20240321</version>
+    <version>2.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>View CSV and Excel files, filter, group, sort, etc. with ease</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
+++ b/packages/trustedsec-remote-ops-bof.vm/trustedsec-remote-ops-bof.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>truestedsec-remote-ops-bof.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>trustedsec</authors>
     <description>Addition to Situational Awareness BOFs intended for single task Windows primitives such as creating a task, stopping a service, etc.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/unhook-bof.vm/unhook-bof.vm.nuspec
+++ b/packages/unhook-bof.vm/unhook-bof.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>unhook-bof.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>rsmudge, physics-sec</authors>
     <description>This is a Beacon Object File to refresh DLLs and remove their hooks. The code is from Cylance's Universal Unhooking research.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/uniextract2.vm/uniextract2.vm.nuspec
+++ b/packages/uniextract2.vm/uniextract2.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>uniextract2.vm</id>
-    <version>2.0.0.20231220</version>
+    <version>2.0.0.20240411</version>
     <description>Universal Extractor 2 is an unofficial updated and extended version of the original UniExtract by Jared Breland.</description>
     <authors>William Engelmann (Bioruebe)</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/upx.vm/upx.vm.nuspec
+++ b/packages/upx.vm/upx.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>upx.vm</id>
-    <version>4.2.3</version>
+    <version>4.2.3.20240411</version>
     <authors>markus-oberhumer</authors>
     <description>UPX is a free, secure, portable, extendable, high-performance executable packer for several executable formats.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/vscmount.vm/vscmount.vm.nuspec
+++ b/packages/vscmount.vm/vscmount.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscmount.vm</id>
-    <version>1.5.0.20231208</version>
+    <version>1.5.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Mount all VSCs on a drive letter to a given mount point</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/whisker.vm/whisker.vm.nuspec
+++ b/packages/whisker.vm/whisker.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>whisker.vm</id>
-    <version>0.0.0.20240323</version>
+    <version>0.0.0.20240411</version>
     <authors>Elad Shamir</authors>
     <description>Whisker is a C# tool for taking over Active Directory user and computer accounts by manipulating their msDS-KeyCredentialLink attribute, effectively adding "Shadow Credentials" to the target account.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/wxtcmd.vm/wxtcmd.vm.nuspec
+++ b/packages/wxtcmd.vm/wxtcmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wxtcmd.vm</id>
-    <version>1.0.0.20231208</version>
+    <version>1.0.0.20240411</version>
     <authors>Eric Zimmerman</authors>
     <description>Windows 10 Timeline database parser</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
From https://github.com/mandiant/VM-Packages/pull/959, there was an issue with packages not requiring the most up to date `common.vm` leading to many packages to fail in the `daily.yml` check.

There was also an issue with some older packages not performing `sha256 checks` due to it not being a mandatory requirement when made, which will need to be fully addressed later.

This should fix these issues.

