### PR TITLE
[npcap.vm] Fix npcap never finishing, blocking FLARE-VM installation

### DIFF
--- a/packages/npcap.vm/npcap.vm.nuspec
+++ b/packages/npcap.vm/npcap.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>npcap.vm</id>
-    <version>1.80</version>
+    <version>1.80.20241216</version>
     <authors>Nmap Project</authors>
     <description>Npcap is an architecture for packet capture and network analysis for Windows operating systems, consisting of a software library and a network driver.</description>
     <dependencies>

--- a/packages/npcap.vm/tools/chocolateyinstall.ps1
+++ b/packages/npcap.vm/tools/chocolateyinstall.ps1
@@ -17,8 +17,11 @@ try {
     VM-Assert-Path $packageArgs.fileFullPath
 
     $ahkInstaller = Join-Path $(Split-Path $MyInvocation.MyCommand.Definition) "install.ahk" -Resolve
-    $rc = (Start-Process -FilePath $ahkInstaller -ArgumentList $packageArgs.fileFullPath -PassThru -Wait).ExitCode
-    if ($rc -eq 1) {
+    $process = Start-Process -FilePath $ahkInstaller -ArgumentList $packageArgs.fileFullPath -PassThru
+    # Wait for the AutoHotKey script to finish. We need a max time as if something goes wrong
+    # (for example the installation takes longer than exception), it will never finish.
+    $process.WaitForExit(600000)
+    if ($process.ExitCode -eq 1) {
         throw "AutoHotKey returned a failure exit code ($rc) for: ${Env:ChocolateyPackageName}"
     } else {
         VM-Assert-Path $(Join-Path ${Env:PROGRAMFILES} "Npcap\npcap.cat")

--- a/packages/npcap.vm/tools/install.ahk
+++ b/packages/npcap.vm/tools/install.ahk
@@ -13,7 +13,7 @@ WinWait, %installerTitle%,,20
 WinActivate
 
 exitCode := 1
-loop, 20
+loop, 50
 {
     if WinExist(installerTitle, "i).*license agreement.*")
     {
@@ -27,7 +27,7 @@ loop, 20
     }
     if WinExist(installerTitle, "i).*installing.*")
     {
-        Sleep, 5000
+        Sleep, 10000
     }
     if WinExist(installerTitle, "i).*installation complete.*")
     {
@@ -51,6 +51,6 @@ loop, 20
         exitCode := 0
         break
     }
-    Sleep 1000
+    Sleep, 1000
 }
 ExitApp %exitCode%


### PR DESCRIPTION
Some times the npcap installation takes longer than the ahk script expects. The script finishes with error code and without closing the installation window and the package installation script waits indefinitely for the process to finish. This prevents FLARE-VM installation to continue. If you close it manually if fails (because of the error return code).

![image](https://github.com/user-attachments/assets/9fab400d-2302-4f75-ae29-0421d3e65e1f)


**To fix the issue, the following two steps are needed:**
- **Increase waiting time in the ahk script**
- **Set a maximum time to wait for the process in the package installation script**


