### PR TITLE
[common.vm] Fix VM-Uninstall-IDA-Plugin

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240429</version>
+    <version>0.0.0.20240508</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -366,8 +366,8 @@ function VM-Uninstall-IDA-Plugin {
         [Parameter(Mandatory=$true)]
         [string] $pluginName # Example: capa_explorer.py
     )
-    $pluginPath = Join-Path VM-Get-IDA-Plugins-Dir $pluginName
-    Remove-Item $pluginPath
+    $pluginPath = Join-Path (VM-Get-IDA-Plugins-Dir) $pluginName
+    Remove-Item $pluginPath -Recuse -Force -ea 0
 }
 
 # This functions returns $toolDir and $executablePath


### PR DESCRIPTION
The string `VM-Get-IDA-Plugins-Dir` was being used instead of calling the function. In `Remove-Item` we need `-Force` to remove read-only and hidden files, `-Recurse` to remove directories, and `- ea 0` because of a bug with the `ErrorActionPreference`.