### PR TITLE
Add Python category and unpyc3.vm

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_metapackage.yml
+++ b/.github/ISSUE_TEMPLATE/new_metapackage.yml
@@ -75,6 +75,7 @@ body:
         - Persistence
         - Privilege Escalation
         - Productivity Tools
+        - Python
         - Reconnaissance
         - Registry
         - Shellcode

--- a/.github/ISSUE_TEMPLATE/new_node_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_node_package.yml
@@ -59,8 +59,8 @@ body:
         - Debuggers
         - Delphi
         - Disassemblers
-        - dotNet
         - Documents
+        - dotNet
         - Exploitation
         - File Information
         - Forensic
@@ -77,6 +77,7 @@ body:
         - Persistence
         - Privilege Escalation
         - Productivity Tools
+        - Python
         - Reconnaissance
         - Registry
         - Shellcode

--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -93,6 +93,7 @@ body:
         - Persistence
         - Privilege Escalation
         - Productivity Tools
+        - Python
         - Reconnaissance
         - Registry
         - Shellcode

--- a/categories.txt
+++ b/categories.txt
@@ -22,6 +22,7 @@ Persistence
 PowerShell
 Privilege Escalation
 Productivity Tools
+Python
 Reconnaissance
 Registry
 Shellcode

--- a/packages/unpyc3.vm/tools/chocolateyinstall.ps1
+++ b/packages/unpyc3.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'unpyc3'
+$category = 'Python'
+
+VM-Pip-Install "https://github.com/greyblue9/unpyc37-3.10/archive/c1486ce3cf5b8fdfb5065e9c81a73a61481ed9ff.zip"
+
+$pyPath = (Get-Command py).Source
+VM-Install-Shortcut -toolName $toolName -category $category -executablePath $pyPath -consoleApp $true -arguments "-3.10 -m unpyc.unpyc3"

--- a/packages/unpyc3.vm/tools/chocolateyuninstall.ps1
+++ b/packages/unpyc3.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'unpyc3'
+$category = 'Python'
+
+VM-Remove-Tool-Shortcut $toolName $category

--- a/packages/unpyc3.vm/unpyc3.vm.nuspec
+++ b/packages/unpyc3.vm/unpyc3.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>unpyc3.vm</id>
+    <version>0.0.0.20241206</version>
+    <authors>David Reilly</authors>
+    <description>A decompiler for Python 3.7+.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+      <dependency id="libraries.python3.vm" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Add a new `Python` category to add tools like Python decompilers as proposed in https://github.com/mandiant/VM-Packages/issues/1182.

Add unpyc3.vm that installs with Pip the last commit in the GH repository https://github.com/greyblue9/unpyc37-3.10.

There is an issue of using `py -3.10 -m unpyc.unpyc3` in the shortcut, as it does not get the Python icon:
![image](https://github.com/user-attachments/assets/45e1cdfa-b7eb-4523-8624-8360178bab29)

@emtuls I remember we have had this before, but do not remember how/if we fixed it. Can you help me here? :pray: 

This issue partially addresses (as we still need to add [pycdc.exe](https://github.com/extremecoders-re/decompyle-builds/releases/download/build-16-Oct-2024-5e1c403/pycdc.exe)): https://github.com/mandiant/VM-Packages/issues/1182
