### PR TITLE
Fix Custom Taskbar from breaking on Win 11

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20240913</version>
+    <version>0.0.0.20241002</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1523,6 +1523,8 @@ public class Shell {
         $SHCNE_ASSOCCHANGED = 0x08000000
         $SHCNF_IDLIST = 0
         [void][Shell]::SHChangeNotify($SHCNE_ASSOCCHANGED, $SHCNF_IDLIST, [IntPtr]::Zero, [IntPtr]::Zero)
+        # Refresh the Taskbar
+        Stop-Process -Name explorer -Force  # This restarts the explorer process so that the new taskbar is displayed.
     } catch {
         VM-Write-Log-Exception $_
     }

--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,12 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20240402</version>
+    <version>0.0.0.20241002</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20241002" />
     </dependencies>
   </metadata>
 </package>
-

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -32,15 +32,6 @@ try {
     }
     VM-Write-Log "INFO" "Packages installation complete"
 
-    ## Configure taskbar with custom Start Layout if it exists.
-    $customLayout = Join-Path ${Env:VM_COMMON_DIR} "CustomStartLayout.xml"
-    if (Test-Path $customLayout) {
-        Import-StartLayout -LayoutPath $customLayout -MountPath "C:\"
-        Stop-Process -Name explorer -Force  # This restarts the explorer process so that the new taskbar is displayed.
-    } else {
-        VM-Write-Log "WARN" "CustomStartLayout.xml missing. No items will be pinned to the taskbar."
-    }
-
     # Set Profile/Version specific configurations
     VM-Write-Log "INFO" "Beginning Windows OS VM profile configuration changes"
     $configPath = Join-Path $Env:VM_COMMON_DIR "config.xml" -Resolve


### PR DESCRIPTION
This is step 2 for fixing the Windows 11 installation error as noted in https://github.com/mandiant/flare-vm/issues/603

This works in tandem with https://github.com/mandiant/flare-vm/pull/617 and needs to be merged alongside it in order for installations not to break.