### PR TITLE
Add new package capa-explorer-web.vm

### DIFF
--- a/packages/capa-explorer-web.vm/capa-explorer-web.vm.nuspec
+++ b/packages/capa-explorer-web.vm/capa-explorer-web.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>capa-explorer-web.vm</id>
+    <version>1.0.0</version>
+    <authors>Soufiane Fariss</authors>
+    <description>Web interface for exploring and understanding capa results</description>
+    <dependencies>
+      <dependency id="common.vm" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/capa-explorer-web.vm/tools/chocolateyinstall.ps1
+++ b/packages/capa-explorer-web.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$category = 'Utilities'
+$toolName = 'capa Explorer Web'
+$zipUrl = 'https://github.com/mandiant/capa/raw/refs/heads/master/web/explorer/releases/capa-explorer-web-v1.0.0-6a2330c.zip'
+$zipSha256 = '3a7cf6927b0e8595f08b685669b215ef779eade622efd5e8d33efefadd849025'
+
+$executableName = "index.html"
+VM-Install-From-Zip $toolName $category $zipUrl $zipSha256 -executableName $executableName -withoutBinFile -innerFolder $true

--- a/packages/capa-explorer-web.vm/tools/chocolateyuninstall.ps1
+++ b/packages/capa-explorer-web.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'capa Explorer Web'
+$category = 'Utilities'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
closes #1136 

This PR adds a new VM-package capa-explorer-web.vm.

ZIP URL: `https://github.com/mandiant/capa/raw/refs/heads/master/web/explorer/releases/capa-explorer-web-v1.0.0-6a2330c.zip`