### PR TITLE
Fixed broken URL for dcode.vm

### DIFF
--- a/packages/dcode.vm/dcode.vm.nuspec
+++ b/packages/dcode.vm/dcode.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dcode.vm</id>
-    <version>5.6.24123.20240507</version>
+    <version>5.6.24123.20241121</version>
     <authors>Digital Detective Group</authors>
     <description>Utility for converting data found on desktop and mobile devices into human-readable timestamps.</description>
     <dependencies>

--- a/packages/dcode.vm/tools/chocolateyinstall.ps1
+++ b/packages/dcode.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'DCode'
 $category = 'Forensic'
 
-$url = 'https://www.digital-detective.net/download/download.php?downcode=ae2znu5994j1lforlh03'
+$url = 'https://www.digital-detective.net/download/downloadbac.php?downcode=ae2znu5994j1lforlh03'
 $sha256 = '9ffe1106ee9d9f55b53d5707621d5990f493604e20f3dbdb0d22ec1b8ecb2458'
 
 $toolDir = Join-Path ${Env:ProgramFiles(x86)} "Digital Detective"


### PR DESCRIPTION
dcode.vm package is broken and throws error 404 when downloading installer.

```
ERROR: The remote file either doesn't exist, is unauthorized, or is forbidden for url 'https://www.digital-detective.net/download/download.php?downcode=ae2znu5994j1lforlh03'. Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (404) Not Found."
The install of dcode.vm was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\dcode.vm\tools\chocolateyinstall.ps1'.
 See log for details.
```

Following the original link in browser returns...

`https://www.digital-detective.net/download/downloadbac.php?downcode=ae2znu5994j1lforlh03`

`...downloadbac.php?...` instead of `...download.php?...`

Does the command, Get-WebFIle, have problems following redirects? Hope this is helpful.