### PR TITLE
Split pdbresym.vm

### DIFF
--- a/packages/pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbresym.vm/tools/chocolateyinstall.ps1
@@ -1,20 +1,10 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-  $toolName = 'PDBReSym'
-  $category = 'Utilities'
+$toolName = 'PDBReSym'
+$category = 'Utilities'
 
-  $zipUrl = 'https://github.com/mandiant/STrace/releases/download/v1.3.3/PDBReSym.zip'
-  $zipSha256 = '803dfc0321581bc39001f050cdafe672e9e3247e96ffd42606fda3d641f0fd57'
+$zipUrl = 'https://github.com/mandiant/STrace/releases/download/v1.3.3/PDBReSym.zip'
+$zipSha256 = '803dfc0321581bc39001f050cdafe672e9e3247e96ffd42606fda3d641f0fd57'
 
-  $executablePath = (VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -arguments "--help")[-1]
-
-  # Iterate through C:\Windows\System32 downloading all PDBs concurrently
-  VM-Write-Log "INFO" "Iterating through C:\Windows\System32 downloading PDBs to C:\symbols"
-  & $executablePath cachesyms
-  # The downloaded symbols are store into C:\symbols
-  VM-Assert-Path "C:\symbols"
-} catch {
-  VM-Write-Log-Exception $_
-}
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -arguments "--help"

--- a/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
+++ b/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>pdbresym.vm</id>
-    <version>1.3.3.20240415</version>
+    <id>pdbs.pdbresym.vm</id>
+    <version>0.0.0.20240415</version>
     <authors>Stephen Eckels</authors>
     <description>Download PDBs</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240411" />
-      <dependency id="vcredist140.vm" />
+      <dependency id="pdbresym.vm" version="1.3.3.20240415" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  # Iterate through C:\Windows\System32 downloading all PDBs concurrently
+  $executablePath = Join-Path ${Env:RAW_TOOLS_DIR} PDBReSym\PDBReSym.exe -Resolve
+  VM-Write-Log "INFO" "Iterating through C:\Windows\System32 downloading PDBs to C:\symbols"
+  & $executablePath cachesyms
+  # The downloaded symbols are store into C:\symbols
+  VM-Assert-Path "C:\symbols"
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -302,9 +302,9 @@ class FirstLineDoesNotSetErrorAction(Lint):
 class UsesInvalidCategory(Lint):
     # Some packages don't have a category (we don't create a link in the tools directory)
     EXCLUSIONS = [
+        ".dbgchild.vm",
         ".ollydumpex.vm",
         ".scyllahide.vm",
-        ".dbgchild.vm",
         "common.vm",
         "debloat.vm",
         "dokan.vm",
@@ -316,6 +316,7 @@ class UsesInvalidCategory(Lint):
         "notepadpp.plugin.",
         "npcap.vm",
         "openjdk.vm",
+        "pdbs.pdbresym.vm",
         "python3.vm",
         "x64dbgpy.vm",
     ]


### PR DESCRIPTION
Split pdbresym.vm into pdbresym.vm and dbs.pdbresym.vm to separate the download of the symbols (which increases the VM size considerable) and the too installation. @mandiant/flare-vm I think we should add pdbresym.vm to the default config, anything against it?

Closes https://github.com/mandiant/VM-Packages/issues/991

