### PR TITLE
[nodejs.vm] Relax git version to fix CI

### DIFF
--- a/packages/nodejs.vm/nodejs.vm.nuspec
+++ b/packages/nodejs.vm/nodejs.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nodejs.vm</id>
-    <version>0.0.0.20240516</version>
+    <version>0.0.0.20240827</version>
     <authors>Node.js Foundation</authors>
     <description>Metapackage for Node.js to ensure all packages use the same Node.js version.</description>
     <dependencies>
       <dependency id="common.vm" />
       <dependency id="nodejs" version="[20.7.0, 20.8.0)" />
-      <dependency id="git" version="[2.45.0, 2.46)" />
+      <dependency id="git" version="[2.45.0,)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
GitHub actions has upgraded to `git` 2.46, causing that the installation of `git.install` 2.45 fails in the CI.

Because of what seems to be a [Chocolatey bug](https://github.com/chocolatey/choco/issues/3487#issuecomment-2312063152), the failure of `git.install` dependency does not make the packages `git` or `nodejs.vm` to fail, causing unresolved package dependency constraints in Chocolatey. This makes any other package to fail to install after the installation of `nodejs.vm`.

The issue seem to cause a big amount of failure packages in our daily run, causing that it takes more than 12 hours hours to run.

Related: https://github.com/mandiant/VM-Packages/pull/1122