### PR TITLE
[libraries.python3.vm] Add pycryptodomex library

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20240425</version>
+    <version>0.0.0.20240726</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -18,6 +18,7 @@
     <module name="psutil"/>
     <module name="pyasn1"/>
     <module name="pycryptodome"/>
+    <module name="pycryptodomex"/>
     <module name="pyftpdlib"/>
     <module name="pyOpenSSL"/>
     <module name="pyreadline3"/>


### PR DESCRIPTION
Add `pycryptodomex` Python library, the new PyCryptodome. The old PyCrypto and PyCryptodome can coexist, keep the old one for better compatibility.