### PR TITLE
Update .py default app execution

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240612</version>
+    <version>0.0.0.20240726</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -954,7 +954,7 @@ function VM-Set-Open-With-Association {
             # Create the 'command' key and its default value
             $commandKey = "${hive}\Software\Classes\${exeName}_auto_file\shell\open\command"
             New-Item -Path $commandKey -Force
-            New-ItemProperty -Path $commandKey -Name '(Default)' -Value "`"$executablePath`" `"%1`""
+            New-ItemProperty -Path $commandKey -Name '(Default)' -Value "`"$executablePath`" `"%1`" %*"
 
             # Create/update the file extension key
             $extKey = "${hive}\Software\Classes\$extension"

--- a/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
+++ b/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-beta.vm</id>
-    <version>0.0.0.20240226</version>
+    <version>0.0.0.20240726</version>
     <authors>Didier Stevens</authors>
     <description>Beta versions of Didier Stevens's software</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20231221" />
-      <dependency id="python3.vm" />
+      <dependency id="common.vm" version="0.0.0.20240726" />
+      <dependency id="python3.vm" version="0.0.0.20240726"/>
     </dependencies>
   </metadata>
 </package>

--- a/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
+++ b/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-suite.vm</id>
-    <version>0.0.0.20240226</version>
+    <version>0.0.0.20240726</version>
     <authors>Didier Stevens</authors>
     <description>Tools collection by Didier Stevens</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20231221" />
-      <dependency id="python3.vm" />
+      <dependency id="common.vm" version="0.0.0.20240726" />
+      <dependency id="python3.vm" version="0.0.0.20240726"/>
     </dependencies>
   </metadata>
 </package>

--- a/packages/python3.vm/python3.vm.nuspec
+++ b/packages/python3.vm/python3.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>python3.vm</id>
-    <version>0.0.0.20231019</version>
+    <version>0.0.0.20240726</version>
     <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
     <authors>Mandiant</authors>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20240425" />
       <dependency id="python3" version="[3.10.0, 3.11.0)" />
     </dependencies>
   </metadata>

--- a/packages/python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/python3.vm/tools/chocolateyinstall.ps1
@@ -2,10 +2,15 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
+  # Remove default python stubs created by Microsoft
+  Remove-Item $env:USERPROFILE\AppData\Local\Microsoft\WindowsApps\python*.exe
+
+  # Set all python files to use correct python3 install
+  VM-Set-Open-With-Association (Get-Command python).Source ".py"
+
   # Re-add shim path to the top of the path to ensure it is found before Python libraries
   $shimPath = Join-Path $Env:ChocolateyInstall "bin" -Resolve
   [Environment]::SetEnvironmentVariable("Path", "$shimPath;$Env:Path", "Machine")
 } catch {
     VM-Write-Log-Exception $_
 }
-


### PR DESCRIPTION
This fixes the issue with python files prompting for a default execution app noted here: https://github.com/mandiant/VM-Packages/issues/1085