### PR TITLE
[ida.plugin.capa.vm] Update to version 8.0.1

### DIFF
--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.capa.vm</id>
-    <version>7.0.1.20240425</version>
+    <version>8.0.1</version>
     <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>

--- a/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
@@ -3,19 +3,20 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     # Install dependency: capa Python library
-    VM-Pip-Install "flare-capa"
+    $version = "8.0.1"
+    VM-Pip-Install "flare-capa==$version"
 
     # Install plugin
     $pluginName = "capa_explorer.py"
-    $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v7.0.1/capa/ida/plugin/capa_explorer.py"
-    $pluginSha256 = "a9a60d9066c170c4e18366eb442f215009433bcfe277d3c6d0c4c9860824a7d3"
+    $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v$version/capa/ida/plugin/capa_explorer.py"
+    $pluginSha256 = "bf6c9a0e5fd2c75a93bb3c19e0221c36cda441c878af3c23ea3aafef4fecf3e9"
     VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256
 
 
     # Download capa rules
     $pluginsDir = VM-Get-IDA-Plugins-Dir
-    $rulesUrl = "https://github.com/mandiant/capa-rules/archive/refs/tags/v7.0.1.zip"
-    $rulesSha256 = "f4ed60bcf342007935215ea76175dddfbcbfb3f97d95387543858e0c1ecf8bcd"
+    $rulesUrl = "https://github.com/mandiant/capa-rules/archive/refs/tags/v$version.zip"
+    $rulesSha256 = "7c5f932b1da4e18eed50add117e7fc55c14dc51487495cb31e33e0b44c522fbc"
     $packageArgs = @{
         packageName    = ${Env:ChocolateyPackageName}
         unzipLocation  = $pluginsDir
@@ -24,7 +25,7 @@ try {
         checksumType   = 'sha256'
     }
     Install-ChocolateyZipPackage @packageArgs
-    $rulesDir = Join-Path $pluginsDir "capa-rules-7.0.1" -Resolve
+    $rulesDir = Join-Path $pluginsDir "capa-rules-$version" -Resolve
 
     # Set capa rules in the capa plugin
     $registryPath = 'HKCU:\SOFTWARE\IDAPython\IDA-Settings\capa'

--- a/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyuninstall.ps1
@@ -8,8 +8,8 @@ $pluginPath = Join-Path $pluginsDir "capa_explorer.py"
 Remove-Item $pluginPath
 
 # Delete capa rules
-$rulesDir = Join-Path $pluginsDir "capa-rules-6.1.0"
-Remove-Item $rulesDir
+$rulesDir = Get-ChildItem "$pluginsDir\capa-rules-*"
+Remove-Item $rulesDir -Recurse
 
 # Delete registry information
 Remove-Item 'HKCU:\SOFTWARE\IDAPython\IDA-Settings\capa'


### PR DESCRIPTION
Update capa explorer to version 8.0.1 that supports IDA 9. I have introduced a `$version` variable in `chocolateyinstall.ps1` and removed the use of the version in `chocolateyuninstall.ps1` to make it easier to update the package in the future as this package has to be update manually. I have documented an idea to update this package automatically in https://github.com/mandiant/VM-Packages/issues/1192, but the change is not trivial so I don't except that update this package automatically in the near future.

So excited to get capa explorer back to my IDA!

![Celebrate image](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnBjcmQyY3pyb2dlbmRzZGdqc2NlZ3EwOTVqZmkzbms2b3lsOTdveSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kyLYXonQYYfwYDIeZl/giphy.gif)

Closes https://github.com/mandiant/VM-Packages/issues/1173