### PR TITLE
Add issue template & automation for IDA plugins

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_IDA_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/new_IDA_plugin.yml
@@ -1,0 +1,98 @@
+name: 🆕 NEW IDA PLUGIN
+description: Propose the addition of a new IDA plugin.
+title: "Package proposal: <ida_plugin_name>.vm"
+labels: [":new: package", ":curly_haired_woman: IDA", ":cyclone: FLARE-VM"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to [VM-Packages](https://github.com/mandiant/VM-Packages), your package proposal supports IDA plugins available for [FLARE-VM](https://github.com/mandiant/flare-vm)! :cupid: Please ensure that your suggested IDA plugin doesn't already exist within the set of [current packages](https://github.com/mandiant/VM-Packages/tree/main/packages) and that there is no [issue](https://github.com/mandiant/VM-Packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+package%22) proposal already.
+  - type: input
+    id: pkg_name
+    attributes:
+      label: Package Name
+      description: |
+        The convention is to use lowercase names with the following format: `pluginname` or `plugin-name`, with `ida.plugin.` prepended and without the `.vm` appended. Example: `ida.plugin.capa` and `ida.plugin.sigmaker`. **Please add this name to the issue title as well** (keep the `.vm` in the title).
+      placeholder: ex. ida.plugin.capa
+    validations:
+      required: true
+  - type: input
+    id: tool_name
+    attributes:
+      label: Tool Name
+      description: |
+        The name of the plugin main file including the extension (`.py` or `.dll`) which is copied to the IDA plugins directory. Example: `capa-explorer.py` and `SigMaker64.dll`
+      placeholder: ex. capa-explorer.py
+    validations:
+      required: true
+  - type: dropdown
+    id: type
+    validations:
+      required: true
+    attributes:
+      label: Package type
+      description: |
+        - **`IDA_PLUGIN`** - IDA plugin distributed as a single file or ZIP containing a plugin (and supporting files/directories) that need to be copied to the IDA plugins directory. For ZIPs, we check if there is an inner folder (this is the case for GH ZIPs) and if there is a directory called `plugins`. We copy all files in this directory (the root directory, the inner folder or the `plugins` directory depending what is present) with the exception of the README and the LICENSE file (often present in GH repos). The copied files must include the file `plugin name` specified below.
+        - **`OTHER/UNKNOWN`** - An IDA plugin distributed in a different way than `IDA_PLUGIN`. It is required that you provide details of how the plugin is installed in the `Extra information` section. Note this type does not support automation, a PR would be appreciated!
+      options:
+        - IDA_PLUGIN
+        - OTHER/UNKNOWN
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        Plugin's version number. Example: `1.4.11`.
+      placeholder: ex. 1.4.11
+    validations:
+      required: true
+  - type: input
+    id: authors
+    attributes:
+      label: Tool's authors
+      description: |
+        Comma separated list of the plugin's authors. Example: `Elmo, Bert, Grover, Cookie Monster`.
+      placeholder: ex. Elmo, Bert, Grover, Cookie Monster
+    validations:
+      required: true
+  - type: input
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Tool's description
+      description: |
+        The plugin description should be short and not include version specific details or other information that is likely to change in a future version. Example: `capa explorer is an IDAPython plugin that integrates capa with IDA Pro.`
+  - type: input
+    id: target_url
+    validations:
+      required: true
+    attributes:
+      label: Download URL
+      description: |
+        URL to download the plugin file or ZIP containing the plugin. Use a URL that is not likely to be deleted/unavailable and whose downloaded file is not likely to change as this will eventually break the package. Example: `https://raw.githubusercontent.com/mandiant/capa/v7.0.1/capa/ida/plugin/capa_explorer.py`
+  - type: input
+    id: target_hash
+    validations:
+      required: true
+    attributes:
+      label: Download SHA256 Hash
+      description: |
+        SHA256 hash of the file or ZIP downloaded from the download url introduced in the previous field. The hash is used for verification purposes. Example: `62af5cce80dbbf5cdf961ec9515549334a2112056d4168fced75c892c24baa95`
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this tool a good addition?
+      description: Tell us why you would like to have this package in FLARE-VM and how this IDA plugin is useful for malware analysis. Adding new packages involves more maintenance work, tell us what is unique about this plugin that can not be done with the current toolset.
+    validations:
+      required: true
+  - type: textarea
+    id: info
+    attributes:
+      label: Extra information
+      description: Tell us any other extra information that may be useful to create the package, such us how is the plugin installed if it is not done in a standard way (if you selected type `OTHER/UNKNOWN`).
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        We really appreciate that you share your package idea with us and we will review your issue as soon as possible. Please understand that our time is limited and we may not be able to create a package for this plugin as fast as you may like. To speed up the process, please fill the issue accurately as this may allow our bot to send an automatic PR. Note that this may not work for all cases. You can check our [Contributing Wiki page](https://github.com/mandiant/VM-Packages/wiki/Contributing) and send a pull request with the new package. We encourage the community to help us create new packages and to maintain existing ones. Join us! :hugs:

--- a/.github/ISSUE_TEMPLATE/new_metapackage.yml
+++ b/.github/ISSUE_TEMPLATE/new_metapackage.yml
@@ -6,13 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for contributing to [VM-Packages](https://github.com/mandiant/VM-Packages), your package proposal supports tools available for [FLARE-VM](https://github.com/mandiant/flare-vm), [Commando-VM](https://github.com/mandiant/commando-vm) and (ThreatPursuit-VM)[https://github.com/mandiant/ThreatPursuit-VM]! :cupid: Please ensure that your suggested tool doesn't already exist within the set of [current packages](https://github.com/mandiant/VM-Packages/tree/main/packages) and that there is no [issue](https://github.com/mandiant/VM-Packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+package%22) proposal already.
+        Thanks for contributing to [VM-Packages](https://github.com/mandiant/VM-Packages), your package proposal supports tools available for [FLARE-VM](https://github.com/mandiant/flare-vm) and [CommandoVM](https://github.com/mandiant/commando-vm)! :cupid: Please ensure that your suggested tool doesn't already exist within the set of [current packages](https://github.com/mandiant/VM-Packages/tree/main/packages) and that there is no [issue](https://github.com/mandiant/VM-Packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+package%22) proposal already. If the tool is not related malware analysis, incident response, penetration testing and other security related tasking, consider using directly the [Chocolatey community package](https://community.chocolatey.org/packages).
   - type: input
     id: pkg_name
     attributes:
       label: Package Name
       description: |
-        The convention is to use lowercase names with the following format: `toolname` or `tool-name`. For example `capa` and `fakenet-ng`. **Please add this name to the issue title as well.**
+        The convention is to use lowercase names with the following format: `toolname` or `tool-name` and without `.vm` appended. Example: `capa` and `fakenet-ng`. **Please add this name to the issue title as well** (keep the `.vm` in the title)
       placeholder: ex. fakenet-ng
     validations:
       required: true
@@ -20,7 +20,8 @@ body:
     id: tool_name
     attributes:
       label: Tool Name
-      description: The name of the tool being installed (usually the file name with the `.exe`), normally different from the package name. For example fakenet-ng (package name) vs FakeNet-NG (tool name).
+      description: |
+        The name of the tool being installed (usually the file name with the `.exe`), normally different from the package name. Example: `FakeNet-NG` (tool name) vs `fakenet-ng` (package name).
       placeholder: ex. FakeNet-NG
     validations:
       required: true
@@ -31,14 +32,15 @@ body:
     attributes:
       label: Package type
       description: |
-        This is needed to know how to send the automatic PR.
-        METAPACKAGE - Install and configure existing packages via dependencies
+        **`METAPACKAGE`** - Install and configure existing packages via dependencies
       options:
         - METAPACKAGE
   - type: input
     id: version
     attributes:
-      label: Tool's version number
+      label: Version
+      description: |
+        Tool's version number. Example: `1.4.11`.
       placeholder: ex. 1.4.11
     validations:
       required: true
@@ -84,7 +86,8 @@ body:
     id: authors
     attributes:
       label: Tool's authors
-      description: Comma separated list of authors for tool
+      description: |
+        Comma separated list of the tool's authors. Example: `Elmo, Bert, Grover, Cookie Monster`.
       placeholder: ex. Elmo, Bert, Grover, Cookie Monster
     validations:
       required: true
@@ -94,29 +97,36 @@ body:
       required: true
     attributes:
       label: Tool's description
-      description: The description should be short and not include version specific details or other information that is likely to change in a future version.
-      placeholder: ex. FakeNet-NG is a next generation dynamic network analysis tool for malware analysts and penetration testers.
+      description: |
+        The tool description should be short and not include version specific details or other information that is likely to change in a future version. Example: `FakeNet-NG is a dynamic network analysis tool.`
   - type: input
     id: dependency
     validations:
       required: true
     attributes:
       label: Dependency
-      description: Preexisting Chocolatey package name to install via Chocolatey's dependency functionality. Find preexisting packages at https://community.chocolatey.org/packages (e.g., the name `ghidra` from https://community.chocolatey.org/packages/ghidra).
+      description: |
+        Preexisting Chocolatey package name to install via Chocolatey's dependency functionality. Find preexisting packages at https://community.chocolatey.org/packages (e.g., the name `ghidra` from https://community.chocolatey.org/packages/ghidra).
   - type: input
     id: shim_path
     validations:
       required: true
     attributes:
       label: Shim path
-      description: Installed Chocolatey packages automatically create "shims" (i.e., executable proxies) to the installed applications. The default Chocolatey shim location is `%PROGRAMDATA%\chocolatey\bin`. Provide the path for the Chocolatey "shimmed" executable relative to the `$Env:ChocolateyInstall` path (i.e., `%PROGRAMDATA%\chocolatey`). For example, provide a path like `bin\ollydbg.exe`.
+      description: |
+        Installed Chocolatey packages automatically create "shims" (i.e., executable proxies) to the installed applications. The default Chocolatey shim location is `%PROGRAMDATA%\chocolatey\bin`. Provide the path for the Chocolatey "shimmed" executable relative to the `$Env:ChocolateyInstall` path (i.e., `%PROGRAMDATA%\chocolatey`). Example: `bin\ollydbg.exe`.
   - type: textarea
     id: why
     attributes:
       label: Why is this tool a good addition?
-      description: Tell us why you would like to have this package in FLARE-VM and how this tool is useful for malware analysis, incident response, penetration testing and other security related tasking. Adding new packages involves more maintenance work, tell us what is unique about this tool that can not be done with the current toolset.
+      description: Tell us why you would like to have this package in FLARE-VM/CommandoVM and how this tool is useful for malware analysis, incident response, penetration testing and other security related tasking. Adding new packages involves more maintenance work, tell us what is unique about this tool that can not be done with the current toolset.
     validations:
       required: true
+  - type: textarea
+    id: info
+    attributes:
+      label: Extra information
+      description: Tell us any other extra information that may be useful to create the package.
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -6,13 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for contributing to [VM-Packages](https://github.com/mandiant/VM-Packages), your package proposal supports tools available for [FLARE-VM](https://github.com/mandiant/flare-vm), [Commando-VM](https://github.com/mandiant/commando-vm) and [ThreatPursuit-VM](https://github.com/mandiant/ThreatPursuit-VM)! :cupid: Please ensure that your suggested tool doesn't already exist within the set of [current packages](https://github.com/mandiant/VM-Packages/tree/main/packages) and that there is no [issue](https://github.com/mandiant/VM-Packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+package%22) proposal already.
+        Thanks for contributing to [VM-Packages](https://github.com/mandiant/VM-Packages), your package proposal supports tools available for [FLARE-VM](https://github.com/mandiant/flare-vm) and [CommandoVM](https://github.com/mandiant/commando-vm)! :cupid: Please ensure that your suggested tool doesn't already exist within the set of [current packages](https://github.com/mandiant/VM-Packages/tree/main/packages) and that there is no [issue](https://github.com/mandiant/VM-Packages/issues?q=is%3Aopen+is%3Aissue+label%3A%22%3Anew%3A+package%22) proposal already. If the tool is not related malware analysis, incident response, penetration testing and other security related tasking, consider using directly the [Chocolatey community package](https://community.chocolatey.org/packages) if there is one for the tool.
   - type: input
     id: pkg_name
     attributes:
       label: Package Name
       description: |
-        The convention is to use lowercase names with the following format: `toolname` or `tool-name`. For example `capa` and `fakenet-ng`. **Please add this name to the issue title as well.**
+        The convention is to use lowercase names with the following format: `toolname` or `tool-name` and without `.vm` appended. Example: `capa` and `fakenet-ng`. **Please add this name to the issue title as well** (keep the `.vm` in the title).
       placeholder: ex. fakenet-ng
     validations:
       required: true
@@ -20,7 +20,8 @@ body:
     id: tool_name
     attributes:
       label: Tool Name
-      description: The name of the tool being installed (usually the file name with the `.exe`), normally different from the package name. For example fakenet-ng (package name) vs FakeNet-NG (tool name).
+      description: |
+        The name of the tool being installed (usually the file name with the `.exe`), normally different from the package name. Example: `FakeNet-NG` (tool name) vs `fakenet-ng` (package name).
       placeholder: ex. FakeNet-NG
     validations:
       required: true
@@ -31,10 +32,10 @@ body:
     attributes:
       label: Package type
       description: |
-        This is needed to know how to send the automatic PR.
-        `ZIP_EXE` - An executable tool distributed in a ZIP file
-        `SINGLE_EXE` - An executable tool distributed via direct/raw download
-        `SINGLE_PS1` - A PowerShell script distributed via direct/raw download
+        - **`ZIP_EXE`** - An executable tool distributed in a ZIP file
+        - **`SINGLE_EXE`** - An executable tool distributed via direct/raw download
+        - **`SINGLE_PS1`** - A PowerShell script distributed via direct/raw download
+        - **`OTHER/UNKNOWN`** - A tool distributed in a different way than the ones described above. It is required that you provide details of how the tool is installed in the `Extra information` section. Note this type does not support automation, a PR would be appreciated!
       options:
         - ZIP_EXE
         - SINGLE_EXE
@@ -55,7 +56,9 @@ body:
   - type: input
     id: version
     attributes:
-      label: Tool's version number
+      label: Version
+      description: |
+        Tool's version number. Example: `1.4.11`.
       placeholder: ex. 1.4.11
     validations:
       required: true
@@ -101,7 +104,8 @@ body:
     id: authors
     attributes:
       label: Tool's authors
-      description: Comma separated list of authors for tool
+      description: |
+        Comma separated list of the tool's authors. Example: `Elmo, Bert, Grover, Cookie Monster`.
       placeholder: ex. Elmo, Bert, Grover, Cookie Monster
     validations:
       required: true
@@ -111,24 +115,24 @@ body:
       required: true
     attributes:
       label: Tool's description
-      description: The description should be short and not include version specific details or other information that is likely to change in a future version.
-      placeholder: ex. FakeNet-NG is a next generation dynamic network analysis tool for malware analysts and penetration testers.
+      description: |
+        The tool description should be short and not include version specific details or other information that is likely to change in a future version. Example: `FakeNet-NG is a dynamic network analysis tool.`
   - type: input
     id: target_url
     validations:
       required: true
     attributes:
       label: Download URL
-      description: URL to download the tool installer. Use a URL that is not likely to be deleted/unavailable and whose downloaded file is not likely to change as this will eventually break the package.
-      placeholder: ex. https://github.com/mandiant/flare-fakenet-ng/releases/download/v1.4.11/fakenet1.4.11.zip
+      description: |
+        URL to download the tool installer. Use a URL that is not likely to be deleted/unavailable and whose downloaded file is not likely to change as this will eventually break the package. Example: `https://github.com/mandiant/flare-fakenet-ng/releases/download/v1.4.11/fakenet1.4.11.zip`
   - type: input
     id: target_hash
     validations:
       required: true
     attributes:
       label: Download SHA256 Hash
-      description: SHA256 hash of the `.zip` file downloaded from the download url introduced in the previous field. The hash is used for verification purposes.
-      placeholder: ex. 62af5cce80dbbf5cdf961ec9515549334a2112056d4168fced75c892c24baa95
+      description: |
+        SHA256 hash of the `.zip` file downloaded from the download url introduced in the previous field. The hash is used for verification purposes. Example: `62af5cce80dbbf5cdf961ec9515549334a2112056d4168fced75c892c24baa95 `
   - type: input
     id: dependencies
     attributes:
@@ -140,9 +144,14 @@ body:
     id: why
     attributes:
       label: Why is this tool a good addition?
-      description: Tell us why you would like to have this package in FLARE-VM and how this tool is useful for malware analysis, incident response, penetration testing and other security related tasking. Adding new packages involves more maintenance work, tell us what is unique about this tool that can not be done with the current toolset.
+      description: Tell us why you would like to have this package in FLARE-VM/CommandoVM and how this tool is useful for malware analysis, incident response, penetration testing and other security related tasking. Adding new packages involves more maintenance work, tell us what is unique about this tool that can not be done with the current toolset.
     validations:
       required: true
+  - type: textarea
+    id: info
+    attributes:
+      label: Extra information
+      description: Tell us any other extra information that may be useful to create the package, such us how is the tool installed if it is not done in a standard way (if you selected type `OTHER/UNKNOWN`.).
   - type: markdown
     attributes:
       value: |

--- a/scripts/utils/create_package_template_from_json.py
+++ b/scripts/utils/create_package_template_from_json.py
@@ -23,7 +23,7 @@ def main():
 
     cmd_args = list()
     for k, v in pkg.items():
-        if k in ("why", "dependencies"):
+        if k in ("why", "dependencies", "info"):
             continue
         cmd_args.append(f"--{k}")
         cmd_args.append(f"{v}")


### PR DESCRIPTION
Add issue template for IDA plugins & improve and keep consistent the current issue templates. The new issue template supports the `send PR` automation to create new packages for IDA plugin distributed in a standard way: as a single file or ZIP containing a plugin (and supporting files/directories) that need to be copied to the IDA plugins directory. You can see it working in https://github.com/ana06/VM-Packages (see the three open issues and PRs and the latest run actions).

Note I have created a new label in this repository: `:curly_haired_woman: IDA`. :curly_haired_woman: is the most similar emoji to IDA that I found :rofl: 

Closes https://github.com/mandiant/VM-Packages/issues/996