### PR TITLE
Add the CFF Explorer icon to the right click & fix uninstallation

### DIFF
--- a/packages/explorersuite.vm/explorersuite.vm.nuspec
+++ b/packages/explorersuite.vm/explorersuite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>explorersuite.vm</id>
-    <version>0.0.0.20240614</version>
+    <version>0.0.0.20240717</version>
     <authors>Erik Pistelli</authors>
     <description>A suite of tools including CFF Explorer and a process viewer.</description>
     <dependencies>

--- a/packages/explorersuite.vm/tools/chocolateyinstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyinstall.ps1
@@ -26,12 +26,14 @@ try {
     VM-Assert-Path $shortcut
   }
 
-  $cffExplorerExecutablePath = Join-Path $toolDir 'CFF Explorer.exe' -Resolve
-  Install-BinFile -Name 'CFFExplorer' -Path $cffExplorerExecutablePath
-  # "Open with CFF Explorer" is added to the registry for several extensions,
-  # add it for all extension with same key to avoid duplication.
-  # Use same label and no icon to make it look the same for all extensions.
-  VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExplorerExecutablePath`" %1"
+  $cffExecutablePath = Join-Path $toolDir 'CFF Explorer.exe' -Resolve
+  Install-BinFile -Name 'CFFExplorer' -Path $cffExecutablePath
+
+  # Installing CFF Explorer adds it to the right click menu for several file extensions (without icon)
+  # Delete the registry subkeys for the concrete file extensions to ensure the one we create (with icon) for all extensions applies
+  Remove-Item -Path "HKLM:\SOFTWARE\Classes\*file\shell\Open with CFF Explorer" -Recurse
+
+  VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExecutablePath`" %1" $cffExecutablePath
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
@@ -7,6 +7,6 @@ foreach ($subtoolName in $subtoolNames) {
   VM-Remove-Tool-Shortcut  $subtoolName $category
 }
 
-VM-Remove-From-Right-Click-Menu 'CFF explorer'
+VM-Remove-From-Right-Click-Menu 'Open with CFF Explorer'
 
 VM-Uninstall-With-Uninstaller "Explorer Suite IV" $category "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"


### PR DESCRIPTION
Add the CFF Explorer icon to the right click menu option. Installing CFF Explorer adds it to the right click menu for several file extensions (without icon). Delete the registry subkeys for the concrete file extensions to ensure the one we create for all extensions applies.

![image](https://github.com/user-attachments/assets/fffee7b0-8d7a-4169-a03a-52dbc0274b53)

Closes https://github.com/mandiant/VM-Packages/issues/1101

When uninstalling CFF Explorer, the right click menu option was not being removed because the
wrong name was being used. Correct the name to fix it.