### PR TITLE
[microsoft-office.vm] Improve installation params & add verification + shortcuts 

### DIFF
--- a/packages/microsoft-office.vm/microsoft-office.vm.nuspec
+++ b/packages/microsoft-office.vm/microsoft-office.vm.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-office.vm</id>
-    <version>0.0.0.20250123</version>
-    <description>Microsoft Office ProPlusRetail</description>
+    <version>0.0.0.20250203</version>
+    <description>Microsoft Office ProPlus2024Retail.</description>
     <authors>Microsoft</authors>
     <dependencies>
       <dependency id="common.vm" />

--- a/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
+++ b/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
@@ -2,8 +2,28 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 try {
+    $tools = @(
+        @{name = 'Word'; executable = 'WINWORD.EXE'},
+        @{name = 'Excel'; executable = 'EXCEL.EXE'},
+        @{name = 'PowerPoint'; executable = 'POWERPNT.EXE'},
+        @{name = 'OneNote'; executable = 'ONENOTE.EXE'}
+    )
+    $category = 'Documents'
+    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
+
     # Install with choco instead as dependency to provide params such the product
     choco install microsoft-office-deployment --params="'/DisableUpdate:TRUE  /Product:ProPlus2024Retail'" --no-progress
+
+    # Find the directory where the tools are installed
+    $officeDirectory = Resolve-Path "C:\Program Files**\Microsoft Office\root\Office16" | Select-Object -first 1
+
+    # Ensure the tools are installed and create shortcuts
+    forEach ($tool in $tools) {
+        $executablePath = Join-Path $officeDirectory $($tool.executable) -Resolve
+        $shortcut = Join-Path $shortcutDir "$($tool.name).lnk"
+        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
+        VM-Assert-Path $shortcut
+    }
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
+++ b/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     # Install with choco instead as dependency to provide params such the product
-    choco install microsoft-office-deployment --params="'/DisableUpdate:TRUE /Language:en-us /Product:ProPlusRetail'" --no-progress
+    choco install microsoft-office-deployment --params="'/DisableUpdate:TRUE  /Product:ProPlus2024Retail'" --no-progress
 } catch {
     VM-Write-Log-Exception $_
 }

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -334,7 +334,6 @@ class UsesInvalidCategory(Lint):
         "installer.vm",
         "libraries.python2.vm",
         "libraries.python3.vm",
-        "microsoft-office.vm",
         "notepadpp.plugin.",
         "npcap.vm",
         "openjdk.vm",


### PR DESCRIPTION
Install a concrete version `ProPlus2024Retail` to avoid untested updates. Remove the language to use the system default. Ensure Office tools useful for malware analysis are installed and create
shortcuts in the Tools directory to make accessing them easier.