### PR TITLE
Fix ZimmermanTools Install

### DIFF
--- a/packages/amcacheparser.vm/amcacheparser.vm.nuspec
+++ b/packages/amcacheparser.vm/amcacheparser.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>amcacheparser.vm</id>
-    <version>1.5.1.20240411</version>
+    <version>1.5.1.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Amcache.hve parser with lots of extra features. Handles locked files</description>
     <dependencies>

--- a/packages/amcacheparser.vm/tools/chocolateyinstall.ps1
+++ b/packages/amcacheparser.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'AmcacheParser'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/AmcacheParser.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/AmcacheParser.zip'
 $zipSha256 = '7b78aa7f26287c6b9b3bf68d3bbccc372687760edf9ae84fafceaed3de535566'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/appcompatcacheparser.vm/appcompatcacheparser.vm.nuspec
+++ b/packages/appcompatcacheparser.vm/appcompatcacheparser.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>appcompatcacheparser.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>AppCompatCache aka ShimCache parser. Handles locked files</description>
     <dependencies>

--- a/packages/appcompatcacheparser.vm/tools/chocolateyinstall.ps1
+++ b/packages/appcompatcacheparser.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'AppCompatCacheParser'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/AppCompatCacheParser.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/AppCompatCacheParser.zip'
 $zipSha256 = '0ef9cc96a0784bc54f79e584f5845f7e3ada703cbfb6e209e9612bf1f7aad6c9'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/bstrings.vm/bstrings.vm.nuspec
+++ b/packages/bstrings.vm/bstrings.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bstrings.vm</id>
-    <version>1.5.2.20240411</version>
+    <version>1.5.2.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Find them strings yo. Built in regex patterns. Handles locked files</description>
     <dependencies>

--- a/packages/bstrings.vm/tools/chocolateyinstall.ps1
+++ b/packages/bstrings.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'bstrings'
 $category = 'Utilities'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/bstrings.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/bstrings.zip'
 $zipSha256 = '1521031bab2843757bb701b75741a24154965ba219a57cbfefddb792c6d5b301'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/evtxecmd.vm/evtxecmd.vm.nuspec
+++ b/packages/evtxecmd.vm/evtxecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>evtxecmd.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Event log (evtx) parser with standardized CSV, XML, and json output! Custom maps, locked file support, and more!</description>
     <dependencies>

--- a/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'EvtxECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/EvtxECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/EvtxECmd.zip'
 $zipSha256 = 'e1b4a5f9b09eca3c057cdc2d0ed1a28fe0c24dc90f9f68b7e0572e373dce86a6'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true

--- a/packages/ezviewer.vm/ezviewer.vm.nuspec
+++ b/packages/ezviewer.vm/ezviewer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ezviewer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Standalone, zero dependency viewer for .doc, .docx, .xls, .xlsx, .txt, .log, .rtf, .otd, .htm, .html, .mht, .csv, and .pdf. Any non-supported files are shown in a hex editor (with data interpreter!)</description>
     <dependencies>

--- a/packages/ezviewer.vm/tools/chocolateyinstall.ps1
+++ b/packages/ezviewer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'EZViewer'
 $category = 'Documents'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/EZViewer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/EZViewer.zip'
 $zipSha256 = '86a27bf8f4744d283c33d7321ad8a510e6f4067ec776cfdf1cc4748a0684072d'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/hasher.vm/hasher.vm.nuspec
+++ b/packages/hasher.vm/hasher.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hasher.vm</id>
-    <version>2.1.0.20220618</version>
+    <version>2.1.0.20220826</version>
     <authors>Eric Zimmerman</authors>
     <description>Hash all the things</description>
     <dependencies>

--- a/packages/hasher.vm/tools/chocolateyinstall.ps1
+++ b/packages/hasher.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'Hasher'
 $category = 'File Information'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/hasher.zip'
+$zipUrl = 'https://download.mikestammer.com/hasher.zip'
 $zipSha256 = '14ee103793fae4f165adc5e0a9424ca75ea0a4dc2e823dcc2b7cdeb2ae94483c'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/jlecmd.vm/jlecmd.vm.nuspec
+++ b/packages/jlecmd.vm/jlecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jlecmd.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Jump List parser</description>
     <dependencies>

--- a/packages/jlecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/jlecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'JLECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/JLECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/JLECmd.zip'
 $zipSha256 = 'b0635517a72d2a7cdfdc92d5161f38e968380ae2ec33673571108bacf31b4480'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/jumplist_explorer.vm/jumplist_explorer.vm.nuspec
+++ b/packages/jumplist_explorer.vm/jumplist_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>jumplist_explorer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>GUI based Jump List viewer</description>
     <dependencies>

--- a/packages/jumplist_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/jumplist_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'JumpListExplorer'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/JumpListExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/JumpListExplorer.zip'
 $zipSha256 = '5543774e73f6c42ece035b95f2e3689a1a52ef89cb04b15512da264c8bc799f9'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/lecmd.vm/lecmd.vm.nuspec
