### PR TITLE
[visualstudio.vm] Increase execution timeout

### DIFF
--- a/packages/visualstudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyinstall.ps1
@@ -9,7 +9,7 @@ try {
     # The community package chocolatey-visualstudio.extension 1.11 includes a -DefaultParameterValues parameter
     # that would be a better solution (as it would allow to change the parameters when installing the package),
     # but only a preview is available at the moment.
-    choco install visualstudio2022community --params "--add Microsoft.VisualStudio.Component.CoreEditor --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --includeRecommended"
+    choco install visualstudio2022community --params "--add Microsoft.VisualStudio.Component.CoreEditor --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --includeRecommended" --execution-timeout 6000
 
     $executablePath = Join-Path ${Env:ProgramFiles} "Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe" -Resolve
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category

--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1.20240217</version>
+    <version>17.6.1.20250120</version>
     <description>IDE.</description>
     <authors>Microsoft</authors>
     <dependencies>


### PR DESCRIPTION
Increase execution timeout for visualstudio2022community to ensure it is installed in slow environments if the execution timeout for visualstudio.vm is also increased.

Fixes https://github.com/mandiant/VM-Packages/issues/1222 (I hope, it is tricky to test). There may also be better solutions, please let me know if you have any ideas.