### PR TITLE
Improve license & copyright & documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# How to contribute
+
+Want to open an issue or send a code contribution?
+Read the information below to learn how.
+We are looking forward working with you to improve VM-Packages! :sparkling_heart:
+
+
+## Repository structure
+
+This repository contains the source code of [tool packages](https://github.com/mandiant/VM-Packages/tree/main/packages) that supports the analysis enviroment projects [FLARE-VM](https://github.com/mandiant/flare-vm) and [CommandoVM](https://github.com/mandiant/commando-vm).
+
+To propose new tools, to report problems, and to suggest improvements please open a new [issue](https://github.com/mandiant/VM-Packages/issues).
+Ensure you select the correct issue type, read the issue template carefully and provide all the needed information.
+
+
+## Before contributing code
+
+### Sign our Contributor License Agreement
+
+Contributions to this project must be accompanied by a [Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.
+
+If you or your current employer have already signed the Google CLA (even if it was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to sign a new one.
+
+### Check the Wiki
+
+Please see our [Wiki](https://github.com/mandiant/VM-Packages/wiki) for documentation on how to create a package using our established best practices.
+
+
+## Review our community guidelines
+
+This project follows [Google's Open Source Community Guidelines](https://opensource.google/conduct).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (C) 2021 Mandiant, Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 VM-Packages
-Copyright 2021 Mandiant, Inc.
+Copyright 2021 Google LLC
 
-This software includes code developed by Mandiant, Inc.
+This software includes code developed by Google LLC.
 
 Portions of this software may be contributed by the community.

--- a/README.md
+++ b/README.md
@@ -10,21 +10,38 @@ This repository contains the source code for packages supporting the following a
 * [FLARE VM](https://github.com/mandiant/flare-vm)
 * [CommandoVM](https://github.com/mandiant/commando-vm)
 
-> Packages do not contain actual software distributions. Packages are PowerShell scripts that only contain instructions for obtaining and configuring tools. See [Chocolatey legal information](https://docs.chocolatey.org/en-us/information/legal) for more details.
+> Packages do not contain actual software distributions.
+> Packages are PowerShell scripts that only contain instructions for obtaining and configuring tools.
+> See [Chocolatey legal information](https://docs.chocolatey.org/en-us/information/legal) for more details.
+
 
 # How does this work?
-The packages stored in this repository are automatically built and pushed to a public package feed hosted on myget.org. From this feed FLARE VM and our other binary analysis environments download packages and execute the included scripts to install tools.
 
+The packages stored in this repository are automatically built and pushed to a public [package feed hosted on MyGet](https://www.myget.org/feed/Packages/vm-packages).
+From this feed FLARE VM and our other binary analysis environments download packages and execute the included scripts to install tools.
 The installation of packages relies on [Chocolatey](https://chocolatey.org/).
 
-# Contributing
-To propose new tools, to report problems, and to suggest improvements please open a new [issue](https://github.com/mandiant/VM-Packages/issues).
-Ensure you select the correct issue type and provide all the requested information.
 
-Please see the [Wiki](https://github.com/mandiant/VM-Packages/wiki) for documentation on how to create a package using our established best practices.
+## Open Source Packages
 
-# Open Source Packages
-Open sourcing the installation packages allows the community to not only suggest new tools, improvements, and report bugs, but to help implement them. It's now very transparent how and what gets installed. Moreover, we can use GitHub Actions (free for open-source repositories) for testing and automations. This reduces manual maintenance and simplifies contributions.
+Open sourcing the installation packages allows the community to not only suggest new tools, improvements, and report bugs, but to help implement them.
+It's now transparent how and what gets installed.
+Moreover, we can use GitHub Actions (free for open-source repositories) for testing and automation.
+This reduces manual maintenance and simplifies contributions.
 
-## Automation
-Once a package is submitted, our pull request automations test the package to see if it builds and installs correctly. Additionally, we use GitHub Actions to build and test each package on a daily basis to check for any errors (see [Daily Failures Wiki page](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)). Simply being aware of broken packages should quickly solve a lot of problems VM users faced in the past.
+
+## Automation using GitHub Actions
+
+Once a package is submitted, our pull request automation test the package to see if it builds and installs correctly.
+Additionally, we build and test each package on a daily basis to check for any errors.
+Simply being aware of broken packages should quickly solve a lot of problems VM users faced in the past.
+To see the daily test results check the [Daily Failures](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures) and [MyGet Version Mismatches](https://github.com/mandiant/VM-Packages/wiki/MyGet-Version-Mismatches) wiki pages.
+The status is also displayed in the badges at the beginning of this README.
+
+We have also automated other task, such as the creation of new packages (using [`create_package_template.py`](https://github.com/mandiant/VM-Packages/blob/main/scripts/utils/create_package_template.py)) and the package updates (using [`update_package.py`](https://github.com/mandiant/VM-Packages/blob/main/scripts/utils/update_package.py)).
+
+
+## Documentation
+
+- Check our [CONTRIBUTING guide](/CONTRIBUTING.md) to learn how to contribute to the project.
+- Check our [Wiki](https://github.com/mandiant/VM-Packages/wiki) for documentation on how to create a package using our established best practices.

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -1,18 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Check the given packages for style issues.
 
 Usage:
 
    $ python lint.py packages/
-
-Copyright (C) 2022 Mandiant, Inc. All Rights Reserved.
-Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
-You may obtain a copy of the License at: [package root]/LICENSE.txt
-Unless required by applicable law or agreed to in writing, software distributed under the License
- is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and limitations under the License.
 """
+
 import os
 import sys
 import logging


### PR DESCRIPTION
- Replace LICENSE text file with the official Apache one: https://www.apache.org/licenses/LICENSE-2.0.txt. This changes `Copyright (C) 2021 Mandiant, Inc.` by the following template language that had been **incorrectly** replaced: `Copyright [yyyy] [name of copyright owner]`
- Improve copyright information.
- Add CONTRIBUTING file with information about CLA and Google's code of conduct to follow Google conventions/policies and make contributing easier. Improve information in the README too.