### PR TITLE
Introduce `VM-Install-Node-Tool`  and add `obfuscator-io-deobfuscator.vm`

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240509</version>
+    <version>0.0.0.20240514</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -454,6 +454,26 @@ function VM-Install-From-Zip {
     }
 }
 
+function VM-Install-Node-Tool {
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    Param
+    (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $toolName,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $category,
+        [Parameter(Mandatory=$false)]
+        [string] $arguments
+    )
+    try {
+        npm install -g $toolName --no-update-notifier
+        VM-Install-Shortcut -toolName $toolName -category $category -arguments "$toolName $arguments" -powershell
+    } catch {
+      VM-Write-Log-Exception $_
+    }
+}
+
 function VM-Install-Node-Tool-From-Zip {
     [CmdletBinding()]
     [OutputType([System.Object[]])]

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -493,17 +493,10 @@ function VM-Install-Node-Tool-From-Zip {
         [Parameter(Mandatory=$false)]
         [bool] $innerFolder=$true # Default to true as most node apps are GH repos (ZIP with inner folder)
     )
-    # Install dependencies with npm when running shortcut as we ignore errors below
-    $powershellCommand = "npm install; node $command"
+    $toolDir = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $innerFolder -powershellCommand "node $command")[0]
 
-    $toolDir = (VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -innerFolder $innerFolder -powershellCommand $powershellCommand)[0]
-
-    # Prevent the following warning from failing the package: "npm WARN deprecated request@2.79.0"
-    $ErrorActionPreference = 'Continue'
-    # Get absolute path as npm may not be in PATH until Powershell is restarted
-    $npmPath = Join-Path ${Env:ProgramFiles} "\nodejs\npm.cmd" -Resolve
     # Install tool dependencies with npm
-    Set-Location $toolDir; & "$npmPath" install | Out-Null
+    Set-Location $toolDir; npm install --no-update-notifier
 }
 
 # This functions returns $executablePath

--- a/packages/obfuscator-io-deobfuscator.vm/obfuscator-io-deobfuscator.vm.nuspec
+++ b/packages/obfuscator-io-deobfuscator.vm/obfuscator-io-deobfuscator.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>obfuscator-io-deobfuscator.vm</id>
+    <version>0.0.0.20240514</version>
+    <authors>ben-sb</authors>
+    <description>A deobfuscator for scripts obfuscated by Obfuscator.io</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240514"/>
+      <dependency id="nodejs.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/obfuscator-io-deobfuscator.vm/tools/chocolateyinstall.ps1
+++ b/packages/obfuscator-io-deobfuscator.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'obfuscator-io-deobfuscator'
+$category = 'Javascript'
+
+VM-Install-Node-Tool -toolName $toolName -category $category -arguments "--help"

--- a/packages/obfuscator-io-deobfuscator.vm/tools/chocolateyuninstall.ps1
+++ b/packages/obfuscator-io-deobfuscator.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'obfuscator-io-deobfuscator'
+$category = 'Javascript'
+
+VM-Remove-Tool-Shortcut $toolName $category


### PR DESCRIPTION
Introduce `VM-Install-Node-Tool` to easily create packages that use `npm` to install tools published on the JavaScript Package Registry. Use `VM-Install-Node-Tool` to add `obfuscator-io-deobfuscator`.

Simplify the code of the `VM-Install-Node-Tool-From-Zip` function helper and keep it consistent with `VM-Install-Node-Tool`.

It will make it easier to implement https://github.com/mandiant/VM-Packages/issues/999