### PR TITLE
Increase version to push packages (2nd round)

### DIFF
--- a/packages/ollydbg.plugin.scyllahide.vm/ollydbg.plugin.scyllahide.vm.nuspec
+++ b/packages/ollydbg.plugin.scyllahide.vm/ollydbg.plugin.scyllahide.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg.plugin.scyllahide.vm</id>
-    <version>1.4</version>
+    <version>1.4.0.20240606</version>
     <description>ScyllaHide is an advanced open-source x64/x86 user mode Anti-Anti-Debug library.</description>
     <authors>x64dbg</authors>
     <dependencies>

--- a/packages/ollydbg2.plugin.ollydumpex.vm/ollydbg2.plugin.ollydumpex.vm.nuspec
+++ b/packages/ollydbg2.plugin.ollydumpex.vm/ollydbg2.plugin.ollydumpex.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.plugin.ollydumpex.vm</id>
-    <version>1.84</version>
+    <version>1.84.0.20240606</version>
     <description>This plugin is process memory dumper for OllyDbg2 and Immunity Debugger. OllyDumpEx = OllyDump + PE Dumper - obsoleted + useful features</description>
     <authors>low-priority</authors>
     <dependencies>

--- a/packages/ollydbg2.plugin.scyllahide.vm/ollydbg2.plugin.scyllahide.vm.nuspec
+++ b/packages/ollydbg2.plugin.scyllahide.vm/ollydbg2.plugin.scyllahide.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.plugin.scyllahide.vm</id>
-    <version>1.4</version>
+    <version>1.4.0.20240606</version>
     <description>ScyllaHide is an advanced open-source x64/x86 user mode Anti-Anti-Debug library.</description>
     <authors>x64dbg</authors>
     <dependencies>

--- a/packages/systeminformer.vm/systeminformer.vm.nuspec
+++ b/packages/systeminformer.vm/systeminformer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>systeminformer.vm</id>
-    <version>3.0.7645</version>
+    <version>3.0.7645.20240606</version>
     <authors>winsiderss</authors>
     <description>A free, powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.</description>
     <dependencies>

--- a/packages/testdisk.vm/testdisk.vm.nuspec
+++ b/packages/testdisk.vm/testdisk.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>testdisk.vm</id>
-    <version>7.2.0.20240516</version>
+    <version>7.2.0.20240606</version>
     <authors>Christophe Grenier</authors>
     <description>A robust data recovery tool, TestDisk, specializes in restoring lost partitions across diverse filesystems and facilitates file undeletion within supported filesystems.</description>
     <dependencies>

--- a/packages/winscp.vm/winscp.vm.nuspec
+++ b/packages/winscp.vm/winscp.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>winscp.vm</id>
-    <version>6.3.3</version>
+    <version>6.3.3.20240606</version>
     <authors>Martin Přikryl</authors>
     <description>WinSCP is an open source free SFTP client, SCP client, FTPS client and FTP client for Windows. Its main function is file transfer between a local and a remote computer.</description>
     <dependencies>

--- a/packages/x64dbg.plugin.ollydumpex.vm/x64dbg.plugin.ollydumpex.vm.nuspec
+++ b/packages/x64dbg.plugin.ollydumpex.vm/x64dbg.plugin.ollydumpex.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>x64dbg.plugin.ollydumpex.vm</id>
-    <version>1.84</version>
+    <version>1.84.0.20240606</version>
     <description>This plugin is process memory dumper for OllyDbg and Immunity Debugger. OllyDumpEx = OllyDump + PE Dumper - obsoleted + useful features</description>
     <authors>low-priority</authors>
     <dependencies>

--- a/packages/x64dbg.vm/x64dbg.vm.nuspec
+++ b/packages/x64dbg.vm/x64dbg.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>x64dbg.vm</id>
-    <version>2024.04.11</version>
+    <version>2024.04.11.20240606</version>
     <description>An open-source x64/x32 debugger for Windows.</description>
     <authors>mrexodia</authors>
     <dependencies>


### PR DESCRIPTION
Increase version of 8 packages updated in https://github.com/mandiant/VM-Packages/pull/1053, but that were not pushed to MyGet because of the failure of idafree.vm (whose hash changed between the PR CI run and the merged CI run). Some packages were pushed in https://github.com/mandiant/VM-Packages/pull/1078 and this PR will push the rest.

Closes https://github.com/mandiant/VM-Packages/issues/1061