### PR TITLE
Force same icon layout when sorting

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240419</version>
+    <version>0.0.0.20240423</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>


### PR DESCRIPTION
This fixes https://github.com/mandiant/VM-Packages/issues/974

I also moved the icon sorting function call outside of the `VM-Remove-DesktopFiles` call since it felt a little out of place as it's not removing desktop files, rather, it's sorting icons on the desktop, and it also made it more clear what individual steps were being performed when calling `VM-Clean-Up`