### PR TITLE
[CI] Check daily that local versions match MyGet

### DIFF
--- a/.github/workflows/compare_myget.yml
+++ b/.github/workflows/compare_myget.yml
@@ -1,0 +1,44 @@
+name: MyGet version mitmatches
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs daily at a weird time (02:41 UTC) to avoid delays during periods of
+    # high loads of GitHub Actions workflow runs.
+    - cron: '41 2 * * *'
+
+
+jobs:
+  update_badge:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout wiki code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: ${{ github.repository }}.wiki
+          path: wiki
+      - name: Add results to wiki
+        run: |
+          $mismatches=$(python scripts/utils/compare_myget.py)
+          echo "mismatches=$mismatches" >> $env:GITHUB_ENV
+      - name: Commit changes
+        working-directory: wiki
+        run: |
+          git config user.email 'vm-packages@google.com'
+          git config user.name 'vm-packages'
+          git commit -am 'Add MyGet mismatches'
+          git push
+      - name: Update dynamic badge gist
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.REPO_TOKEN }}
+          gistID: dfe6ed22576b6c1d2fa749ff46f3bc6f
+          filename: myget_badge.svg
+          label: 'MyGet mismatches'
+          message: ${{ env.mismatches }}
+          valColorRange: ${{ env.mismatches }}
+          maxColorRange: 1
+          minColorRange: 0
+          invertColorRange: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](packages)
 [![Daily run failures Windows 2022](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2022_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![Daily run failures Windows 2019](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2019_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
+[![MyGet version mismatches](https://gist.githubusercontent.com/vm-packages/dfe6ed22576b6c1d2fa749ff46f3bc6f/raw/myget_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/MyGet-Version-Mismatches)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 
 # Virtual Machine Packages

--- a/scripts/utils/compare_myget.py
+++ b/scripts/utils/compare_myget.py
@@ -1,0 +1,53 @@
+import glob
+import os
+import re
+
+log_file = "wiki/MyGet-Version-Mismatches.md"
+source = "https://www.myget.org/F/vm-packages/api/v2"
+
+# Convert 1.02.0 to 1.2 to ensure we compare versions consistency
+def format_version(version):
+    version = re.sub("\.0(?P<digit>\d)", lambda x: f".{x.group('digit')}", version)
+    return re.sub("(\.0+)+$", "", version)
+
+
+def get_remote_version(package_name):
+    stream = os.popen(f"powershell.exe choco find -er {package_name} -s {source}")
+    output = stream.read()
+    m = re.search(f"^{package_name}\|(?P<version>.+)", output, re.M)
+    if not m:
+        return ''
+    return m.group("version")
+
+
+mismatches = []
+nuspecs_path = "packages/*/*.nuspec"
+nuspecs = glob.glob(nuspecs_path)
+for nuspec in nuspecs:
+    with open(nuspec, "r") as file:
+        nuspec_content = file.read()
+
+    # Find local package version
+    m = re.search("<id>(?P<name>[^<]+)</id>", nuspec_content)
+    m2 = re.search("<version>(?P<version>[^<]+)</version>", nuspec_content)
+
+    if (m and m2):
+        name = m.group("name")
+        local_version = m2.group("version")
+        my_get_version = get_remote_version(name)
+        if format_version(local_version) != format_version(my_get_version):
+            mismatches.append([name, my_get_version, local_version])
+
+log_f = open(log_file, "w")
+if not mismatches:
+    log_f.write("**All local versions match MyGet versions** :tada:")
+else:
+    W1 = 40
+    W2 = 25
+    log_f.write("The following packages local version do not match the latest version in MyGet.\n\n")
+    log_f.write(f"| {'Package Name'.ljust(W1)} | {'MyGet version'.ljust(W2)} | {'Local version'.ljust(W2)} |\n|-|-|-|\n")
+    for mismatch in mismatches:
+        log_f.write(f"| {mismatch[0].ljust(W1)} | {mismatch[1].rjust(W2)} | {mismatch[2].rjust(W2)} |\n")
+
+print(len(mismatches))
+


### PR DESCRIPTION
If the packages testing fail when merging a PR, the packages are not pushed to MyGet. To ensure we are aware (and fix/repush the packages as needed), compare the local package versions with the ones in MyGet daily. Update the badge on the README and the `MyGet Version Mismatches` wiki page with the results.

![image](https://github.com/mandiant/VM-Packages/assets/16052290/527248e6-e634-4faa-b1ff-ffb3b618d235)

You can see it working in my fork:
- [`MyGet Version Mismatches` wiki page](https://github.com/ana06/VM-Packages/wiki/MyGet-Version-Mismatches)
- [GH workflow run](https://github.com/Ana06/VM-Packages/actions/runs/9405503985/job/25906821463)

Closes https://github.com/mandiant/VM-Packages/issues/132