### PR TITLE
[internet_detector.vm] Do not run by default

### DIFF
--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0.20241209</version>
+    <version>1.0.0.20241216</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>

--- a/packages/internet_detector.vm/tools/chocolateyinstall.ps1
+++ b/packages/internet_detector.vm/tools/chocolateyinstall.ps1
@@ -22,8 +22,3 @@ $imagesPath = Join-Path $packageToolDir "images"
 Copy-Item "$imagesPath\*" ${Env:VM_COMMON_DIR} -Force
 
 VM-Install-Shortcut -toolName $toolName -category $category -executablePath "$toolDir/$toolName.exe"
-
-# Create scheduled task for tool to run every 2 minutes.
-$action = New-ScheduledTaskAction -Execute "$toolDir/$toolName.exe"
-$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 2)
-Register-ScheduledTask -Action $action -Trigger $trigger -TaskName 'Internet Detector' -Force


### PR DESCRIPTION
Remove schedule task to run internet_detector by default until we have fixed the following important bugs:
- Restarting the VM with the internet enabled set the taskbar to always be pink: https://github.com/mandiant/VM-Packages/issues/1217
- The installer overwrites the internet_detector background and internet_detector does not set it back: https://github.com/mandiant/VM-Packages/issues/1216
