### PR TITLE
[common] Print directory in Powershell shortcuts

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240514</version>
+    <version>0.0.0.20240516</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -239,7 +239,7 @@ function VM-Install-Shortcut{
             $executableArgs = "/K `"cd `"$executableDir`" && echo $executableDir^> $executablePath $arguments && `"$executablePath`" $arguments`""
         } else {
             $executableCmd = Join-Path "${PSHome}" "powershell.exe" -Resolve
-            $executableArgs = "-ExecutionPolicy Bypass -NoExit -Command `"`$cmd = '$arguments'; Write-Host `$cmd; Invoke-Expression `$cmd`""
+            $executableArgs = "-ExecutionPolicy Bypass -NoExit -Command `"`$cmd = '$arguments'; Write-Host PS $executableDir ``> `$cmd; Invoke-Expression `$cmd`""
             $iconLocation = $executableCmd
         }
 


### PR DESCRIPTION
Fix bug I noticed while testing https://github.com/mandiant/VM-Packages/pull/1049#pullrequestreview-2061233129: Make Powershell shortcuts consistent with the cmd one by printing the execution directory.


### Before
![image](https://github.com/mandiant/VM-Packages/assets/16052290/fe6f5076-dea5-42f4-bf95-f77f535cb97e)
### After 
![image](https://github.com/mandiant/VM-Packages/assets/16052290/0492639b-bf30-4fac-82f0-7ea5847e94a9)
