### PR TITLE
Add ida.plugin.hashdb.vm

### DIFF
--- a/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
+++ b/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.hashdb.vm</id>
+    <version>1.9.0</version>
+    <authors>OALabs</authors>
+    <description>Malware string hash lookup plugin for IDA Pro</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ida.plugin.hashdb.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.hashdb.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    # Install requirements: https://github.com/OALabs/hashdb-ida/blob/1.9.0/requirements.txt
+    VM-Pip-Install requests
+
+    $pluginName = 'hashdb.py'
+    $pluginUrl = 'https://github.com/OALabs/hashdb-ida/releases/download/1.9.0/hashdb.py'
+    $pluginSha256 = '45c55bd5c234e42b02435f2c93637dc33c13fc2f92fd060bcd755533eaa2807d'
+
+    VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/ida.plugin.hashdb.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.hashdb.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'hashdb.py'
+VM-Uninstall-IDA-Plugin -pluginName $pluginName
+


### PR DESCRIPTION
Add ida.plugin.hashdb.vm. We couldn't use the issues automation as we need to install the requirements (the `requests` Python library), but being able to use the script/template/helper functions made it very easy to create it manually.