### PR TITLE
Fix Internet Detector Background/Taskbar Issues

### DIFF
--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0.20241216</version>
+    <version>1.0.0.20241217</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>

--- a/packages/internet_detector.vm/tools/chocolateyinstall.ps1
+++ b/packages/internet_detector.vm/tools/chocolateyinstall.ps1
@@ -21,4 +21,9 @@ Start-Process -FilePath 'cmd.exe' -WorkingDirectory $toolDir -ArgumentList "/c p
 $imagesPath = Join-Path $packageToolDir "images"
 Copy-Item "$imagesPath\*" ${Env:VM_COMMON_DIR} -Force
 
-VM-Install-Shortcut -toolName $toolName -category $category -executablePath "$toolDir/$toolName.exe"
+VM-Install-Shortcut -toolName $toolName -category $category -executablePath "$toolDir\$toolName.exe"
+
+# Create scheduled task for tool to run every 2 minutes.
+$action = New-ScheduledTaskAction -Execute "$toolDir\$toolName.exe"
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1)
+Register-ScheduledTask -Action $action -Trigger $trigger -TaskName 'Internet Detector' -Force


### PR DESCRIPTION
This fixes both https://github.com/mandiant/VM-Packages/issues/1216 and https://github.com/mandiant/VM-Packages/issues/1217

The issue with the wallpaper (https://github.com/mandiant/VM-Packages/issues/1216) was actually that `internet_detector` ended up in a broken state after the `installer.vm` performed a `VM-Refresh-Desktop`, which made `internet_detector` continue to run but unable to modify the background and also display an indicator in the taskbar. This has been fixed by having a detection for if `explorer.exe` is restarted and/or if the taskbar icon is removed, and if so, it attempts to restart itself or die gracefully so that the scheduled task can start it back up again properly.

The Taskbar issue (https://github.com/mandiant/VM-Packages/issues/1217) has been resolved by storing the old/default taskbar color scheme into a registry key that will be checked if it exists before setting a new default. It then reads this value for when it adjusts back to the state of when it does not detect internet.

I have also adjusted the package to re-enable the scheduled task and also made the time to kick off every 1 minute instead of 2 minutes.