### PR TITLE
Add internet_detector scheduled task

### DIFF
--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>3.3</version>
+    <version>3.3.0.20241124</version>
     <description>FakeNet-NG is a dynamic network analysis tool.</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/fakenet-ng.vm/tools/default.ini
+++ b/packages/fakenet-ng.vm/tools/default.ini
@@ -114,7 +114,7 @@ DefaultUDPListener:    ProxyUDPListener
 # NOTE: This setting is only honored when 'RedirectAllTraffic' is enabled.
 
 BlackListPortsTCP: 139
-BlackListPortsUDP: 67, 68, 137, 138, 443, 1900, 5355, 53
+BlackListPortsUDP: 67, 68, 137, 138, 443, 1900, 5355
 
 # Specify processes to ignore when diverting traffic. Windows example used
 # here.
@@ -275,6 +275,7 @@ Listener:    HTTPListener
 UseSSL:      No
 Webroot:     defaultFiles/
 Timeout:     10
+#ProcessBlackList: dmclient.exe, OneDrive.exe, svchost.exe, backgroundTaskHost.exe, GoogleUpdate.exe, chrome.exe
 DumpHTTPPosts: Yes
 DumpHTTPPostsFilePrefix: http
 Hidden:      False
@@ -346,4 +347,3 @@ Protocol:    TCP
 Listener:    POPListener
 UseSSL:      No
 Hidden:      False
-

--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0.20241112</version>
+    <version>1.0.0.20241209</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20241029" />
       <dependency id="libraries.python3.vm" version="0.0.0.20240726" />
-      <dependency id="fakenet-ng.vm" version="3.2.0.20240902" />
+      <dependency id="fakenet-ng.vm" version="3.3" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/internet_detector.vm/tools/chocolateyinstall.ps1
+++ b/packages/internet_detector.vm/tools/chocolateyinstall.ps1
@@ -23,8 +23,7 @@ Copy-Item "$imagesPath\*" ${Env:VM_COMMON_DIR} -Force
 
 VM-Install-Shortcut -toolName $toolName -category $category -executablePath "$toolDir/$toolName.exe"
 
-# TODO - Uncomment when FakeNet BlackList for DNS is fixed/addressed. https://github.com/mandiant/flare-fakenet-ng/issues/190
-# # Create scheduled task for tool to run every 2 minutes.
-# $action = New-ScheduledTaskAction -Execute $rawToolPath
-# $trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 2)
-# Register-ScheduledTask -Action $action -Trigger $trigger -TaskName 'Internet Detector' -Force
+# Create scheduled task for tool to run every 2 minutes.
+$action = New-ScheduledTaskAction -Execute "$toolDir/$toolName.exe"
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 2)
+Register-ScheduledTask -Action $action -Trigger $trigger -TaskName 'Internet Detector' -Force


### PR DESCRIPTION
This is step 1 for fixing https://github.com/mandiant/VM-Packages/issues/1174, which adds `internet_detector.exe` to a scheduled task so that it is always running, now that `fakenet-ng` has been updated to version `3.3` which allows blacklisted processes to not be displayed in the terminal interface.

Step 2 is https://github.com/mandiant/flare-vm/pull/630, which is to add the modification of the `DNSCache` registry key to our `flarevm` install script so that DNS requests will display as the asking process rather than `svchost`.