### PR TITLE
Fix VM-Unzip-Recursively

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20241209</version>
+    <version>0.0.0.20241216</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1828,6 +1828,7 @@ function VM-Create-Ico {
 # Delete extracted ZIPS after unzipping them.
 # Useful to extract zipped labs downloaded from GDrive keeping the folder structure.
 function VM-Unzip-Recursively {
+    $ErrorActionPreference = 'Continue'
     $desktop = Join-Path ${Env:UserProfile} "Desktop"
     $zip = Get-Item "$desktop\drive-download*.zip"
     if (-Not (Test-Path $zip)) {


### PR DESCRIPTION
Prevent `VM-Unzip-Recursively` to fail setting the error action preference to `Continue` inside the function (instead of `Error` as set at the beginning of the file) as we are handling errors inside the function.