### PR TITLE
Github version change on update_package.py

### DIFF
--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -89,12 +89,12 @@ def update_github_url(package):
     # Use findall as some packages have two urls (for 32 and 64 bits), we need to update both
     # Match urls like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
     matches = re.findall(
-        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/(?P<version>[^/]+)/[^\"']+)[\"']",
+        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/v?(?P<version>[^/]+)/[^\"']+)[\"']",
         content,
     )
     # Match also urls like https://github.com/joxeankoret/diaphora/archive/refs/tags/3.0.zip
     matches += re.findall(
-        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/archive/refs/tags/(?P<version>[^/]+).zip)[\"']",
+        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/archive/refs/tags/v?(?P<version>[^/]+).zip)[\"']",
         content,
     )
 


### PR DESCRIPTION
As commented in #1053:
`hayabusa` as well as other packages such as `upx` have a problem when the version for example `v2.15.0` is different of the version in the filename `hayabusa-2.15.0-win-x64.zip` because of the `v`. The update works only because it will fallback to `update_version_url` and the updated version is in one of the case of `get_increased_version`.

From my testing adding `v?` in the url of `update_github_url` will allow the update via github without breaking any other package auto update (but I think a deeper review is required).

