### PR TITLE
Add autoit-ripper.vm & helper functions to install tools with Pip

### DIFF
--- a/packages/autoit-ripper.vm/autoit-ripper.vm.nuspec
+++ b/packages/autoit-ripper.vm/autoit-ripper.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>autoit-ripper.vm</id>
+    <version>0.0.0.20240607</version>
+    <authors>Michał Praszmo</authors>
+    <description>Extracts compiled AutoIt scripts from PE executables.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240607" />
+      <dependency id="python3.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/autoit-ripper.vm/tools/chocolateyinstall.ps1
+++ b/packages/autoit-ripper.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'autoit-ripper'
+$category = 'Packers'
+
+VM-Install-With-Pip -toolName $toolName -category $category

--- a/packages/autoit-ripper.vm/tools/chocolateyuninstall.ps1
+++ b/packages/autoit-ripper.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'autoit-ripper'
+$category = 'Packers'
+
+VM-Uninstall-With-Pip -toolName $toolName -category $category

--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240531</version>
+    <version>0.0.0.20240607</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/magika.vm/magika.vm.nuspec
+++ b/packages/magika.vm/magika.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>magika.vm</id>
-    <version>0.5.1</version>
+    <version>0.0.0.20240607</version>
     <authors>Yanick Fratantonio, Luca Invernizzi, Marina Zhang, Giancarlo Metitieri, Thomas Kurt, Francois Galilee, Alexandre Petit-Bianco, Loua Farah, Ange Albertini, Elie Bursztein</authors>
     <description>Magika is an AI powered file type detection tool that uses deep learning to provide accurate detection.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240607" />
       <dependency id="python3.vm" />
     </dependencies>
   </metadata>

--- a/packages/magika.vm/tools/chocolateyinstall.ps1
+++ b/packages/magika.vm/tools/chocolateyinstall.ps1
@@ -1,16 +1,7 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-    $toolName = 'magika'
-    $category = 'File Information'
+$toolName = 'magika'
+$category = 'File Information'
 
-    VM-Pip-Install $toolName
-
-    $executablePath = "$(where.exe $toolName)"
-    $arguments = "--help"
-
-    VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $arguments -iconLocation $iconLocation
-} catch {
-    VM-Write-Log-Exception $_
-}
+VM-Install-With-Pip -toolName $toolName -category $category

--- a/packages/magika.vm/tools/chocolateyuninstall.ps1
+++ b/packages/magika.vm/tools/chocolateyuninstall.ps1
@@ -4,6 +4,4 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'magika'
 $category = 'File Information'
 
-Invoke-Expression "py -3.10 -m pip uninstall $toolName -y"
-
-VM-Uninstall $toolName $category
+VM-Uninstall-With-Pip -toolName $toolName -category $category


### PR DESCRIPTION
Add helper functions in `vm.common.psm1` to simplify installation of Python tools installed with pip. Related: https://github.com/mandiant/VM-Packages/issues/1080


Use the new helpers in magika.vm, also fixing the following issues:
- Fix uninstallation which wrongly used `VM-Uninstall`, as it is only  needed to remove the shortcut in the Tools category.
- Remove unused `$iconLocation` in installation. This change does not have any visible effect, but simplifies the code.

Note the version of magika has been **decreased** because it was incorrect. I have just deleted the previous package from MyGet to ensure the change is tested. **We should merge this PR quick as the package will be broken till then**.

Add [`autoit-ripper`](https://github.com/nazywam/AutoIt-Ripper) which has helped me analysing a compiled AutoIt script recently. The extracted script is similar to the one extracted with `UnAutoIt`, which seems to have been removed from GitHub.
