### PR TITLE
fix param bug with vm-uninstall-with-uninstaller

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240412</version>
+    <version>0.0.0.20240416</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -639,10 +639,10 @@ function VM-Uninstall-With-Uninstaller {
         [string] $toolName,
         [Parameter(Mandatory=$true, Position=1)]
         [string] $category,
-        [Parameter(Mandatory=$true, Position=1)]
+        [Parameter(Mandatory=$true, Position=2)]
         [ValidateSet("EXE", "MSI")]
         [string] $fileType,
-        [Parameter(Mandatory=$true, Position=2)]
+        [Parameter(Mandatory=$true, Position=3)]
         # Some general silent args:
         # $silentArgs = '/qn /norestart' # MSI
         # $silentArgs = '/S'             # NSIS

--- a/packages/map.vm/map.vm.nuspec
+++ b/packages/map.vm/map.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>map.vm</id>
-    <version>0.0.0.20240410</version>
+    <version>0.0.0.20240416</version>
     <authors>David Zimmer</authors>
     <description>Handful of small utility type applications useful for analyzing malicious code.</description>
     <dependencies>

--- a/packages/map.vm/tools/chocolateyuninstall.ps1
+++ b/packages/map.vm/tools/chocolateyuninstall.ps1
@@ -8,4 +8,4 @@ $category = 'Utilities'
 VM-Remove-Tool-Shortcut $toolName $category
 
 # Manually silently uninstall
-VM-Uninstall-With-Uninstaller "Malcode Analyst Pack *" "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"
+VM-Uninstall-With-Uninstaller "Malcode Analyst Pack *" "$category" "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"


### PR DESCRIPTION
`VM-Uninstall-With-Uninstaller` used the position parameter of `1` more than once causing an issue with tools attempting to uninstall using it that did not directly pass in parameter names.