+++ b/packages/lecmd.vm/lecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>lecmd.vm</id>
-    <version>1.5.0.20240618</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Parse lnk files</description>
     <dependencies>

--- a/packages/lecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/lecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'LECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/LECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/LECmd.zip'
 $zipSha256 = '545f6eb250fa44c1d0c8f0abe361e283c3f22194f32dbae8e913265cefb05677'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/mft_explorer.vm/mft_explorer.vm.nuspec
+++ b/packages/mft_explorer.vm/mft_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mft_explorer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Graphical $MFT viewer</description>
     <dependencies>

--- a/packages/mft_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/mft_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MFTExplorer'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/MFTExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/MFTExplorer.zip'
 $zipSha256 = '99947e91bbc19e440de7b1ff7a3557beed6ee79a3765eb67d58e4369ac711f1f'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/mftecmd.vm/mftecmd.vm.nuspec
+++ b/packages/mftecmd.vm/mftecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mftecmd.vm</id>
-    <version>1.2.2.20240411</version>
+    <version>1.2.2.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>$MFT, $Boot, $J, $SDS, $I30, and $LogFile (coming soon) parser. Handles locked files</description>
     <dependencies>

--- a/packages/mftecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/mftecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MFTECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/MFTECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/MFTECmd.zip'
 $zipSha256 = '9beb6bb054df4806023937548bec212177cb8967f6f4d84b73a4e35fb13b8a50'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/pecmd.vm/pecmd.vm.nuspec
+++ b/packages/pecmd.vm/pecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pecmd.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Prefetch parser</description>
     <dependencies>

--- a/packages/pecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/pecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'PECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/PECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/PECmd.zip'
 $zipSha256 = 'e20254b2f813e66fe5295488e5a00e9675679c91841f99ddcc8d083299bb55d6'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/rbcmd.vm/rbcmd.vm.nuspec
+++ b/packages/rbcmd.vm/rbcmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rbcmd.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Recycle Bin artifact (INFO2/$I) parser</description>
     <dependencies>

--- a/packages/rbcmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/rbcmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'RBCmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/RBCmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/RBCmd.zip'
 $zipSha256 = '326b4d77bd2915551b85391bdebf1dc4a32bc5a872a4da0d55af8df657086135'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/recentfilecacheparser.vm/recentfilecacheparser.vm.nuspec
+++ b/packages/recentfilecacheparser.vm/recentfilecacheparser.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>recentfilecacheparser.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>RecentFileCache parser</description>
     <dependencies>

--- a/packages/recentfilecacheparser.vm/tools/chocolateyinstall.ps1
+++ b/packages/recentfilecacheparser.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'RecentFileCacheParser'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/RecentFileCacheParser.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/RecentFileCacheParser.zip'
 $zipSha256 = '4b9760b75f4e91269e55d9a03b0b0572b3ed90948f2a08cc6c1215e2e00e3353'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/recmd.vm/recmd.vm.nuspec
+++ b/packages/recmd.vm/recmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>recmd.vm</id>
-    <version>2.0.0.20240507</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Powerful command line Registry tool searching, multi-hive support, plugins, and more</description>
     <dependencies>

--- a/packages/recmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/recmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'RECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/RECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/RECmd.zip'
 $zipSha256 = '58d1884c5f0ff5b1564220377630316303adc5a0840126921c93139f618e2e61'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>registry_explorer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Registry viewer with searching, multi-hive support, plugins, and more. Handles locked files</description>
     <dependencies>

--- a/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'RegistryExplorer'
 $category = 'Registry'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/RegistryExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/RegistryExplorer.zip'
 $zipSha256 = '50a11bd0a5e44dcea6469b8564eb3f010b9a8faf323ff6481222d391da26887e'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/rla.vm/rla.vm.nuspec
+++ b/packages/rla.vm/rla.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rla.vm</id>
-    <version>2.0.0.20240507</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Replay transaction logs and update Registry hives so they are no longer dirty. Useful when tools do not know how to handle transaction logs</description>
     <dependencies>

--- a/packages/rla.vm/tools/chocolateyinstall.ps1
+++ b/packages/rla.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'RLA'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/rla.zip'
-$zipSha256 = '08b9decae513e707ac8bacc2205734652bc66b10fdacee8ca82b20f01a7ceb38'
+$zipUrl = 'https://download.mikestammer.com/net6/rla.zip'
+$zipSha256 = 'F30F9EF4F2E6BA8A002F8A799851D4173D85D5784FC3E388FBE1CFD525D20333'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/sbecmd.vm/sbecmd.vm.nuspec
+++ b/packages/sbecmd.vm/sbecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sbecmd.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>ShellBags Explorer, command line edition, for exporting shellbag data</description>
     <dependencies>

--- a/packages/sbecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sbecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'SBECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/SBECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/SBECmd.zip'
 $zipSha256 = '76e68ea696cb94f3a26c5c05e01467bdd8e18503fabd55ce4065448251071595'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/sdb_explorer.vm/sdb_explorer.vm.nuspec
