### PR TITLE
Avoid error when installing packages in headless mode

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250203</version>
+    <version>0.0.0.20250204</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1564,8 +1564,10 @@ public class Shell {
         $SHCNE_ASSOCCHANGED = 0x08000000
         $SHCNF_IDLIST = 0
         [void][Shell]::SHChangeNotify($SHCNE_ASSOCCHANGED, $SHCNF_IDLIST, [IntPtr]::Zero, [IntPtr]::Zero)
-        # Refresh the Taskbar
-        Stop-Process -Name explorer -Force  # This restarts the explorer process so that the new taskbar is displayed.
+        # Restart the explorer process to refresh the taskbar.
+        # Use '-ErrorAction Continue' to avoid failing the package installation if it fails,
+        # for example if there is no desktop session (as in this case explorer.exe is not running)
+        Stop-Process -Name explorer -Force -ErrorAction Continue
     } catch {
         VM-Write-Log-Exception $_
     }


### PR DESCRIPTION
VM-Refresh-Desktop tries to restart explorer.exe by using the Stop-Process cmdlet. When installing VM-Packages without a desktop session running (e.g. using ansible) this results in an error, because explorer.exe is not running. This error can be avoided by using ErrorAction SilentlyContinue. 

`ERROR: Cannot find a process with name "explorer".`