### PR TITLE
Fix internet_detector not installing

### DIFF
--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0.20241029</version>
+    <version>1.0.0.20241112</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>

--- a/packages/internet_detector.vm/tools/chocolateyinstall.ps1
+++ b/packages/internet_detector.vm/tools/chocolateyinstall.ps1
@@ -10,12 +10,12 @@ $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 New-Item -Path $toolDir -ItemType Directory -Force -ea 0
 VM-Assert-Path $toolDir
 
-# Install pyinstaller (needed to build the Python executable) and tool dependencies ('pywin32')
-$dependencies = "pyinstaller,pywin32"
+# Install pyinstaller 6.11.1 (needed to build the Python executable with a version capable of executing in admin cmd) and tool dependencies ('pywin32')
+$dependencies = "pyinstaller==6.11.1,pywin32"
 VM-Pip-Install $dependencies
 
-# This wrapper is needed because we can't run PyInstaller as admin, so this forces a usermode context.
-Start-Process -FilePath 'cmd.exe' -ArgumentList "/c pyinstaller --onefile -w --distpath $toolDir --workpath $packageToolDir --specpath $packageToolDir $packageToolDir\internet_detector.pyw" -Wait
+# This wrapper is needed because PyInstaller emits an error when running as admin and this mitigates the issue.
+Start-Process -FilePath 'cmd.exe' -WorkingDirectory $toolDir -ArgumentList "/c pyinstaller --onefile -w --log-level FATAL --distpath $toolDir --workpath $packageToolDir --specpath $packageToolDir $packageToolDir\internet_detector.pyw" -Wait
 
 # Move images to %VM_COMMON_DIR% directory
 $imagesPath = Join-Path $packageToolDir "images"


### PR DESCRIPTION
This  fixes https://github.com/mandiant/VM-Packages/issues/1131

I believe the issue stems primarily from BoxStarter running a terminal from `system32`, which PyInstaller will not run properly from. This is why it worked during testing via our test script and not when running a full install with the FlareVM install script.

I also noticed that what I thought was a workaround for `cmd` being spawned in a usermode context from an admin PowerShell was not actually doing such, so I removed the statement that said that and also forced PyInstaller to be a version that will continue to allow us to run it in an admin context.