### PR TITLE
[libraries.python3.vm] Fix dependency version

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20240410</version>
+    <version>0.0.0.20240416</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>
-      <dependency id="common.vm" version="[0.0.0.20240409]"/>
+      <dependency id="common.vm" version="0.0.0.20240409"/>
       <dependency id="vcbuildtools.vm" />
       <dependency id="python3.vm" />
     </dependencies>


### PR DESCRIPTION
We pinned the common version when we meant to request a minimum version of it instead in the following PR:
https://github.com/mandiant/VM-Packages/pull/946