### PR TITLE
[vscode] Fix metapackage version missmatch

### DIFF
--- a/packages/vscode.vm/vscode.vm.nuspec
+++ b/packages/vscode.vm/vscode.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscode.vm</id>
-    <version>1.85.2.20240507</version>
+    <version>1.89.1</version>
     <authors>Microsoft</authors>
     <description>VSCode is a modern, open-source code editor.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="vscode.install" version="[1.89.0]" />
+      <dependency id="vscode" version="[1.89.1]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Change the dependency to `vscode` instead `vscode.install`, which seems to just be a wrapper, so that the package and the dependency have the same name and the package is considered a metapackage. The CI will now update the version following the metapackage versioning convention.

Closes https://github.com/mandiant/VM-Packages/issues/972