### PR TITLE
Install flare-capa in ida.plugin.capa.vm

### DIFF
--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.capa.vm</id>
-    <version>7.0.1.20240424</version>
+    <version>7.0.1.20240425</version>
     <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240424" />
-      <dependency id="libraries.python3.vm" version="0.0.0.20230927" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
+    # Install dependency: capa Python library
+    VM-Pip-Install "flare-capa"
+
     # Install plugin
     $pluginName = "capa_explorer.py"
     $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v7.0.1/capa/ida/plugin/capa_explorer.py"

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20240416</version>
+    <version>0.0.0.20240425</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -7,7 +7,6 @@
     <module name="dissect"/>
     <module name="dncil"/>
     <module name="dnfile"/>
-    <module name="flare-capa"/>
     <module name="hexdump"/>
     <module name="ldapdomaindump"/>
     <module name="lznt1"/>


### PR DESCRIPTION
Install the Python library `flare-capa` in ida.plugin.capa.vm instead of `libraries.python3.vm`. This is an easy change thanks to the introduction of the `VM-Pip-Install` function in https://github.com/mandiant/VM-Packages/pull/935.

Closes https://github.com/mandiant/VM-Packages/issues/695