### PR TITLE
[daily] Increase timeout again

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     # Testing all packages takes several hours
-    timeout-minutes: 720
+    timeout-minutes: 1380
     strategy:
       fail-fast: false
       # Updating the wiki fails if between the checkout of the wiki and the push of the update the other job pushes its update


### PR DESCRIPTION
The last two daily runs needed 8h 38min and 9h 13min. I think we should increase (again :grimacing:) the current timeout of 12 hours to 23 hours to ensure the daily runs completely even if an unexpected delay happens.