### PR TITLE
[pdbs.pdbresym.vm] Download x32 and driver PDBs

### DIFF
--- a/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
+++ b/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdbs.pdbresym.vm</id>
-    <version>0.0.0.20240710</version>
+    <version>0.0.0.20240813</version>
     <authors>Stephen Eckels</authors>
     <description>Download PDBs</description>
     <dependencies>

--- a/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
+++ b/packages/pdbs.pdbresym.vm/tools/chocolateyinstall.ps1
@@ -3,15 +3,23 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
   $executablePath = Join-Path ${Env:RAW_TOOLS_DIR} PDBReSym\PDBReSym.exe -Resolve
+  $symbolsPath = "C:\symbols"
 
-  VM-Write-Log "INFO" "Iterating through C:\Windows\System32 downloading PDBs to C:\symbols"
-  & $executablePath cachesyms
+  $pdbs = @(
+    @{ name = "x64"; path = "$env:windir\System32" },
+    @{ name = ".NET"; path = "$env:windir\Microsoft.NET" },
+    @{ name = "driver"; path = "$env:windir\System32\drivers" }
+  )
+  if (Get-OSArchitectureWidth -Compare 64) {
+    $pdbs += @{ name = "x32"; path = "$env:windir\SysWOW64" }
+  }
 
-  VM-Write-Log "INFO" "Iterating through  C:\Windows\Microsoft.NET downloading .NET PDBs to C:\symbols"
-  & $executablePath cachesyms --sysdir "C:\Windows\Microsoft.NET"
+  ForEach ($pdb in $pdbs) {
+    VM-Write-Log "INFO" "Iterating through $($pdb.path) downloading $($pdb.name) PDBs to $symbolsPath"
+    & $executablePath cachesyms --sysdir $($pdb.path)
+  }
 
-  # The downloaded symbols are store into C:\symbols
-  VM-Assert-Path "C:\symbols"
+  VM-Assert-Path $symbolsPath
 
   # Set _NT_SYMBOL_PATH to include the downloaded symbols
   $symbolsPath = "srv*c:\symbols*https://msdl.microsoft.com/download/symbols"


### PR DESCRIPTION
Download x32 and driver PDBs to `C:\symbols` iterating thought the following paths respectively:
- `C:\Windows\SysWOW64`
- `C:\Windows\System32\drivers`

Refactor the code to make it easier to add new PDB paths.

Closes https://github.com/mandiant/VM-Packages/issues/1116
Closes https://github.com/mandiant/VM-Packages/issues/1117