### PR TITLE
[7zip] Keep full paths in right click shortcut

### DIFF
--- a/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
+++ b/packages/7zip-15-05.vm/7zip-15-05.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>7zip-15-05.vm</id>
-    <version>15.05.0.20240425</version>
+    <version>15.05.0.20240507</version>
     <authors>Igor Pavlov</authors>
     <description>7-Zip file archiver. This version is able to extract NSIS scripts.</description>
     <dependencies>

--- a/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
+++ b/packages/7zip-15-05.vm/tools/chocolateyinstall.ps1
@@ -34,7 +34,7 @@ try {
   # 7z can unzip other file extensions like .docx but these don't likely use the infected password.
   $extensions = @(".7z", ".bzip2", ".gzip", ".tar", ".wim", ".xz", ".txz", ".zip", ".rar")
   foreach ($extension in $extensions) {
-    VM-Add-To-Right-Click-Menu $toolName 'unzip "infected"' "`"$7zExecutablePath`" e -pinfected `"%1`"" "$executablePath" -extension $extension
+    VM-Add-To-Right-Click-Menu $toolName 'unzip "infected"' "`"$7zExecutablePath`" x -pinfected `"%1`"" "$executablePath" -extension $extension
     VM-Set-Open-With-Association $executablePath $extension
   }
 } catch {

--- a/packages/7zip-nsis.vm/7zip-nsis.vm.nuspec
+++ b/packages/7zip-nsis.vm/7zip-nsis.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>7zip-nsis.vm</id>
-    <version>23.01.0.20240425</version>
+    <version>23.01.0.20240507</version>
     <authors>myfreeer</authors>
     <description>7-zip build with nsis script decompiling</description>
     <dependencies>

--- a/packages/7zip-nsis.vm/tools/chocolateyinstall.ps1
+++ b/packages/7zip-nsis.vm/tools/chocolateyinstall.ps1
@@ -34,7 +34,7 @@ try {
     # 7z can unzip other file extensions like .docx but these don't likely use the infected password.
     $extensions = @(".7z", ".bzip2", ".gzip", ".tar", ".wim", ".xz", ".txz", ".zip", ".rar")
     foreach ($extension in $extensions) {
-      VM-Add-To-Right-Click-Menu $toolName 'unzip "infected"' "`"$7zExecutablePath`" e -pinfected `"%1`"" "$executablePath" -extension $extension
+      VM-Add-To-Right-Click-Menu $toolName 'unzip "infected"' "`"$7zExecutablePath`" x -pinfected `"%1`"" "$executablePath" -extension $extension
       VM-Set-Open-With-Association $executablePath $extension
     }
 } catch {


### PR DESCRIPTION
Swap `e` by `x` in the command used by the right click shortcut `unzip "infected"` to keep full paths when unzipping nested directories.

Closes https://github.com/mandiant/VM-Packages/issues/1018