### PR TITLE
Update hash for event-log-explorer

### DIFF
--- a/packages/event-log-explorer.vm/event-log-explorer.vm.nuspec
+++ b/packages/event-log-explorer.vm/event-log-explorer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>event-log-explorer.vm</id>
-    <version>5.5.2.20240908</version>
+    <version>5.6.0.20241212</version>
     <authors>FSPro Labs</authors>
     <description>Software solution for viewing, analyzing and monitoring events recorded in Microsoft Windows event logs.</description>
     <dependencies>

--- a/packages/event-log-explorer.vm/tools/chocolateyinstall.ps1
+++ b/packages/event-log-explorer.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $toolName = 'Event Log Explorer'
 $category = 'Forensic'
 
 $exeUrl = 'https://eventlogxp.com/download/elex_setup.exe'
-$exeSha256 = '8dc2c9d4a620bf421dac9c9bce2ab690798005edbf5d7ccb202717a14f8cc894'
+$exeSha256 = '5049c96130396f407197a74fa571f10e4106bd0c13858e717fc11c535fded678'
 
 $toolDir = Join-Path ${Env:ProgramFiles(x86)} $toolName
 $executablePath = Join-Path $toolDir "elex.exe"


### PR DESCRIPTION
This updates the hash for `event-log-explorer.vm` so that it will stop failing to install.