### PR TITLE
Add helper function for Node tools

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240416</version>
+    <version>0.0.0.20240419</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/malware-jail.vm/malware-jail.vm.nuspec
+++ b/packages/malware-jail.vm/malware-jail.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>malware-jail.vm</id>
-    <version>0.0.0.20240412</version>
+    <version>0.0.0.20240419</version>
     <authors>Hynek Petrak</authors>
     <description>Sandbox for semi-automatic Javascript malware analysis, deobfuscation and payload extraction.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240412" />
+      <dependency id="common.vm" version="0.0.0.20240419" />
       <dependency id="nodejs.vm" />
     </dependencies>
   </metadata>

--- a/packages/malware-jail.vm/tools/chocolateyinstall.ps1
+++ b/packages/malware-jail.vm/tools/chocolateyinstall.ps1
@@ -1,24 +1,12 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-    $toolName = 'malware-jail'
-    $category = 'Javascript'
+$toolName = 'malware-jail'
+$category = 'Javascript'
 
-    $zipUrl = 'https://github.com/HynekPetrak/malware-jail/archive/ec370f1433652fdd346995f1d6f00b26368aa611.zip'
-    $zipSha256 = '027b59bdb5c0b8b20ae348269b320b924be34c4cb4ae708704290e67c23e8d4d'
-    # Install dependencies with npm when running shortcut as we ignore errors below
-    $powershellCommand = "npm install; node jailme.js -h -b list"
+$zipUrl = 'https://github.com/HynekPetrak/malware-jail/archive/ec370f1433652fdd346995f1d6f00b26368aa611.zip'
+$zipSha256 = '027b59bdb5c0b8b20ae348269b320b924be34c4cb4ae708704290e67c23e8d4d'
+$command = "jailme.js -h -b list"
 
-    $toolDir = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand)[0]
+VM-Install-Node-Tool-From-Zip $toolName $category $zipUrl $zipSha256 -command $command
 
-} catch {
-    VM-Write-Log-Exception $_
-}
-
-# Prevent the following warning from failing the package: "npm WARN deprecated request@2.79.0"
-$ErrorActionPreference = 'Continue'
-# Get absolute path as npm is not in path until Powershell is restarted
-$npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
-# Install tool dependencies with npm
-Set-Location $toolDir; & "$npmPath" install | Out-Null

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pkg-unpacker.vm</id>
-    <version>1.0.0.20240412</version>
+    <version>1.0.0.20240419</version>
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240412" />
+      <dependency id="common.vm" version="0.0.0.20240419" />
       <dependency id="nodejs.vm" />
     </dependencies>
   </metadata>

--- a/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
+++ b/packages/pkg-unpacker.vm/tools/chocolateyinstall.ps1
@@ -1,21 +1,10 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-    $toolName = 'pkg-unpacker'
-    $category = 'Packers'
-    $zipUrl = 'https://github.com/LockBlock-dev/pkg-unpacker/archive/b1fd5200e1bf656dedef6817c177c8bb2dc38028.zip'
-    $zipSha256 = '6eed1d492d37ca3934a3bc838c2256719a3e78ccf72ce1b1ca07684519ace16c'
-    $powershellCommand = "npm install; node unpack.js"
+$toolName = 'pkg-unpacker'
+$category = 'Packers'
+$zipUrl = 'https://github.com/LockBlock-dev/pkg-unpacker/archive/b1fd5200e1bf656dedef6817c177c8bb2dc38028.zip'
+$zipSha256 = '6eed1d492d37ca3934a3bc838c2256719a3e78ccf72ce1b1ca07684519ace16c'
+$command = "unpack.js"
 
-    $toolDir = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $true -powershellCommand $powershellCommand)[0]
-} catch {
-  VM-Write-Log-Exception $_
-}
-
-# Prevent npm warn/notice to fail the package
-$ErrorActionPreference = 'Continue'
-# Get absolute path as npm is not in path until Powershell is restarted
-$npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
-# Install tool dependencies with npm
-Set-Location $toolDir; & "$npmPath" install | Out-Null
+VM-Install-Node-Tool-From-Zip $toolName $category $zipUrl $zipSha256 -command $command

--- a/scripts/test/lint.ps1
+++ b/scripts/test/lint.ps1
@@ -1,6 +1,6 @@
 # PSUseApprovedVerbs is disabled to support VM- functions
 # TODO: Enable other rules
-$excludedRules = "PSAvoidUsingInvokeExpression", "PSUseApprovedVerbs", "PSAvoidUsingWriteHost", "PSUseShouldProcessForStateChangingFunctions", "PSUseSingularNouns"
+$excludedRules = "PSAvoidUsingInvokeExpression", "PSUseApprovedVerbs", "PSAvoidUsingWriteHost", "PSUseShouldProcessForStateChangingFunctions", "PSUseSingularNouns", "PSAvoidUsingPositionalParameters"
 
 choco install psscriptanalyzer --version 1.20.0 --no-progress
 


### PR DESCRIPTION
Introduce a `VM-Install-Node-Tool-From-Zip` helper function to install Node tools installed with `npm` and normally downloaded from a GitHub repository as a ZIP with an inner folder.

First step to address https://github.com/mandiant/VM-Packages/issues/999

I do not understand why `PSAvoidUsingPositionalParameters` has started complaining now in the linter, as we use positional parameters in many functions:

```
packages\common.vm\tools\vm.common\vm.common.psm1
1 rule violation found.    Severity distribution:  Error = 0, Warning = 0, Information = 1

RuleName                            Severity     ScriptName Line  Message
--------                            --------     ---------- ----  -------
PSAvoidUsingPositionalParameters    Information  vm.common. 393   Cmdlet 'VM-Install-From-Zip' has positional
                                                 psm1             parameter. Please use named parameters instead of
                                                                  positional parameters when calling a command.
```

Exclude this violation as it is of `Information` severity and we wouldneed to make a lot of changes to fix it.