### PR TITLE
Fix RegCool Hash

### DIFF
--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>2.015</version>
+    <version>2.019</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'RegCool'
 $category = 'Registry'
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
-$zipSha256 = '8fde37cf66024eb68be3c0e34125540f855626935f1cffc0fb7409f3ba343870'
+$zipSha256 = 'df3c80da807cab5b1612f0697373317523142643c4346ad618c3ec69d16db33e'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false


### PR DESCRIPTION
This fixes the hash for `RegCool.vm` as we have to do this manually due to the download link not containing a version number for us to identify when the tool gets updated.