### PR TITLE
[extreme_dumper.vm] Update broken URL

### DIFF
--- a/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
+++ b/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>extreme_dumper.vm</id>
-    <version>4.0.0.20240411</version>
+    <version>4.0.0.20240603</version>
     <authors>wwh1004</authors>
     <description>.NET Assembly Dumper from memory of processes.</description>
     <dependencies>

--- a/packages/extreme_dumper.vm/tools/chocolateyinstall.ps1
+++ b/packages/extreme_dumper.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'ExtremeDumper'
 $category = 'dotNet'
 
-$zipUrl = 'https://github.com/wwh1004/ExtremeDumper/releases/latest/download/ExtremeDumper.zip'
+$zipUrl = 'https://gitee.com/keyestore/ExtremeDumper/releases/download/v4.0.0.1/ExtremeDumper.zip'
 $zipSha256 = 'fbffedf2a9420be03538f04bd80a69e35503f8d8395da76a9ac2518a65e1facc'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false


### PR DESCRIPTION
Use alternative URL to download ExtremeDumper as the author seems to have deleted their GitHub account breaking the package. Thanks for providing the URL @superguo!

Closes https://github.com/mandiant/VM-Packages/issues/1064