### PR TITLE
[nodejs.vm] Add git as dependency

### DIFF
--- a/packages/nodejs.vm/nodejs.vm.nuspec
+++ b/packages/nodejs.vm/nodejs.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nodejs.vm</id>
-    <version>0.0.0.20231020</version>
+    <version>0.0.0.20240516</version>
     <authors>Node.js Foundation</authors>
     <description>Metapackage for Node.js to ensure all packages use the same Node.js version.</description>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="nodejs" version="[20.7.0, 20.8.0)" />
+      <dependency id="git" version="[2.45.0, 2.46)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Installing some packages from the JavaScript Package Registry with `npm` (such as `js-deobfuscator`) requires having git installed.

Closes https://github.com/mandiant/VM-Packages/issues/1038