+++ b/packages/sdb_explorer.vm/sdb_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sdb_explorer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Shim database GUI</description>
     <dependencies>

--- a/packages/sdb_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/sdb_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'SDBExplorer'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/SDBExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/SDBExplorer.zip'
 $zipSha256 = 'c88085e74405801f9d4f2557ce35eaa6316e6fe812e5efd66a6a1d87f1b1cbd6'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/shellbags_explorer.vm/shellbags_explorer.vm.nuspec
+++ b/packages/shellbags_explorer.vm/shellbags_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>shellbags_explorer.vm</id>
-    <version>2.0.0.20240411</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>GUI for browsing shellbags data. Handles locked files</description>
     <dependencies>

--- a/packages/shellbags_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/shellbags_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'ShellBagsExplorer'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/ShellBagsExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/ShellBagsExplorer.zip'
 $zipSha256 = '8f81e32b723115462d6245357d1c3d8a41fff2926c263c857a086765ce3f7ad2'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/sqlecmd.vm/sqlecmd.vm.nuspec
+++ b/packages/sqlecmd.vm/sqlecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sqlecmd.vm</id>
-    <version>1.0.0.20240411</version>
+    <version>1.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Find and process SQLite files according to your needs with maps!</description>
     <dependencies>

--- a/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'SQLECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/SQLECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/SQLECmd.zip'
 $zipSha256 = '40a23c2bd6855753e5f39a7cb944cd2e13aecb70ae2c5b3db840c959225454be'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true

--- a/packages/srumecmd.vm/srumecmd.vm.nuspec
+++ b/packages/srumecmd.vm/srumecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>srumecmd.vm</id>
-    <version>0.5.1.20240411</version>
+    <version>0.5.1.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Process SRUDB.dat and (optionally) SOFTWARE hive for network, process, and energy info!</description>
     <dependencies>

--- a/packages/srumecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/srumecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'SrumECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/SrumECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/SrumECmd.zip'
 $zipSha256 = 'acfff757f1da4e7cc5c7c521c8fd7eeda938ac9402ae4874f2c8f49239d52dc1'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/sumecmd.vm/sumecmd.vm.nuspec
+++ b/packages/sumecmd.vm/sumecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sumecmd.vm</id>
-    <version>0.5.2.20240411</version>
+    <version>0.5.2.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Process Microsoft User Access Logs found under "C:\Windows\System32\LogFiles\SUM"</description>
     <dependencies>

--- a/packages/sumecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sumecmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'SumECmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/SumECmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/SumECmd.zip'
 $zipSha256 = '74ed2f833056c2c88ee906fd1cbd8938a1d8f0c2df7e7ce031614858c8d16cb7'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/timeline_explorer.vm/timeline_explorer.vm.nuspec
+++ b/packages/timeline_explorer.vm/timeline_explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>timeline_explorer.vm</id>
-    <version>2.0.0.20240507</version>
+    <version>2.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>View CSV and Excel files, filter, group, sort, etc. with ease</description>
     <dependencies>

--- a/packages/timeline_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/timeline_explorer.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'TimelineExplorer'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/TimelineExplorer.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/TimelineExplorer.zip'
 $zipSha256 = '9e6f008102fcf62148856dad03f310b11b4c586495985fd3d3e333497c6fee2b'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true

--- a/packages/vscmount.vm/tools/chocolateyinstall.ps1
+++ b/packages/vscmount.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'VSCMount'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/VSCMount.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/VSCMount.zip'
 $zipSha256 = '28927b892af255673432a962ac41f58f9be5cb3c7c0a2444556a01b033f066a7'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/vscmount.vm/vscmount.vm.nuspec
+++ b/packages/vscmount.vm/vscmount.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vscmount.vm</id>
-    <version>1.5.0.20240411</version>
+    <version>1.5.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Mount all VSCs on a drive letter to a given mount point</description>
     <dependencies>

--- a/packages/wxtcmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/wxtcmd.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'WxTCmd'
 $category = 'Forensic'
 
-$zipUrl = 'https://f001.backblazeb2.com/file/EricZimmermanTools/net6/WxTCmd.zip'
+$zipUrl = 'https://download.mikestammer.com/net6/WxTCmd.zip'
 $zipSha256 = '87d97c832a6c7d82ca57e2213c6e3416a3b4ea5ff5b54db4cc84e48b1cfc424a'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/wxtcmd.vm/wxtcmd.vm.nuspec
+++ b/packages/wxtcmd.vm/wxtcmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wxtcmd.vm</id>
-    <version>1.0.0.20240411</version>
+    <version>1.0.0.20240826</version>
     <authors>Eric Zimmerman</authors>
     <description>Windows 10 Timeline database parser</description>
     <dependencies>


### PR DESCRIPTION
Currently all ZimmermanTools return a 404 when attempting to download them. This changes the server to the appropriate server "https://download.mikestammer.com/" for all 26 packages. 