### PR TITLE
Add pycdc.vm and pycdas.vm

### DIFF
--- a/packages/pycdas.vm/pycdas.vm.nuspec
+++ b/packages/pycdas.vm/pycdas.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pycdas.vm</id>
+    <version>0.0.0.20250110</version>
+    <authors>Michael Hansen, Darryl Pogue</authors>
+    <description>Python byte-code disassembler</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/pycdas.vm/tools/chocolateyinstall.ps1
+++ b/packages/pycdas.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'pycdas'
+$category = 'Python'
+
+$exeUrl = 'https://github.com/extremecoders-re/decompyle-builds/releases/download/build-16-Oct-2024-5e1c403/pycdas.exe'
+$exeSha256 = 'b4a2c51ba859282c12ef505419c8897606345e23a97c72612b1ffaf4c12ac72d'
+
+VM-Install-Single-Exe $toolName $category $exeUrl -exeSha256 $exeSha256 -consoleApp $true -arguments "--help"

--- a/packages/pycdas.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pycdas.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'pycdas'
+$category = 'Python'
+
+VM-Uninstall $toolName $category

--- a/packages/pycdc.vm/pycdc.vm.nuspec
+++ b/packages/pycdc.vm/pycdc.vm.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pycdc.vm</id>
+    <version>0.0.0.20250110</version>
+    <authors>Michael Hansen, Darryl Pogue</authors>
+    <description>Python decompiler</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/pycdc.vm/tools/chocolateyinstall.ps1
+++ b/packages/pycdc.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'pycdc'
+$category = 'Python'
+
+$exeUrl = 'https://github.com/extremecoders-re/decompyle-builds/releases/download/build-16-Oct-2024-5e1c403/pycdc.exe'
+$exeSha256 = '4dc188d897c0e6054f55c4e3f91ec01ca801ecb674314914d1b0ddfb3529512a'
+
+VM-Install-Single-Exe $toolName $category $exeUrl -exeSha256 $exeSha256 -consoleApp $true -arguments "--help"

--- a/packages/pycdc.vm/tools/chocolateyuninstall.ps1
+++ b/packages/pycdc.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'pycdc'
+$category = 'Python'
+
+VM-Uninstall $toolName $category


### PR DESCRIPTION
Add Python byte-code disassembler (pycdas) and decompiler (pycdc) from https://github.com/zrax/pycdc using the pre-compiled builds from https://github.com/extremecoders-re/decompyle-builds/releases/tag/build-16-Oct-2024-5e1c403. I plan to add these packages to FLARE-VM default configuration after this PR is merged.

Closes https://github.com/mandiant/VM-Packages/issues/1182