### PR TITLE
Clarify vcbuildtools.vm dependency

### DIFF
--- a/packages/googlechrome.vm/googlechrome.vm.nuspec
+++ b/packages/googlechrome.vm/googlechrome.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>googlechrome.vm</id>
-    <version>0.0.0.20241106</version>
+    <version>0.0.0.20241122</version>
     <authors>Google LLC.</authors>
     <description>Chrome is a popular web browser.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20241106" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
       <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>

--- a/packages/metasploit.vm/metasploit.vm.nuspec
+++ b/packages/metasploit.vm/metasploit.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>metasploit.vm</id>
-    <version>6.4.13.20241106</version>
+    <version>6.4.13.20241122</version>
     <authors>Rapid7</authors>
     <description>A computer security project that provides information about security vulnerabilities, aids in penetration testing, and IDS signature development.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20241106" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
       <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>

--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>0.0.0.20241106</version>
+    <version>0.0.0.20241122</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20241106" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
       <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Add comment to clarify that `vcbuildtools.vm` because it installs `signtool.exe` needed by `VM-Assert-Signature` since https://github.com/mandiant/VM-Packages/pull/1157. This is not obvious as proved by the discussion in https://github.com/mandiant/VM-Packages/pull/1164/files#r1843911063.