### PR TITLE
Improve VM-Pip-Install & add libraries-extra.python3.vm

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20241002</version>
+    <version>0.0.0.20241029</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1737,16 +1737,18 @@ function VM-Get-MSIInstallerPathByProductName {
     }
 }
 
-# Install Python library with Pip
+# Install Python library/ies with Pip
 function VM-Pip-Install {
     param (
-        [string]$package
+        [string]$libraries # Comma-separated list of libraries to install, example: "flare-capa", "flare-capa,tabulate"
     )
     # Create output file to log python module installation details
     $outputFile = VM-New-Install-Log ${Env:VM_COMMON_DIR}
 
-    # Ignore warning with `-W ignore` to avoid warnings like deprecation to fail the installation
-    Invoke-Expression "py -3.10 -W ignore -m pip install $package --disable-pip-version-check 2>&1 >> $outputFile"
+    ForEach ($library in $libraries.Split(",")) {
+        # Ignore warning with `-W ignore` to avoid warnings like deprecation to fail the installation
+        Invoke-Expression "py -3.10 -W ignore -m pip install $library --disable-pip-version-check 2>&1 >> $outputFile"
+    }
 }
 
 # Install tool using Pip and create shortcut in the Tools directory

--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0</version>
+    <version>1.0.0.20241029</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240821" />
+      <dependency id="common.vm" version="0.0.0.20241029" />
       <dependency id="libraries.python3.vm" version="0.0.0.20240726" />
       <dependency id="fakenet-ng.vm" version="3.2.0.20240902" />
     </dependencies>

--- a/packages/internet_detector.vm/tools/chocolateyinstall.ps1
+++ b/packages/internet_detector.vm/tools/chocolateyinstall.ps1
@@ -11,10 +11,8 @@ New-Item -Path $toolDir -ItemType Directory -Force -ea 0
 VM-Assert-Path $toolDir
 
 # Install pyinstaller (needed to build the Python executable) and tool dependencies ('pywin32')
-$dependencies = @('pyinstaller', 'pywin32')
-ForEach ($dependency in $dependencies) {
-    VM-Pip-Install $dependency
-}
+$dependencies = "pyinstaller,pywin32"
+VM-Pip-Install $dependencies
 
 # This wrapper is needed because we can't run PyInstaller as admin, so this forces a usermode context.
 Start-Process -FilePath 'cmd.exe' -ArgumentList "/c pyinstaller --onefile -w --distpath $toolDir --workpath $packageToolDir --specpath $packageToolDir $packageToolDir\internet_detector.pyw" -Wait

--- a/packages/libraries-extra.python3.vm/libraries-extra.python3.vm.nuspec
+++ b/packages/libraries-extra.python3.vm/libraries-extra.python3.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>libraries-extra.python3.vm</id>
+    <version>0.0.0.20241029</version>
+    <description>Install extra Python useful libraries</description>
+    <authors>Several, check in pypi.org for every of the libraries</authors>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20241029"/>
+      <dependency id="libraries.python3.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/libraries-extra.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries-extra.python3.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+    $dependencies = "asciinet,bs4,flare_capa,langchain,langchain_google_genai,langchain_openai,networkx,python-statemachine,requests,tabulate,tenacity"
+    VM-Pip-Install $dependencies
+} catch {
+    VM-Write-Log-Exception $_
+}


### PR DESCRIPTION
The FLARE team is working in a new tool and needs the libraries installed by the new `libraries-extra.python3.vm` package. This libraries are useful in general to develop reverse engineering related tools.

Extend the `VM-Pip-Install` function helper to support a list of Python libraries to install. Use the new feature to simplify the code in `internet_detector.vm` and in the new `libraries-extra.python3.vm`. 