### PR TITLE
Remove double console when opening fakenet

### DIFF
--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>3.3.0.20241124</version>
+    <version>3.3.0.20241219</version>
     <description>FakeNet-NG is a dynamic network analysis tool.</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
@@ -32,7 +32,7 @@ try {
   $toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
 
   $executablePath = Join-Path $toolDir "$toolName.exe" -Resolve
-  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -executableDir $toolDir -consoleApp $true
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -executableDir $toolDir
   Install-BinFile -Name $toolName -Path $executablePath
 
   # Replace `default.ini` with our modified one that includes change for 'internet_detector'.


### PR DESCRIPTION
When opening Fakenet via the shortcut, it spawns a second command prompt which runs Fakenet.

The original intent was to have Fakenet opened in a cmd that would not close after terminating Fakenet, but unfortunately this doesn't seem to be something that can be done via execution through a shortcut, rather, I believe it needs to be done from within Fakenet.

This PR will put fakenet back to its original way where it opens a single command prompt, but will terminate the cmd after closing fakenet.