### PR TITLE
Update CyberChef to use CyberChef icon

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240826</version>
+    <version>0.0.0.20240913</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1800,3 +1800,19 @@ function VM-Set-Legal-Notice {
     New-ItemProperty -Path $RegistryPath -Name legalnoticetext -Value $legalnoticetext -Force
 }
 
+# Converts image file to .ico needed for file icons
+function VM-Create-Ico {
+    param (
+        [string]$imagePath
+    )
+    Add-Type -AssemblyName System.Drawing
+    $imageDirPath = Split-Path -Path $imagePath -Parent
+    $filenameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($imagePath)
+    $iconLocation = Join-Path $imageDirPath "$($filenameWithoutExtension).ico"
+    $bitmap = [System.Drawing.Bitmap]::FromFile($imagePath)
+    $icon = [System.Drawing.Icon]::FromHandle($bitmap.GetHicon())
+    $fs = New-Object System.IO.FileStream($iconLocation, 'OpenOrCreate')
+    $icon.Save($fs)
+    $fs.Close()
+    return $iconLocation
+}

--- a/packages/cyberchef.vm/cyberchef.vm.nuspec
+++ b/packages/cyberchef.vm/cyberchef.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cyberchef.vm</id>
-    <version>10.19.0</version>
+    <version>10.19.0.20240913</version>
     <authors>GCHQ</authors>
     <description>The Cyber Swiss Army Knife - a web app for encryption, encoding, compression, data analysis, and more.</description>
     <dependencies>

--- a/packages/cyberchef.vm/tools/chocolateyinstall.ps1
+++ b/packages/cyberchef.vm/tools/chocolateyinstall.ps1
@@ -25,7 +25,7 @@ try {
   $htmlPath = Join-Path $toolDir "CyberChef_v10.19.0.html" -Resolve
   $arguments = "start chrome $htmlPath && exit"
   $executableArgs = "/C $arguments"
-  $iconLocation = "%ProgramFiles%\Google\Chrome\Application\chrome.exe"
+  $iconLocation = VM-Create-Ico (Join-Path $toolDir "images\cyberchef-128x128.png") # Create .ico for cyberchef icon
 
   Install-ChocolateyShortcut -ShortcutFilePath $shortcut -TargetPath $executableCmd -Arguments $executableArgs -WorkingDirectory $toolDir -WindowStyle 7 -IconLocation $iconLocation
 


### PR DESCRIPTION
This converts the CyberChef PNG file that is provided with the download and converts it to a `.ico` so that Chocolatey can use it for an icon for the shortcut. 

Closes https://github.com/mandiant/VM-Packages/issues/966