### PR TITLE
Ensure strings from sysinternals is the first in PATH

### DIFF
--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>0.0.0.20240306</version>
+    <version>0.0.0.20240717</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite.</description>
     <dependencies>

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -30,6 +30,11 @@ try {
 try {
     # Add sysinternals tools to path
     Install-ChocolateyPath $toolDir
+
+    # Ensure strings is high in PATH
+    $executablePath = Join-Path $toolDir "strings.exe" -Resolve
+    Install-BinFile -Name strings -Path $executablePath
+
     # Add shortcut to sysinternals folder
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
     $shortcut = Join-Path $shortcutDir 'sysinternals.lnk'


### PR DESCRIPTION
I expect the strings from sysinternals to be the first one in the PATH (and not others like the ones in DidierStevensSuite). Use `Install-BinFile` to creates a shim for `strings.exe` in `$env:ChocolateyInstall\bin` that we ensure is on the top of the PATH after installing Python.

Closes https://github.com/mandiant/VM-Packages/issues/1086


![image](https://github.com/user-attachments/assets/d1c41b23-ccee-4e68-9f0e-38b825102160)
