### PR TITLE
Add ida.plugin.flare.vm with shellcode_hashes_search_plugin & apply_callee_type_plugin

### DIFF
--- a/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
+++ b/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.flare.vm</id>
+    <version>0.0.0.20240513</version>
+    <authors>Jay Smith</authors>
+    <description>IDA Pro plugins used by the FLARE team.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.plugin.flare.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.flare.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,42 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $pluginUrl = 'https://github.com/mandiant/flare-ida/archive/011cb3310d82a1c00104a4830289ea2fed5165f5.zip'
+    $pluginSha256 = 'd74c81d9fb1db2de801a05aeeb289ea98d93604aa11e44b27568382e78225bb2'
+
+    $tempDownloadDir = Join-Path ${Env:chocolateyPackageFolder} "temp_$([guid]::NewGuid())"
+    # Download and unzip
+    $packageArgs = @{
+        packageName    = ${Env:ChocolateyPackageName}
+        unzipLocation  = $tempDownloadDir
+        url            = $pluginUrl
+        checksum       = $pluginSha256
+        checksumType   = 'sha256'
+    }
+    Install-ChocolateyZipPackage @packageArgs | Out-Null
+    VM-Assert-Path $tempDownloadDir
+
+    # Copy plugins to IDA plugins directory
+    $pluginsDir = VM-Get-IDA-Plugins-Dir
+    $pluginDir = Get-Item "$tempDownloadDir\*\plugins"
+    $pluginNames = @('apply_callee_type_plugin.py',
+                     'shellcode_hashes_search_plugin.py')
+    ForEach ($pluginName in $pluginNames) {
+        $pluginPath = Join-Path $pluginDir $pluginName -Resolve
+        Copy-Item $pluginPath $pluginsDir -Force
+    }
+
+    # Copy flare Python module to the IDA plugins directory
+    $flareDir = Get-Item "$tempDownloadDir\*\python\flare"
+    Copy-Item $flareDir $pluginsDir -Recurse -Force
+
+    # Copy sc_hashes.db to a directory where shellcode_hashes_search_plugin.py can find it:
+    # https://github.com/mandiant/flare-ida/blob/011cb3310d82a1c00104a4830289ea2fed5165f5/python/flare/shellcode_hash_search.py#L428
+    $dbFile = Get-Item "$tempDownloadDir\*\shellcode_hashes\sc_hashes.db"
+    $dbDir = New-Item "$Env:APPDATA\Hex-Rays\IDA Pro\shellcode_hashes" -ItemType "directory" -Force
+    Copy-Item $dbFile $dbDir -Recurse -Force
+} catch {
+    VM-Write-Log-Exception $_
+}
+

--- a/packages/ida.plugin.flare.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.flare.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginItems = @('apply_callee_type_plugin.py',
+                 'shellcode_hashes_search_plugin.py',
+                 'flare')
+
+ForEach ($name in $pluginItems) {
+    VM-Uninstall-IDA-Plugin -pluginName $name
+}
+
+Remove-Item "$Env:APPDATA\Hex-Rays\IDA Pro\shellcode_hashes" -Force -Recurse


### PR DESCRIPTION
In addition to copy the `apply_callee_type_plugin.py` file to the IDA plugins directory, we need 3 extra files from the `flare` Python module.

Closes https://github.com/mandiant/VM-Packages/issues/1032.

![image](https://github.com/mandiant/VM-Packages/assets/16052290/2747ad42-a11b-4dac-970c-e405871fbca3)


Closes https://github.com/mandiant/VM-Packages/issues/1032