### PR TITLE
Use SigCheck w/ Zimmerman Tools

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250124</version>
+    <version>0.0.0.20250203</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -404,6 +404,8 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [string] $executableName, # Executable name, needed if different from "$toolName.exe"
         [Parameter(Mandatory=$false)]
+        [bool] $verifySignature=$false,
+        [Parameter(Mandatory=$false)]
         [switch] $withoutBinFile, # Tool should not be installed as a bin file
         # Examples:
         # $powershellCommand = "Get-Content README.md"
@@ -417,17 +419,31 @@ function VM-Install-From-Zip {
         # Remove files from previous zips for upgrade
         VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
-        # Download and unzip
-        $packageArgs = @{
-            packageName    = ${Env:ChocolateyPackageName}
-            unzipLocation  = $toolDir
-            url            = $zipUrl
-            checksum       = $zipSha256
-            checksumType   = 'sha256'
-            url64bit       = $zipUrl_64
-            checksum64     = $zipSha256_64
+        # We do not check hashes for tools that we use signature verification for
+        if ($verifySignature) {
+            # Download zip
+            $packageArgs      = @{
+                packageName     = $env:ChocolateyPackageName
+                file            = Join-Path ${Env:TEMP} $toolName
+                url             = $zipUrl
+            }
+            $filePath = Get-ChocolateyWebFile @packageArgs
+            # Extract zip
+            Get-ChocolateyUnzip -FileFullPath $filePath -Destination $toolDir
         }
-        Install-ChocolateyZipPackage @packageArgs | Out-Null
+        else {  # Not verifying signature, so check if hash is as expected
+            # Download and unzip
+            $packageArgs = @{
+                packageName    = ${Env:ChocolateyPackageName}
+                unzipLocation  = $toolDir
+                url            = $zipUrl
+                checksum       = $zipSha256
+                checksumType   = 'sha256'
+                url64bit       = $zipUrl_64
+                checksum64     = $zipSha256_64
+            }
+            Install-ChocolateyZipPackage @packageArgs | Out-Null
+        }
         VM-Assert-Path $toolDir
 
         # If $innerFolder is set to $true, after unzipping there should be only one folder
@@ -435,6 +451,21 @@ function VM-Install-From-Zip {
         if ($innerFolder) {
             $dirList = Get-ChildItem $toolDir -Directory
             $toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
+        }
+
+        if ($verifySignature) {
+            # Check signature of all executable files individually
+            Get-ChildItem -Path "$toolDir\*.exe" | ForEach-Object {
+                try {
+                    # Check signature for each file
+                    VM-Assert-Signature $_.FullName
+                } catch {
+                    # Remove the file with invalid signature
+                    Write-Warning "Removing file '$($_.FullName)' due to invalid signature"
+                    Remove-Item $_.FullName -Force -ea 0 | Out-Null
+                    VM-Write-Log-Exception $_
+                }
+            }
         }
 
         if ($powershellCommand) {

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -404,7 +404,7 @@ function VM-Install-From-Zip {
         [Parameter(Mandatory=$false)]
         [string] $executableName, # Executable name, needed if different from "$toolName.exe"
         [Parameter(Mandatory=$false)]
-        [bool] $verifySignature=$false,
+        [switch] $verifySignature,
         [Parameter(Mandatory=$false)]
         [switch] $withoutBinFile, # Tool should not be installed as a bin file
         # Examples:

--- a/packages/evtxecmd.vm/evtxecmd.vm.nuspec
+++ b/packages/evtxecmd.vm/evtxecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>evtxecmd.vm</id>
-    <version>1.5.0.20240826</version>
+    <version>1.5.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Event log (evtx) parser with standardized CSV, XML, and json output! Custom maps, locked file support, and more!</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/evtxecmd.vm/evtxecmd.vm.nuspec
+++ b/packages/evtxecmd.vm/evtxecmd.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Event log (evtx) parser with standardized CSV, XML, and json output! Custom maps, locked file support, and more!</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/evtxecmd.vm/evtxecmd.vm.nuspec
+++ b/packages/evtxecmd.vm/evtxecmd.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/EvtxECmd.zip'
 $zipSha256 = 'e1b4a5f9b09eca3c057cdc2d0ed1a28fe0c24dc90f9f68b7e0572e373dce86a6'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true

--- a/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'EvtxECmd'
 $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/EvtxECmd.zip'
 
-VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature

--- a/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/evtxecmd.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'EvtxECmd'
 $category = 'Forensic'
-
 $zipUrl = 'https://download.mikestammer.com/net6/EvtxECmd.zip'
-$zipSha256 = 'e1b4a5f9b09eca3c057cdc2d0ed1a28fe0c24dc90f9f68b7e0572e373dce86a6'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true

--- a/packages/pecmd.vm/pecmd.vm.nuspec
+++ b/packages/pecmd.vm/pecmd.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Prefetch parser</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/pecmd.vm/pecmd.vm.nuspec
+++ b/packages/pecmd.vm/pecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pecmd.vm</id>
-    <version>1.5.0.20240826</version>
+    <version>1.5.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Prefetch parser</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/pecmd.vm/pecmd.vm.nuspec
+++ b/packages/pecmd.vm/pecmd.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/pecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/pecmd.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/PECmd.zip'
 $zipSha256 = 'e20254b2f813e66fe5295488e5a00e9675679c91841f99ddcc8d083299bb55d6'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -verifySignature

--- a/packages/pecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/pecmd.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/PECmd.zip'
 $zipSha256 = 'e20254b2f813e66fe5295488e5a00e9675679c91841f99ddcc8d083299bb55d6'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -verifySignature $true

--- a/packages/recmd.vm/recmd.vm.nuspec
+++ b/packages/recmd.vm/recmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>recmd.vm</id>
-    <version>2.0.0.20240908</version>
+    <version>2.0.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Powerful command line Registry tool searching, multi-hive support, plugins, and more</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/recmd.vm/recmd.vm.nuspec
+++ b/packages/recmd.vm/recmd.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/recmd.vm/recmd.vm.nuspec
+++ b/packages/recmd.vm/recmd.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Powerful command line Registry tool searching, multi-hive support, plugins, and more</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/recmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/recmd.vm/tools/chocolateyinstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'RECmd'
 $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/RECmd.zip'
 
-VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature

--- a/packages/recmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/recmd.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/RECmd.zip'
 $zipSha256 = '90a1c5be877c3a50294a134b81fe26755980a70e6b9d914e444b43c1e205b0f3'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true

--- a/packages/recmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/recmd.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RECmd'
 $category = 'Forensic'
-
 $zipUrl = 'https://download.mikestammer.com/net6/RECmd.zip'
-$zipSha256 = '90a1c5be877c3a50294a134b81fe26755980a70e6b9d914e444b43c1e205b0f3'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Registry viewer with searching, multi-hive support, plugins, and more. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/registry_explorer.vm/registry_explorer.vm.nuspec
+++ b/packages/registry_explorer.vm/registry_explorer.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>registry_explorer.vm</id>
-    <version>2.0.0.20240826</version>
+    <version>2.0.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Registry viewer with searching, multi-hive support, plugins, and more. Handles locked files</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'RegistryExplorer'
 $category = 'Registry'
 $zipUrl = 'https://download.mikestammer.com/net6/RegistryExplorer.zip'
 
-VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $false -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $false -innerFolder $true -verifySignature

--- a/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RegistryExplorer'
 $category = 'Registry'
-
 $zipUrl = 'https://download.mikestammer.com/net6/RegistryExplorer.zip'
-$zipSha256 = '50a11bd0a5e44dcea6469b8564eb3f010b9a8faf323ff6481222d391da26887e'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $false -innerFolder $true -verifySignature $true

--- a/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/registry_explorer.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Registry'
 $zipUrl = 'https://download.mikestammer.com/net6/RegistryExplorer.zip'
 $zipSha256 = '50a11bd0a5e44dcea6469b8564eb3f010b9a8faf323ff6481222d391da26887e'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $true -verifySignature $true

--- a/packages/rla.vm/rla.vm.nuspec
+++ b/packages/rla.vm/rla.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rla.vm</id>
-    <version>2.0.0.20240908</version>
+    <version>2.0.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Replay transaction logs and update Registry hives so they are no longer dirty. Useful when tools do not know how to handle transaction logs</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/rla.vm/rla.vm.nuspec
+++ b/packages/rla.vm/rla.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/rla.vm/rla.vm.nuspec
+++ b/packages/rla.vm/rla.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Replay transaction logs and update Registry hives so they are no longer dirty. Useful when tools do not know how to handle transaction logs</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/rla.vm/tools/chocolateyinstall.ps1
+++ b/packages/rla.vm/tools/chocolateyinstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'RLA'
 $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/rla.zip'
 
-VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $false -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $false -verifySignature

--- a/packages/rla.vm/tools/chocolateyinstall.ps1
+++ b/packages/rla.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/rla.zip'
 $zipSha256 = '1017f1d19d57665afd8fdfb13955a8280708931cb5cd75eca45ae28e23756b16'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -verifySignature $true

--- a/packages/rla.vm/tools/chocolateyinstall.ps1
+++ b/packages/rla.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'RLA'
 $category = 'Forensic'
-
 $zipUrl = 'https://download.mikestammer.com/net6/rla.zip'
-$zipSha256 = '1017f1d19d57665afd8fdfb13955a8280708931cb5cd75eca45ae28e23756b16'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $false -verifySignature $true

--- a/packages/sqlecmd.vm/sqlecmd.vm.nuspec
+++ b/packages/sqlecmd.vm/sqlecmd.vm.nuspec
@@ -8,6 +8,8 @@
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
+      <!-- vcbuildtools.vm installs signtool.exe needed by VM-Assert-Signature -->
+      <dependency id="vcbuildtools.vm" />
     </dependencies>
   </metadata>
 </package>

--- a/packages/sqlecmd.vm/sqlecmd.vm.nuspec
+++ b/packages/sqlecmd.vm/sqlecmd.vm.nuspec
@@ -6,7 +6,7 @@
     <authors>Eric Zimmerman</authors>
     <description>Find and process SQLite files according to your needs with maps!</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20241212" />
+      <dependency id="common.vm" version="0.0.0.20250203" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/sqlecmd.vm/sqlecmd.vm.nuspec
+++ b/packages/sqlecmd.vm/sqlecmd.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sqlecmd.vm</id>
-    <version>1.0.0.20240826</version>
+    <version>1.0.0.20241212</version>
     <authors>Eric Zimmerman</authors>
     <description>Find and process SQLite files according to your needs with maps!</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20240411" />
+      <dependency id="common.vm" version="0.0.0.20241212" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
   </metadata>

--- a/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
@@ -5,4 +5,4 @@ $toolName = 'SQLECmd'
 $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/SQLECmd.zip'
 
-VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature

--- a/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
@@ -7,4 +7,4 @@ $category = 'Forensic'
 $zipUrl = 'https://download.mikestammer.com/net6/SQLECmd.zip'
 $zipSha256 = '40a23c2bd6855753e5f39a7cb944cd2e13aecb70ae2c5b3db840c959225454be'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true

--- a/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
+++ b/packages/sqlecmd.vm/tools/chocolateyinstall.ps1
@@ -3,8 +3,6 @@ Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'SQLECmd'
 $category = 'Forensic'
-
 $zipUrl = 'https://download.mikestammer.com/net6/SQLECmd.zip'
-$zipSha256 = '40a23c2bd6855753e5f39a7cb944cd2e13aecb70ae2c5b3db840c959225454be'
 
-VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $true -verifySignature $true
+VM-Install-From-Zip $toolName $category $zipUrl -consoleApp $true -innerFolder $true -verifySignature $true


### PR DESCRIPTION
This fixes many of the tools that are running into an error in our Daily checks (https://github.com/mandiant/VM-Packages/wiki/Daily-Failures). These specific tools run into an issue where we need to manually update the hashes due to the links not having a version in them so our updater does not properly update the packages for us.

Specifically, this fixes:
-  `evtxecmd.vm`
-  `pecmd.vm`
-  `recmd.vm`
-  `registry_explorer.vm`
-  `rla.vm`
-  `sqlecmd.vm`