### PR TITLE
Fix daily test

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    # Testing all packages takes several hours
+    timeout-minutes: 720
     strategy:
       fail-fast: false
       # Updating the wiki fails if between the checkout of the wiki and the push of the update the other job pushes its update

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -27,21 +27,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test all packages
+        continue-on-error: true
         run: scripts/test/test_install.ps1 -all -max_tries 3
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
-        if: always()
       - name: Checkout wiki code
-        if: always()
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
       - name: Add results to wiki
-        if: always()
         run: python scripts/utils/generate_daily_results.py ${{ github.repository }} ${{ github.sha }} ${{ github.run_number }} ${{ github.run_id }} ${{ matrix.os }}
       - name: Commit changes
-        if: always()
         working-directory: wiki
         run: |
           git config user.email 'vm-packages@google.com'
@@ -49,7 +46,6 @@ jobs:
           git commit -am 'Add daily results'
           git push
       - name: Get badge info
-        if: always()
         run: |
           pwd
           $json = Get-Content -Raw "success_failure.json" | ConvertFrom-Json
@@ -61,7 +57,6 @@ jobs:
           echo "failure=$failure" >> $env:GITHUB_ENV
           echo "message=$message" >> $env:GITHUB_ENV
       - name: Update dynamic badge gist
-        if: always()
         uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
         with:
           auth: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
The daily test hasn't run correctly in the last weeks. The testing of the packages seem to be aborted because the default maximum execution time (6 hours) is exceeded. Increase the timeout to 12 hours.

The failure caused the README badge to be updated wrongly: 
![image](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/ae98f788383dc6219794b4b977fde1ebe8345eae/windows-2019_daily_badge.svg)
Change the conclusion status of the package testing step to success even if packages fail, as the action is still
running as expected (we want to count the failures, so we expect failures). This way we detect other errors early avoiding the wiki and the badge to be updated.