### PR TITLE
[cyberchef.vm] Add documentation

### DIFF
--- a/packages/cyberchef.vm/cyberchef.vm.nuspec
+++ b/packages/cyberchef.vm/cyberchef.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cyberchef.vm</id>
-    <version>10.19.4</version>
+    <version>10.19.4.20241209</version>
     <authors>GCHQ</authors>
     <description>The Cyber Swiss Army Knife - a web app for encryption, encoding, compression, data analysis, and more.</description>
     <dependencies>

--- a/packages/cyberchef.vm/tools/chocolateyinstall.ps1
+++ b/packages/cyberchef.vm/tools/chocolateyinstall.ps1
@@ -18,6 +18,9 @@ try {
   Install-ChocolateyZipPackage @packageArgs
   VM-Assert-Path $toolDir
 
+  # FLARE-VM adds CyberChef to the taskbar.
+  # We use the chrome executable as e can't use an `.html` shortcut for the taskbar.
+  # Because of this reason we are not using the `VM-Install-From-Zip` helper that would simplify the package code.
   $chromePath = "${env:ProgramFiles}\Google\Chrome\Application\chrome.exe"
   $cyberchefPath = Get-Item "$toolDir\CyberChef*.html"
   $iconLocation = VM-Create-Ico (Join-Path $toolDir "images\cyberchef-128x128.png")


### PR DESCRIPTION
Document why we can't use the `.html` directly in the shortcut, which is also the reason why we can't use the `VM-Install-From-Zip` helper.