### PR TITLE
[libraries.python3.vm] Add rpyc

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20240726</version>
+    <version>0.0.0.20241213</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <modules>
     <module name="acefile"/>
+    <module name="rpyc"/>
     <module name="art"/>
     <module name="binwalk" url="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"/>
     <module name="capstone-windows"/>


### PR DESCRIPTION
Add missing `rpyc` dependency for IDA 9.0 Feeds plugin.