### PR TITLE
[vcredist140] Update to version 14.42

### DIFF
--- a/packages/vcredist140.vm/vcredist140.vm.nuspec
+++ b/packages/vcredist140.vm/vcredist140.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcredist140.vm</id>
-    <version>0.0.0.20231019</version>
+    <version>0.0.0.20241213</version>
     <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
     <authors>Mandiant</authors>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="vcredist140" version="[14.36.32532, 14.37)" />
+      <dependency id="vcredist140" version="[14.42.34433, 14.43)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Another package seem to be installing vcredist140 version 14.42 causing a conflict (not sure which one). Updating the version should fix the issue. However the issue may occur again in the future when a version > 14.42 is released. I have tested all the packages that use this dependency locally and all seem to work fine with the newer version.