### PR TITLE
[fakenet-ng.vm] Update tool and improve code

### DIFF
--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>1.4.11.20230418</version>
-    <description>FakeNet-NG is a next generation dynamic network analysis tool for malware analysts and penetration testers.</description>
+    <version>3.2.0.20240412</version>
+    <description>FakeNet-NG is a dynamic network analysis tool.</description>
     <authors>Mandiant</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240411" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/fakenet-ng.vm/tools/chocolateyuninstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyuninstall.ps1
@@ -2,26 +2,14 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $toolName = 'FakeNet-NG'
+  $toolName = 'fakenet'
   $category = 'Networking'
 
-  $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-  $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
+  VM-Uninstall $toolName $category
 
-  # Remove tool files
-  Remove-Item $toolDir -Recurse -Force -ea 0
-
-  # Remove shortcut file
-  $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-  Remove-Item $shortcut -Force -ea 0
-
-  # Remove shim
-  $shim = Join-Path $env:ChocolateyInstall "bin\fakenet.exe"
-  Remove-Item $shim -Force -ea 0
-
-  # Remove fakenet_logs LNK file
-  $logDir  = Join-Path ${Env:UserProfile} "Desktop\fakenet_logs.lnk"
-  Remove-Item $logDir -Force -ea 0
+  # Remove Desktop shortcut to FakeNet tool directory
+  $desktopShortcut  = Join-Path ${Env:UserProfile} "Desktop\fakenet_logs.lnk"
+  Remove-Item $desktopShortcut -Force -ea 0
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
Update tool to latest alpha version, which includes a bug affecting VirtualBox in Linux.

Simplify code and make it consistent with helper functions using same structure and variables names.

Access the inner tool directory without hardcoding the version to allow the script to update this package automatically.