### PR TITLE
Update ilspy.vm & add dotnet-8.vm

### DIFF
--- a/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
+++ b/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>arsenalimagemounter.vm</id>
-    <version>3.11.293</version>
+    <version>3.11.293.20250122</version>
     <authors>Arsenal Recon</authors>
     <description>Mounts the contents of disk images as complete disks in Windows.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="dotnet-8.0-desktopruntime" version="[8, 8.1)" />
+      <dependency id="dotnet-8.vm" />
       <dependency id="arsenalimagemounter" version="[3.11.293]" />
       <dependency id="dokan.vm" />
     </dependencies>

--- a/packages/dotnet-8.vm/dotnet-8.vm.nuspec
+++ b/packages/dotnet-8.vm/dotnet-8.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>dotnet-8.vm</id>
+    <version>0.0.0.20250122</version>
+    <authors>Microsoft</authors>
+    <description>Metapackage for .NET8 to ensure all packages use the same version.</description>
+    <dependencies>
+      <dependency id="common.vm" />
+      <dependency id="dotnet-8.0-desktopruntime" version="[8, 8.1)" />
+    </dependencies>
+  </metadata>
+</package>

--- a/packages/ilspy.vm/ilspy.vm.nuspec
+++ b/packages/ilspy.vm/ilspy.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ilspy.vm</id>
-    <version>8.2.0</version>
+    <version>9.0.0</version>
     <authors>SharpDevelop Team</authors>
     <description>The open-source .NET assembly browser and decompiler.</description>
     <dependencies>
       <dependency id="common.vm" />
-      <dependency id="ilspy" version="[8.2.0]" />
+      <dependency id="ilspy" version="[9.0.0]" />
+      <dependency id="dotnet-8.vm" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Update ilspy.vm to 9.0.0. As ILSpy requires .NET 8, add a new metapackage for .NET8 to ensure all packages use the same version (dotnet-8.vm). Use dotnet-8.vm in arsenalimagemounter.vm, the only package requiring .NET8 as dependency at the moment. 

It would be good if merge this PR in the next hours or our bot will try to update ILSpy without the .NET8 update (it does not run without the dependency) later today.