### PR TITLE
Add idapro.vm

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250116</version>
+    <version>0.0.0.20250117</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -621,6 +621,9 @@ function VM-Uninstall {
 
     # Uninstall binary
     Uninstall-BinFile -Name $toolName
+
+    # Refresh Desktop, needed for example if shortcut is used in FLARE-VM LayoutModification.xml
+    VM-Refresh-Desktop
 }
 
 function VM-Remove-Tool-Shortcut {

--- a/packages/cyberchef.vm/cyberchef.vm.nuspec
+++ b/packages/cyberchef.vm/cyberchef.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cyberchef.vm</id>
-    <version>10.19.4.20241209</version>
+    <version>10.19.4.20250117</version>
     <authors>GCHQ</authors>
     <description>The Cyber Swiss Army Knife - a web app for encryption, encoding, compression, data analysis, and more.</description>
     <dependencies>

--- a/packages/cyberchef.vm/tools/chocolateyinstall.ps1
+++ b/packages/cyberchef.vm/tools/chocolateyinstall.ps1
@@ -25,6 +25,9 @@ try {
   $cyberchefPath = Get-Item "$toolDir\CyberChef*.html"
   $iconLocation = VM-Create-Ico (Join-Path $toolDir "images\cyberchef-128x128.png")
   VM-Install-Shortcut -toolName $toolName -category $category -executablePath $chromePath -arguments "-home $cyberchefPath" -iconLocation $iconLocation
+
+  # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/explorersuite.vm.nuspec
+++ b/packages/explorersuite.vm/explorersuite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>explorersuite.vm</id>
-    <version>0.0.0.20240717</version>
+    <version>0.0.0.20250117</version>
     <authors>Erik Pistelli</authors>
     <description>A suite of tools including CFF Explorer and a process viewer.</description>
     <dependencies>

--- a/packages/explorersuite.vm/tools/chocolateyinstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyinstall.ps1
@@ -34,6 +34,9 @@ try {
   Remove-Item -Path "HKLM:\SOFTWARE\Classes\*file\shell\Open with CFF Explorer" -Recurse
 
   VM-Add-To-Right-Click-Menu 'Open with CFF Explorer' 'Open with CFF Explorer' "`"$cffExecutablePath`" %1" $cffExecutablePath
+
+  # Refresh Desktop as CFF Explorer shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
+++ b/packages/explorersuite.vm/tools/chocolateyuninstall.ps1
@@ -10,3 +10,6 @@ foreach ($subtoolName in $subtoolNames) {
 VM-Remove-From-Right-Click-Menu 'Open with CFF Explorer'
 
 VM-Uninstall-With-Uninstaller "Explorer Suite IV" $category "EXE" "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-"
+
+# Refresh Desktop as CFF Explorer shortcut is used in FLARE-VM LayoutModification.xml
+VM-Refresh-Desktop

--- a/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
+++ b/packages/fakenet-ng.vm/fakenet-ng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>fakenet-ng.vm</id>
-    <version>3.3.0.20241219</version>
+    <version>3.3.0.20250117</version>
     <description>FakeNet-NG is a dynamic network analysis tool.</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyinstall.ps1
@@ -44,6 +44,9 @@ try {
   $desktopShortcut  = Join-Path ${Env:UserProfile} "Desktop\fakenet_logs.lnk"
   Install-ChocolateyShortcut -shortcutFilePath $desktopShortcut -targetPath $toolDir
   VM-Assert-Path $desktopShortcut
+
+  # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/fakenet-ng.vm/tools/chocolateyuninstall.ps1
+++ b/packages/fakenet-ng.vm/tools/chocolateyuninstall.ps1
@@ -1,15 +1,14 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-try {
-  $toolName = 'fakenet'
-  $category = 'Networking'
+$toolName = 'fakenet'
+$category = 'Networking'
 
-  VM-Uninstall $toolName $category
+VM-Uninstall $toolName $category
 
-  # Remove Desktop shortcut to FakeNet tool directory
-  $desktopShortcut  = Join-Path ${Env:UserProfile} "Desktop\fakenet_logs.lnk"
-  Remove-Item $desktopShortcut -Force -ea 0
-} catch {
-  VM-Write-Log-Exception $_
-}
+# Remove Desktop shortcut to FakeNet tool directory
+$desktopShortcut  = Join-Path ${Env:UserProfile} "Desktop\fakenet_logs.lnk"
+Remove-Item $desktopShortcut -Force -ea 0
+
+# Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+VM-Refresh-Desktop

--- a/packages/googlechrome.vm/googlechrome.vm.nuspec
+++ b/packages/googlechrome.vm/googlechrome.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>googlechrome.vm</id>
-    <version>0.0.0.20241212</version>
+    <version>0.0.0.20250117</version>
     <authors>Google LLC.</authors>
     <description>Chrome is a popular web browser.</description>
     <dependencies>

--- a/packages/googlechrome.vm/tools/chocolateyinstall.ps1
+++ b/packages/googlechrome.vm/tools/chocolateyinstall.ps1
@@ -72,5 +72,4 @@ SetDefaultBrowser "chrome"
 # Do not show the "Open with" popup
 Set-ItemProperty -path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer" -name "NoNewAppAlert" -value 1 -type "DWord"
 
-# Restart Explorer.exe for registry change to take effect
-Stop-Process -Name explorer -Force
+VM-Refresh-Desktop # For registry change to take effect

--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>8.4.0.20241124</version>
-    <authors>hex-rays</authors>
-    <description>Free version of IDA, a powerful Interactive DisAssembler and debugger</description>
+    <version>8.4.0.20250116</version>
+    <authors>Hex-Rays</authors>
+    <description>Free version of IDA Pro, a powerful Interactive DisAssembler and debugger.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240119" />
     </dependencies>

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
-  $toolName = 'idafree'
+  $toolName = 'ida'
   $category = 'Disassemblers'
 
   $packageArgs = @{
@@ -21,10 +21,8 @@ try {
   Install-BinFile -Name $toolname -Path $executablePath
 
   # Delete Desktop shortcut
-  $desktopShortcut = Join-Path ${Env:Public} "Desktop\IDA Freeware 8.4.lnk"
-  if (Test-Path $desktopShortcut) {
-    Remove-Item $desktopShortcut -Force -ea 0
-  }
+  $desktopShortcut = Resolve-Path "${Env:Public}\Desktop\IDA Freeware*"
+  if ($null -ne $desktopShortcut) { Remove-Item $desktopShortcut -Force -ea 0 }
 
   # Download ida_launcher.exe to assist with taskbar and right click option and store it in %RAW_TOOLS_DIR%
   # ida_launcher.exe is a custom binary that searches for the latest ida64.exe and executes it
@@ -32,17 +30,14 @@ try {
   $launcherSource = 'https://raw.githubusercontent.com/mandiant/VM-Packages/119ba385de053b01b0d1732d60ad1b1152496dc2/ida_launcher/ida_launcher.exe'
   $launcherPath = Join-Path ${Env:RAW_TOOLS_DIR} "$launcherName.exe"
   $launcherChecksum = "a98241e476150d053d67d149c1b54816c8306db51e0987613ec25a0f8ad22006"
-  Write-Host "[+] Downloading '$launcherSource'"
   Get-ChocolateyWebFile -PackageName $launcherName -FileFullPath $launcherPath -Url $launcherSource -Checksum $launcherChecksum -ChecksumType "sha256"
-
   VM-Assert-Path $launcherPath
 
-  $menuIcon = Join-Path $toolDir "ida.ico" -Resolve
-
-  VM-Install-Shortcut -toolName "ida" -category $category -executablePath $launcherPath -IconLocation $menuIcon
+  $icon = Join-Path $toolDir "$toolName.ico" -Resolve
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $launcherPath -IconLocation $icon
 
   # ida64.exe supports both 32 bit and 64 bit in IDA >= 8.2
-  VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$menuIcon"
+  VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$icon"
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -38,6 +38,9 @@ try {
 
   # ida64.exe supports both 32 bit and 64 bit in IDA >= 8.2
   VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$icon"
+
+  # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/idafree.vm/tools/chocolateyuninstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyuninstall.ps1
@@ -1,13 +1,11 @@
 $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'idafree'
+$toolName = 'ida'
 $category = 'Disassemblers'
-
-VM-Remove-Tool-Shortcut $toolName $category
 
 # Remove binary from PATH
 Uninstall-BinFile -Name $toolName
 
-# Manually silently uninstall
-VM-Uninstall-With-Uninstaller "IDA Freeware*?8.4" $category "EXE" "--mode unattended"
+# Silently uninstall
+VM-Uninstall-With-Uninstaller "IDA Freeware*" $category "EXE" "--mode unattended" | Out-Null

--- a/packages/idapro.vm/idapro.vm.nuspec
+++ b/packages/idapro.vm/idapro.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>idapro.vm</id>
+    <version>0.0.0.20250116</version>
+    <authors>Hex-Rays</authors>
+    <description>IDA Pro 9 is an interactive DisAssembler and debugger. The installation requires an IDA Pro installer `ida-pro_9*.exe` (and optionally a license file) in the Desktop. Get your installer from https://hex-rays.com/ida-pro.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240509" />
+      <!-- IDA Pro requires Python3 and the rpyc library -->
+      <dependency id="libraries.python3.vm" version="0.0.0.20241213" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/idapro.vm/tools/chocolateyinstall.ps1
+++ b/packages/idapro.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+try {
+  $toolName = 'ida'
+  $category = 'Disassemblers'
+
+  $installerPaths = Resolve-Path "${Env:USERPROFILE}\Desktop\ida-pro_9*.exe"
+  if ($installerPaths.count -eq 0) {
+    throw "An IDA Pro installer 'ida-pro_9*.exe' in the Desktop is required. Get your installer from https://hex-rays.com/ida-pro"
+  }
+  elseif ($installerPaths.count -gt 1) {
+    # Only one installer supported (prospective change)
+    throw "Several IDA Pro installers found in Desktop, only 1 installer is supported."
+  }
+  $installerPath = $installerPaths | Select-Object -first 1
+  VM-Write-Log "INFO" "Installing IDA Pro: $installerPath"
+
+  # Run installer
+  $packageArgs = @{
+    packageName    = $env:ChocolateyPackageName
+    file           = $installerPath
+    fileType       = 'exe'
+    # unclear what the required argument `--install_python` expects
+    silentArgs     = '--mode unattended --install_python flare'
+  }
+  Install-ChocolateyInstallPackage @packageArgs | Out-Null
+
+  # Wait for IDA to be installed
+  Start-Sleep -Seconds 10
+  $executablePath = Resolve-Path "${Env:ProgramFiles}\IDA Professional 9*\ida.exe"
+  VM-Assert-Path $executablePath
+
+  Install-BinFile -Name $toolname -Path $executablePath
+
+  # Delete "IDA Teams Visual Client" Desktop shortcut
+  # Do not delete "IDA Professional 9.0", as it is useful to drag binaries to it
+  $desktopShortcut = Resolve-Path "${Env:Public}\Desktop\IDA Teams Visual Client*"
+  if ($null -ne $desktopShortcut) { Remove-Item $desktopShortcut -Force -ea 0 }
+
+  # Add ida to the Tools directory, use directly (instead of ida_launcher.exe) to avoid taskbar duplication
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath
+
+  # Download ida_launcher.exe and store it in %RAW_TOOLS_DIR%
+  # ida_launcher.exe is a custom binary that searches for the latest ida64.exe and executes it
+  $launcherName = 'ida_launcher'
+  $launcherSource = 'https://raw.githubusercontent.com/mandiant/VM-Packages/119ba385de053b01b0d1732d60ad1b1152496dc2/ida_launcher/ida_launcher.exe'
+  $launcherPath = Join-Path ${Env:RAW_TOOLS_DIR} "$launcherName.exe"
+  $launcherChecksum = "a98241e476150d053d67d149c1b54816c8306db51e0987613ec25a0f8ad22006"
+  Get-ChocolateyWebFile -PackageName $launcherName -FileFullPath $launcherPath -Url $launcherSource -Checksum $launcherChecksum -ChecksumType "sha256"
+  VM-Assert-Path $launcherPath
+
+  # Use ida_launcher.exe in the right click option "Open with IDA"
+  $icon = Resolve-Path "${Env:ProgramFiles}\IDA*\$toolName.ico" | Select-Object -last 1
+  VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$icon"
+
+
+  # Create IDA user directory (also if no license file is copied as it makes it easier to manually add the license file)
+  $idaDir = "${Env:APPDATA}\Hex-Rays\IDA Pro"
+  New-Item $idaDir -ItemType "directory" -Force | Out-Null
+
+  # Copy license file to IDA user directory if present in Desktop
+  $licensePaths = Resolve-Path "${Env:USERPROFILE}\Desktop\idapro_9*.hexlic"
+  if ($licensePaths.count -eq 0) {
+    VM-Write-Log "WARN" "No IDA Pro license file 'idapro_9*.hexlic' found in Desktop."
+    VM-Write-Log "WARN" "Get your license file from https://hex-rays.com/ida-pro and copy it to IDA user directory before launching IDA Pro."
+  }
+  else {
+    # Copy license file(s)
+    ForEach ($licensePath in $licensePaths) {
+      VM-Write-Log "INFO" "Copying license file to IDA user directory: $licensePath"
+      Copy-Item $licensePath $idaDir
+    }
+  }
+} catch {
+  VM-Write-Log-Exception $_
+}

--- a/packages/idapro.vm/tools/chocolateyinstall.ps1
+++ b/packages/idapro.vm/tools/chocolateyinstall.ps1
@@ -72,6 +72,9 @@ try {
       Copy-Item $licensePath $idaDir
     }
   }
+
+  # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/idapro.vm/tools/chocolateyuninstall.ps1
+++ b/packages/idapro.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'ida'
+$category = 'Disassemblers'
+
+# Remove binary from PATH
+Uninstall-BinFile -Name $toolName
+
+# Replace tool shortcut's target by ida_launcher.exe
+$launcherPath = Join-Path ${Env:RAW_TOOLS_DIR} "ida_launcher.exe"
+$icon = Resolve-Path "${Env:ProgramFiles}\IDA*\$toolName.ico" | Select-Object -first 1
+VM-Install-Shortcut -toolName $toolName -category $category -executablePath $launcherPath -IconLocation $icon
+
+# Silently uninstall
+VM-Uninstall-With-Uninstaller "IDA Pro*" $category "EXE" "--mode unattended" | Out-Null

--- a/packages/notepadplusplus.vm/notepadplusplus.vm.nuspec
+++ b/packages/notepadplusplus.vm/notepadplusplus.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>notepadplusplus.vm</id>
-    <version>8.7.5</version>
+    <version>8.7.5.20250122</version>
     <description>Wrapper for Notepad++</description>
     <authors>Don Ho</authors>
     <dependencies>

--- a/packages/notepadplusplus.vm/tools/chocolateyinstall.ps1
+++ b/packages/notepadplusplus.vm/tools/chocolateyinstall.ps1
@@ -46,6 +46,9 @@ try {
 
     $executablePath = Join-Path ${Env:ProgramFiles} "Notepad++\${toolName}.exe" -Resolve
     VM-Install-Shortcut $toolName $category $executablePath
+
+    # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+    VM-Refresh-Desktop
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/sysinternals.vm/sysinternals.vm.nuspec
+++ b/packages/sysinternals.vm/sysinternals.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sysinternals.vm</id>
-    <version>0.0.0.20241122</version>
+    <version>0.0.0.20250117</version>
     <authors>Mark Russinovich, Bryce Cogswell</authors>
     <description>Sysinternals suite.</description>
     <dependencies>

--- a/packages/sysinternals.vm/tools/chocolateyinstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyinstall.ps1
@@ -78,6 +78,9 @@ try {
         New-Item -Path $registryKey -Force | Out-Null
         New-ItemProperty -Path $registryKey -Name EulaAccepted -Value 1 -Force | Out-Null
     }
+
+    # Refresh Desktop as the shortcuts are used in FLARE-VM LayoutModification.xml
+    VM-Refresh-Desktop
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
+++ b/packages/sysinternals.vm/tools/chocolateyuninstall.ps1
@@ -18,3 +18,6 @@ ForEach ($category in $shortcuts.GetEnumerator()) {
 
 $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 Remove-Item $toolDir -Recurse -Force -ea 0 | Out-Null
+
+# Refresh Desktop as the shortcuts are used in FLARE-VM LayoutModification.xml
+VM-Refresh-Desktop

--- a/packages/visualstudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyinstall.ps1
@@ -16,6 +16,9 @@ try {
     $shortcut = Join-Path $shortcutDir "$toolName.lnk"
     Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
     VM-Assert-Path $shortcut
+
+    # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+    VM-Refresh-Desktop
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyuninstall.ps1
@@ -6,4 +6,7 @@ $category = 'Productivity Tools'
 
 VM-Remove-Tool-Shortcut $toolName $category
 
+# Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+VM-Refresh-Desktop
+
 choco uninstall visualstudio2022community --removedependencies

--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1.20250120</version>
+    <version>17.6.1.20250121</version>
     <description>IDE.</description>
     <authors>Microsoft</authors>
     <dependencies>

--- a/packages/windows-terminal.vm/tools/chocolateyinstall.ps1
+++ b/packages/windows-terminal.vm/tools/chocolateyinstall.ps1
@@ -54,6 +54,9 @@ try {
   $label = "Open Terminal here"
   $icon = "$executablePath"
   VM-Add-To-Right-Click-Menu -menuKey $toolName -menuLabel $label -command $command -menuIcon $icon -type "directory" -background
+
+  # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
+  VM-Refresh-Desktop
 } catch {
   VM-Write-Log-Exception $_
 }

--- a/packages/windows-terminal.vm/windows-terminal.vm.nuspec
+++ b/packages/windows-terminal.vm/windows-terminal.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>windows-terminal.vm</id>
-    <version>1.21.3231</version>
+    <version>1.21.3231.20250117</version>
     <authors>Microsoft</authors>
     <description>Windows Terminal is a new, modern, feature-rich, productive terminal application for command-line users.</description>
     <dependencies>

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -49,7 +49,7 @@ foreach ($package in $packages) {
 }
 
 
-$exclude_tests = @("installer.vm")
+$exclude_tests = @("installer.vm", "idapro.vm")
 
 $failures = New-Object Collections.Generic.List[string]
 $failed = 0


### PR DESCRIPTION
Add idapro.vm, that installs IDA Pro 9 using an IDA Pro installer `ida-pro_9*.exe` (and optionally a license file) in the Desktop. Make also some changes to idafree.vm to keep both packages consistent.

There are some conflicts between idafree.vm and idapro.vm, as both use the same tool name, which enable us to have a single shortcut (in the Tools directory and the taskbar) and right-click menu option. As long as idapro.vm is installed after idafree.vm (which should be the case using the installer that uses alphabetical order), the installation is as I would expect it:
- IDA Pro 9 is used in shortcut in the Tools directory and the taskbar (without taskbar duplication)
- The right-click menu option uses IDA launcher to find the highest version of IDA available.

We may be able to merge or improve these two packages as it is clear if we will be able to install IDA Free 9 (tracked in https://github.com/mandiant/VM-Packages/issues/1150).

I have kept IDA Pro 9 Desktop shortcut as I find it useful to drag binaries to it.

We need to exclude this new package from testing, as we can't provide an IDA installer. I have tested locally with `ida-pro_90_x64win.exe` and `ida-pro_90sp1_x64win.exe`.

Refresh Desktop in the packages whose shortcut is used in FLARE-VM LayoutModification.xml, including the new idapro.vm.

Closes https://github.com/mandiant/VM-Packages/issues/1225