### PR TITLE
Update category regex match in lint.py

### DIFF
--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -354,7 +354,7 @@ class UsesInvalidCategory(Lint):
         # utf-8-sig ignores BOM
         file_content = open(path, "r", encoding="utf-8-sig").read()
 
-        match = re.search("\$category = ['\"](?P<category>[\w &/]+)['\"]", file_content)
+        match = re.search(r"\$category = ['\"](?P<category>[\w &/]+)['\"]", file_content)
         if not match or match.group("category") not in self.CATEGORIES:
             return True
         return False


### PR DESCRIPTION
The "\\$" in the regex string collides with Python's escape sequence in string literals. Changing the string literal into a raw string literal to treat backslashes as literal characters instead of trying to escape the next character.

Per the Python re library docs https://docs.python.org/3/library/re.html.

> If you’re not using a raw string to express the pattern, remember that Python also uses the backslash as an escape sequence in string literals; if the escape sequence isn’t recognized by Python’s parser, the backslash and subsequent character are included in the resulting string. However, if Python would recognize the resulting sequence, the backslash should be repeated twice. This is complicated and hard to understand, so it’s highly recommended that you use raw strings for all but the simplest expressions.

Python 3.12 calls this out:
```
$ python3.12 scripts/test/lint.py packages/apktool.vm/
/home/roosta/Downloads/VM-Packages/scripts/test/lint.py:357: SyntaxWarning: invalid escape sequence '\$'
  match = re.search("\$category = ['\"](?P<category>[\w &/]+)['\"]", file_content)
INFO:lint:linting packages/apktool.vm/apktool.vm.nuspec
INFO:lint:linting packages/apktool.vm/tools/chocolateyinstall.ps1
INFO:lint:linting packages/apktool.vm/tools/chocolateyuninstall.ps1
no lints failed, nice!
```