### PR TITLE
[pdbs.pdbresym.vm] Set _NT_SYMBOL_PATH

### DIFF
--- a/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
+++ b/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdbs.pdbresym.vm</id>
-    <version>0.0.0.20240415</version>
+    <version>0.0.0.20240417</version>
     <authors>Stephen Eckels</authors>
     <description>Download PDBs</description>
     <dependencies>

--- a/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
@@ -8,6 +8,10 @@ try {
   & $executablePath cachesyms
   # The downloaded symbols are store into C:\symbols
   VM-Assert-Path "C:\symbols"
+
+  # Set _NT_SYMBOL_PATH to include the downloaded symbols
+  $symbolsPath = "srv*c:\symbols*https://msdl.microsoft.com/download/symbols"
+  [System.Environment]::SetEnvironmentVariable("_NT_SYMBOL_PATH", $symbolsPath, "Machine")
 } catch {
   VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
Set _NT_SYMBOL_PATH to include `C:\symbols`, where we have downloaded the symbols using PDBReSym.

Closes https://github.com/mandiant/VM-Packages/issues/992