### PR TITLE
Add IDA plugins helper functions & templates to script

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240423</version>
+    <version>0.0.0.20240424</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -284,6 +284,54 @@ function VM-Install-Shortcut{
     }
 }
 
+function VM-Get-IDA-Plugins-Dir {
+  return New-Item "$Env:APPDATA\Hex-Rays\IDA Pro\plugins" -ItemType "directory" -Force
+}
+
+# Downloads an IDA plugin file to the plugins directory
+function VM-Install-IDA-Plugin {
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $pluginName, # Example: capa_explorer.py
+        [Parameter(Mandatory=$true)]
+        [string] $pluginUrl,
+        [Parameter(Mandatory=$true)]
+        [string] $pluginSha256
+    )
+    try {
+        $pluginsDir = VM-Get-IDA-Plugins-Dir
+        $pluginPath = Join-Path $pluginsDir $pluginName
+        $packageArgs = @{
+            packageName = ${Env:ChocolateyPackageName}
+            url = $pluginUrl
+            checksum = $pluginSha256
+            checksumType = "sha256"
+            fileFullPath = $pluginPath
+            forceDownload = $true
+        }
+        Get-ChocolateyWebFile @packageArgs
+        VM-Assert-Path $pluginPath
+    } catch {
+        VM-Write-Log-Exception $_
+    }
+}
+
+# Removes an IDA plugin file from the plugins directory
+function VM-Uninstall-IDA-Plugin {
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [string] $pluginName # Example: capa_explorer.py
+    )
+    $pluginPath = Join-Path VM-Get-IDA-Plugins-Dir $pluginName
+    Remove-Item $pluginPath
+}
+
 # This functions returns $toolDir and $executablePath
 function VM-Install-From-Zip {
     [CmdletBinding()]

--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.capa.vm</id>
-    <version>7.0.1</version>
+    <version>7.0.1.20240424</version>
     <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240424" />
       <dependency id="libraries.python3.vm" version="0.0.0.20230927" />
     </dependencies>
   </metadata>

--- a/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
@@ -3,22 +3,14 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     # Install plugin
+    $pluginName = "capa_explorer.py"
     $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v7.0.1/capa/ida/plugin/capa_explorer.py"
     $pluginSha256 = "a9a60d9066c170c4e18366eb442f215009433bcfe277d3c6d0c4c9860824a7d3"
-    $pluginsDir = New-Item "$Env:APPDATA\Hex-Rays\IDA Pro\plugins" -ItemType "directory" -Force
-    $pluginPath = Join-Path $pluginsDir "capa_explorer.py"
-    $packageArgs = @{
-        packageName = ${Env:ChocolateyPackageName}
-        url = $pluginUrl
-        checksum = $pluginSha256
-        checksumType = "sha256"
-        fileFullPath = $pluginPath
-        forceDownload = $true
-    }
-    Get-ChocolateyWebFile @packageArgs
-    VM-Assert-Path $pluginPath
+    VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256
+
 
     # Download capa rules
+    $pluginsDir = VM-Get-IDA-Plugins-Dir
     $rulesUrl = "https://github.com/mandiant/capa-rules/archive/refs/tags/v7.0.1.zip"
     $rulesSha256 = "f4ed60bcf342007935215ea76175dddfbcbfb3f97d95387543858e0c1ecf8bcd"
     $packageArgs = @{

--- a/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$pluginsDir = "$Env:APPDATA\Hex-Rays\IDA Pro\plugins"
+$pluginsDir = VM-Get-IDA-Plugins-Dir
 
 # Uninstall plugin
 $pluginPath = Join-Path $pluginsDir "capa_explorer.py"

--- a/packages/ida.plugin.sigmaker.vm/ida.plugin.sigmaker.vm.nuspec
+++ b/packages/ida.plugin.sigmaker.vm/ida.plugin.sigmaker.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.sigmaker.vm</id>
+    <version>1.0.2</version>
+    <authors>A200K</authors>
+    <description>Signature Maker Plugin for IDA Pro 8.3.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240424" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.plugin.sigmaker.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.sigmaker.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'SigMaker64.dll'
+$pluginUrl = 'https://github.com/A200K/IDA-Pro-SigMaker/releases/download/v1.0.2/SigMaker64.dll'
+$pluginSha256 = '0b44921a2fc35f13a2987fcf8830685d58f9d18bca760a9706ec4efe8b0d5d2f'
+
+VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256

--- a/packages/ida.plugin.sigmaker.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.sigmaker.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'SigMaker64.dll'
+VM-Uninstall-IDA-Plugin -pluginName $pluginName
+

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -309,7 +309,7 @@ class UsesInvalidCategory(Lint):
         "debloat.vm",
         "dokan.vm",
         "googlechrome.vm",
-        "ida.plugin.capa.vm",
+        "ida.plugin",
         "installer.vm",
         "libraries.python2.vm",
         "libraries.python3.vm",


### PR DESCRIPTION
Introduce `VM-Install-IDA-plugin`, `VM-Uninstall-IDA-Plugin`, and `VM-Get-IDA-Plugins-Dir` helper functions in common.vm to simplify IDA plugins installation. Use the new `VM-Install-IDA-plugin` and `VM-Get-IDA-Plugins-Dir` functions in `ida.plugin.capa.vm`.

Add support for simple IDA plugins which just download one single file to the plugins directory to our `create_package_template.py` script. This template can also be used as base for more complicated plugins. See `ida.plugin.capa.vm` for an example.

Use the new IDA plugin template in create_package_template.py to
generate `ida.plugin.sigmaker.vm`:

```
python3 scripts/utils/create_package_template.py --type IDA_PLUGIN --pkg_name "ida.plugin.sigmaker" --version "1.0.2" --authors "A200K" --description "Signature Maker Plugin for IDA Pro 8.3." --tool_name "SigMaker64.dll" --target_url "https://github.com/A200K/IDA-Pro-SigMaker/releases/download/v1.0.2/SigMaker64.dll" --target_hash "0b44921a2fc35f13a2987fcf8830685d58f9d18bca760a9706ec4efe8b0d5d2f"
```

First step for https://github.com/mandiant/VM-Packages/issues/996

We should close the actual PR adding plugins (which have been opened for more than 2 months). https://github.com/mandiant/VM-Packages/pull/913 adds an older version of the sample plugin and all of the PRs would need to be updated to use the new helpers.

Closes https://github.com/mandiant/VM-Packages/pull/914
Closes https://github.com/mandiant/VM-Packages/pull/913
Closes https://github.com/mandiant/VM-Packages/pull/911

