### PR TITLE
Pin magika version to fix pip issue

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20241122</version>
+    <version>0.0.0.20241209</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1762,10 +1762,12 @@ function VM-Install-With-Pip {
         [Parameter(Mandatory=$true)]
         [string] $category,
         [Parameter(Mandatory=$false)]
+        [string] $version = "", # Version using pip format, example: "==0.5.0"
+        [Parameter(Mandatory=$false)]
         [string] $arguments = "--help"
     )
     try {
-        VM-Pip-Install $toolName
+        VM-Pip-Install $toolName$version
         $executablePath = "$(where.exe $toolName)"
 
         VM-Install-Shortcut $toolName $category $executablePath -consoleApp $true -arguments $arguments

--- a/packages/magika.vm/magika.vm.nuspec
+++ b/packages/magika.vm/magika.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>magika.vm</id>
-    <version>0.0.0.20240607</version>
+    <version>0.5.0</version>
     <authors>Yanick Fratantonio, Luca Invernizzi, Marina Zhang, Giancarlo Metitieri, Thomas Kurt, Francois Galilee, Alexandre Petit-Bianco, Loua Farah, Ange Albertini, Elie Bursztein</authors>
     <description>Magika is an AI powered file type detection tool that uses deep learning to provide accurate detection.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240607" />
+      <dependency id="common.vm" version="0.0.0.20241209" />
       <dependency id="python3.vm" />
     </dependencies>
   </metadata>

--- a/packages/magika.vm/tools/chocolateyinstall.ps1
+++ b/packages/magika.vm/tools/chocolateyinstall.ps1
@@ -3,5 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'magika'
 $category = 'File Information'
+$version = "==0.5.0"
 
-VM-Install-With-Pip -toolName $toolName -category $category
+VM-Install-With-Pip -toolName $toolName -category $category -version $version


### PR DESCRIPTION
This pins `magika` to version `0.5.0` to fix a pip resolving issue with `numpy` conflicting with `stringsifter` as noted in https://github.com/mandiant/VM-Packages/issues/1130. It should be fixed when `magika` version `0.6.0` is officially released and we can revert back to how we installed it before after verifying.