### PR TITLE
Make FakeNet not close on ctrl+c

### DIFF
--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>3.2.0.20240412</version>
+    <version>3.2.0.20240425</version>
     <description>FakeNet-NG is a dynamic network analysis tool.</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
@@ -31,7 +31,7 @@ try {
   $toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
 
   $executablePath = Join-Path $toolDir "$toolName.exe" -Resolve
-  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -executableDir $toolDir
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -executableDir $toolDir -consoleApp $true
   Install-BinFile -Name $toolName -Path $executablePath
 
   # Create shortcut in Desktop to FakeNet tool directory


### PR DESCRIPTION
This makes it so that the FakeNet command prompt that it opens up in stays open after you hit `ctrl+c` to stop FakeNet.