### PR TITLE
Fix wrong version for NetworkMiner

### DIFF
--- a/packages/networkminer.vm/networkminer.vm.nuspec
+++ b/packages/networkminer.vm/networkminer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>networkminer.vm</id>
-    <version>2.9.20240411</version>
+    <version>2.9.0</version>
     <authors>Netresec</authors>
     <description>NetworkMiner is an open source Network Forensic Analysis Tool for Windows, but also works in Linux or Mac OS X. NetworkMiner can be used as a passive network sniffer in order to detect operating systems, sessions, hostnames, open ports etc. without putting any traffic on the network. NetworkMiner can also parse PCAP files for off-line analysis and to reassemble transmitted files and certificates from PCAP files.</description>
     <dependencies>


### PR DESCRIPTION
When merging #1056 a wrong version format was pushed. This fixes the version, however it may be necessary to remove the version `2.9.20240411` from MyGet.