### PR TITLE
Fix openjdk.vm dependency version format

### DIFF
--- a/packages/openjdk.vm/openjdk.vm.nuspec
+++ b/packages/openjdk.vm/openjdk.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>openjdk.vm</id>
-    <version>0.0.0.20240202</version>
+    <version>0.0.0.20240531</version>
     <authors>Oracle</authors>
     <description>Metapackage for OpenJDK to ensure all packages use the same OpenJDK version.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="openjdk" version="(21.0.0, 21.0.1]" />
+      <dependency id="openjdk" version="[21.0.1, 21.0.2)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
`openjdk.vm` dependency version wasn't respecting the convention, it should be `[x,y)` not `(x,y]`.  The version `21.0.1` need to be pickup as it is hard-coded in `openjdk.vm`.