### PR TITLE
[wireshark.vm] Add tshark to PATH and Tools dir

### DIFF
--- a/packages/wireshark.vm/tools/chocolateyinstall.ps1
+++ b/packages/wireshark.vm/tools/chocolateyinstall.ps1
@@ -7,9 +7,15 @@ try {
 
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-  $executablePath = Join-Path ${Env:ProgramFiles} "Wireshark\Wireshark.exe" -Resolve
+  $executablePath = Join-Path ${Env:ProgramFiles} "Wireshark\$toolName.exe" -Resolve
   Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin
   VM-Assert-Path $shortcut
+
+  # Add tshark (installed by Wireshark) to PATH and to Tools directory
+  $toolName = 'tshark'
+  $executablePath = Join-Path ${Env:ProgramFiles} "Wireshark\$toolName.exe" -Resolve
+  Install-BinFile -Name $toolname -Path $executablePath
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath -consoleApp $true
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/wireshark.vm/tools/chocolateyuninstall.ps1
+++ b/packages/wireshark.vm/tools/chocolateyuninstall.ps1
@@ -1,7 +1,9 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'Wireshark'
+$toolNames = @('Wireshark', 'tshark')
 $category = 'Networking'
 
-VM-Remove-Tool-Shortcut $toolName $category
+ForEach ($toolName in $toolNames) {
+  VM-Remove-Tool-Shortcut $toolName $category
+}

--- a/packages/wireshark.vm/wireshark.vm.nuspec
+++ b/packages/wireshark.vm/wireshark.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wireshark.vm</id>
-    <version>4.4.2</version>
+    <version>4.4.2.20250108</version>
     <description>Wireshark lets you capture and interactively browse the traffic running on a computer network.</description>
     <authors>Gerald Combs, Wireshark team</authors>
     <dependencies>


### PR DESCRIPTION
Wireshark installs tshark, but it was not added to PATH. Add it to PATH and to the Tools directory to make it easier to find.