### PR TITLE
Improve VM-Assert-Signature & restore hash installation for RegCool

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20241029</version>
+    <version>0.0.0.20241106</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -128,20 +128,20 @@ function VM-Assert-Path {
     }
 }
 
-# Raise an exception if the Signature of $file_path is invalid
+# Raise an exception if the signtool.exe is not found or if the signature of $filePath is invalid
+# vcbuildtools.vm installs signtool.exe
 function VM-Assert-Signature {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true)]
-        [String] $file_path
+        [String] $filePath
     )
-    $signature_status = (Get-AuthenticodeSignature -FilePath $file_path).Status
-    if ($signature_status -eq 'Valid') {
-        VM-Write-Log "INFO" "Valid signature: $file_path"
-    } else {
-        $err_msg = "Invalid signature: $file_path"
-        VM-Write-Log "ERROR" $err_msg
-        throw $err_msg
+    $signtoolPath = Get-ChildItem -Path "C:\Program Files*\Windows Kits\10\bin\*\x86\signtool.exe" | Select-Object -Last 1
+    if (-Not $signtoolPath) { throw "signtool.exe not found" }
+
+    & $signtoolPath verify /pa /all /tw /q $filePath
+    if ($LASTEXITCODE) {
+        throw "INVALID SIGNATURE: $filePath"
     }
 }
 

--- a/packages/googlechrome.vm/googlechrome.vm.nuspec
+++ b/packages/googlechrome.vm/googlechrome.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>googlechrome.vm</id>
-    <version>0.0.0.20241002</version>
+    <version>0.0.0.20241106</version>
     <authors>Google LLC.</authors>
     <description>Chrome is a popular web browser.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240425" />
+      <dependency id="common.vm" version="0.0.0.20241106" />
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/metasploit.vm/metasploit.vm.nuspec
+++ b/packages/metasploit.vm/metasploit.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>metasploit.vm</id>
-    <version>6.4.13.20240614</version>
+    <version>6.4.13.20241106</version>
     <authors>Rapid7</authors>
     <description>A computer security project that provides information about security vulnerabilities, aids in penetration testing, and IDS signature development.</description>
     <dependencies>
-      <dependency id="common.vm" />
+      <dependency id="common.vm" version="0.0.0.20241106" />
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>0.0.0.20240411</version>
+    <version>2.015</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -3,38 +3,8 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegCool'
 $category = 'Registry'
-$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
+$zipSha256 = '8fde37cf66024eb68be3c0e34125540f855626935f1cffc0fb7409f3ba343870'
 
-try {
-    # Download zip
-    $packageArgs      = @{
-      packageName     = $env:ChocolateyPackageName
-      file            = Join-Path ${Env:TEMP} $toolName
-      url             = $zipUrl
-    }
-    $filePath = Get-ChocolateyWebFile @packageArgs
-
-    # Extract zip
-    Get-ChocolateyUnzip -FileFullPath $filePath -Destination $toolDir
-
-    # Check signature of all unzip files
-    Get-ChildItem -Path "$toolDir\*.{exe,dll}" | ForEach-Object {
-        VM-Assert-Signature $_.FullName
-    }
-} catch {
-    # Remove files with invalid signature
-    Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
-    VM-Write-Log-Exception $_
-}
-
-try {
-    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-    $shortcut = Join-Path $shortcutDir "$toolname.lnk"
-    $toolPath = Join-Path $toolDir "$toolName.exe"
-    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $toolPath
-    VM-Assert-Path $shortcut
-} catch {
-    VM-Write-Log-Exception $_
-}
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false

--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>0.0.0.20240717</version>
+    <version>0.0.0.20241106</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240111" />
+      <dependency id="common.vm" version="0.0.0.20241106" />
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
The current implementation of `VM-Assert-Signature` uses `Get-AuthenticodeSignature` status, that only checks that the file has a syntactically syntactically valid signature. Verify the signing authority using `signtool.exe`.

This new signature verification using `signtool.exe` does not work for RegCool. Restore the previous installation checking the SHA256. As the tool is using a URL that does not include the version, the hash will change with every update, breaking the package. If the package is updated often, we will need to remove it from the default configuration (replacing it total-registry) or researching if it is possible to use `signtool.exe` to verify the package. I suggest we discuss this outside this PR.

Note that the current `regcool.vm` package implementation being replaced in this PR had an important bug: `VM-Assert-Signature` was not called at all, as `Get-ChildItem -Path "$toolDir\*.{exe,dll}"` does not match any file.

Closes https://github.com/mandiant/VM-Packages/issues/1144