### PR TITLE
[common.vm] Improve VM-Write-Log

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20241216</version>
+    <version>0.0.0.20250116</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -70,11 +70,18 @@ function VM-Remove-PreviousZipPackage {
     }
 }
 
+
 function VM-Write-Log {
+<#
+.SYNOPSIS
+  Log message to file and console.
+.DESCRIPTION
+  Log message to log file with extra useful information and to console with a color depending on the level.
+#>
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true, Position=0)]
-        [ValidateSet("INFO","WARN","ERROR","FATAL","DEBUG")]
+        [ValidateSet("INFO","WARN","ERROR")]
         [String] $level,
         [Parameter(Mandatory=$true, Position=1)]
         [string] $message
@@ -106,11 +113,11 @@ function VM-Write-Log {
 
     # Log message to console
     if (($level -eq "ERROR") -Or ($level -eq "FATAL")) {
-        Write-Host -ForegroundColor Red -BackgroundColor White "$line"
+        Write-Host -ForegroundColor Red -BackgroundColor White "$message"
     } elseif ($level -eq "WARN") {
-        Write-Host -ForegroundColor Yellow "$line"
+        Write-Host -ForegroundColor Yellow "$message"
     } else {
-        Write-Host "$line"
+        Write-Host -ForegroundColor Cyan "$message"
     }
 }
 


### PR DESCRIPTION
Improve console output of `VM-Write-Log`:
- Use `$message` instead of `$line` as it makes the output difficult to read. This information is only useful in the file.
- Use better colors.

Also remove unused levels (`FATAL`, `DEBUG`) and improve the function help message.

### Example: idapro.vm before the change
![image](https://github.com/user-attachments/assets/18c5ea6d-94ce-4d48-8bf6-08fafbb0e7a2)

### Example: idapro.vm after the change
![image](https://github.com/user-attachments/assets/3059f610-c0f7-47ba-95ac-b846cbb35d03)

idapro.vm added in https://github.com/mandiant/VM-Packages/pull/1243

Related: https://github.com/mandiant/VM-Packages/issues/1244