### PR TITLE
[common.vm] Fix VM-Uninstall-IDA-Plugin again

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240508</version>
+    <version>0.0.0.20240509</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -367,7 +367,7 @@ function VM-Uninstall-IDA-Plugin {
         [string] $pluginName # Example: capa_explorer.py
     )
     $pluginPath = Join-Path (VM-Get-IDA-Plugins-Dir) $pluginName
-    Remove-Item $pluginPath -Recuse -Force -ea 0
+    Remove-Item $pluginPath -Recurse -Force -ea 0
 }
 
 # This functions returns $toolDir and $executablePath

--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -44,7 +44,7 @@ NUSPEC_TEMPLATE = r"""<?xml version="1.0" encoding="utf-8"?>
     <authors>{authors}</authors>
     <description>{description}</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240429" />
+      <dependency id="common.vm" version="0.0.0.20240509" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
I introduced a typo after testing the change in https://github.com/mandiant/VM-Packages/pull/1034. :see_no_evil:  Require also this version of common, which fixes the IDA plugin uninstallation helper, in the IDA plugin template.