### PR TITLE
[common] Add VM-Set-Legal-Notice helper function

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240612</version>
+    <version>0.0.0.20240821</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1789,3 +1789,14 @@ function VM-Uninstall-With-Pip {
     VM-Pip-Uninstall $toolName
     VM-Remove-Tool-Shortcut $toolName $category
 }
+
+function VM-Set-Legal-Notice {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string[]]$legalnoticetext
+    )
+    $RegistryPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
+    New-ItemProperty -Path $RegistryPath -Name legalnoticecaption -Value "Terms and Conditions" -Force
+    New-ItemProperty -Path $RegistryPath -Name legalnoticetext -Value $legalnoticetext -Force
+}
+


### PR DESCRIPTION
Add `VM-Set-Legal-Notice` helper function to set the legal notice to the desired text. The legal notice caption used is `Terms and Conditions`.