### PR TITLE
[pdbs.pdbresym.vm] Download .NET PDBs

### DIFF
--- a/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
+++ b/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdbs.pdbresym.vm</id>
-    <version>0.0.0.20240417</version>
+    <version>0.0.0.20240710</version>
     <authors>Stephen Eckels</authors>
     <description>Download PDBs</description>
     <dependencies>

--- a/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
@@ -2,10 +2,14 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  # Iterate through C:\Windows\System32 downloading all PDBs concurrently
   $executablePath = Join-Path ${Env:RAW_TOOLS_DIR} PDBReSym\PDBReSym.exe -Resolve
+
   VM-Write-Log "INFO" "Iterating through C:\Windows\System32 downloading PDBs to C:\symbols"
   & $executablePath cachesyms
+
+  VM-Write-Log "INFO" "Iterating through  C:\Windows\Microsoft.NET downloading .NET PDBs to C:\symbols"
+  & $executablePath cachesyms --sysdir "C:\Windows\Microsoft.NET"
+
   # The downloaded symbols are store into C:\symbols
   VM-Assert-Path "C:\symbols"
 


### PR DESCRIPTION
Download .NET PDBs to `C:\symbols` using PDBReSym to iterate through `C:\Windows\Microsoft.NET`.

Closes https://github.com/mandiant/VM-Packages/issues/1096