### PR TITLE
Add ZIP support in VM-Install-IDA-Plugin & Add ida.plugin.dereferencing.vm

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240425</version>
+    <version>0.0.0.20240429</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
+++ b/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.dereferencing.vm</id>
+    <version>0.0.0.20240430</version>
+    <authors>danigargu</authors>
+    <description>IDA Pro plugin that implements new registers and stack views.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240429" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.plugin.dereferencing.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.dereferencing.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'dereferencing.py'
+$pluginUrl = 'https://github.com/danigargu/deREferencing/archive/c5c606a9e70bff48214ce5286a37b15752fd8d1b.zip'
+$pluginSha256 = '3ddec5c7569bc53883c5feaeb36d1145e2dde1c67491d14929af05938870dc1e'
+
+VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256

--- a/packages/ida.plugin.dereferencing.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.dereferencing.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'dereferencing.py'
+VM-Uninstall-IDA-Plugin -pluginName $pluginName
+

--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -44,7 +44,7 @@ NUSPEC_TEMPLATE = r"""<?xml version="1.0" encoding="utf-8"?>
     <authors>{authors}</authors>
     <description>{description}</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240424" />
+      <dependency id="common.vm" version="0.0.0.20240429" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
`VM-Install-IDA-Plugin` now in addition of supporting downloading an IDA plugin file to the plugins directory, it also supports ZIPs containing a plugin (and supporting files/directories). For ZIPs, we check if there is an inner folder (this is the case for GH ZIPs) and if there is a directory called 'plugins'.  We copy all files in this directory with the exception of the `README` and the `LICENSE` file (often present in GH repos). The copied files must include `$pluginName`, which is used for uninstallation.

Use the IDA plugin template in `create_package_template.py` to generate `ida.plugin.dereferencing.vm` thank to the new ZIP support:

```
python3 scripts/utils/create_package_template.py --type IDA_PLUGIN --pkg_name "ida.plugin.dereferencing" --version "0.0.0.20240430" --authors "danigargu" --description "IDA Pro plugin that implements new registers and stack views." --tool_name "dereferencing.py" --target_url "https://github.com/danigargu/deREferencing/archive/c5c606a9e70bff48214ce5286a37b15752fd8d1b.zip" --target_hash "3ddec5c7569bc53883c5feaeb36d1145e2dde1c67491d14929af05938870dc1e"
```

Partially addresses https://github.com/mandiant/VM-Packages/issues/996

I would like to add this plugin to the default FLARE-VM installation, anything against it @mandiant/flare-vm ?