### PR TITLE
Fix missing dependency in hashdb plugin

### DIFF
--- a/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
+++ b/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.comida.vm</id>
-    <version>0.0.0.20240507</version>
+    <version>0.0.0.20240725</version>
     <authors>Airbus CERT</authors>
     <description>IDA Plugin that help analyzing modules using COM.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
+++ b/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.dereferencing.vm</id>
-    <version>0.0.0.20240430</version>
+    <version>0.0.0.20240725</version>
     <authors>danigargu</authors>
     <description>IDA Pro plugin that implements new registers and stack views.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
+++ b/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.diaphora.vm</id>
-    <version>3.2.1</version>
+    <version>3.2.1.20240725</version>
     <authors>joxeankoret</authors>
     <description>Diaphora is a program diffing IDA plugin.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
+++ b/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.flare.vm</id>
-    <version>0.0.0.20240513</version>
+    <version>0.0.0.20240725</version>
     <authors>Jay Smith</authors>
     <description>IDA Pro plugins used by the FLARE team.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
+++ b/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.hashdb.vm</id>
-    <version>1.9.1</version>
+    <version>1.9.1.20240526</version>
     <authors>OALabs</authors>
     <description>Malware string hash lookup plugin for IDA Pro</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
+++ b/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.ifl.vm</id>
-    <version>1.4.4</version>
+    <version>1.4.4.20240725</version>
     <authors>hasherezade</authors>
     <description>Interactive Functions List IDA Pro plugin.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
+++ b/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.lighthouse.vm</id>
-    <version>0.0.0.20240507</version>
+    <version>0.0.0.20240725</version>
     <authors>gaasedelen</authors>
     <description>A powerful coverage explorer.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
+      <dependency id="libraries.python3.vm" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This fixes the issue noted [here](https://github.com/mandiant/VM-Packages/pull/1076#issuecomment-2190501954) about the ida plugin `hashdb` missing a dependency for `python3` since it uses `pip` to install `requests`.