### PR TITLE
Fix hash in regcool.vm

### DIFF
--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>2.019</version>
+    <version>2.022</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>

--- a/packages/regcool.vm/tools/chocolateyinstall.ps1
+++ b/packages/regcool.vm/tools/chocolateyinstall.ps1
@@ -5,6 +5,6 @@ $toolName = 'RegCool'
 $category = 'Registry'
 
 $zipUrl = 'https://kurtzimmermann.com/files/RegCoolX64.zip'
-$zipSha256 = 'df3c80da807cab5b1612f0697373317523142643c4346ad618c3ec69d16db33e'
+$zipSha256 = '6514f05dacf360f1c1c968d3f5b0f89d3447b49ee55bd4e21935e6e29e3325ef'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $false -innerFolder $false


### PR DESCRIPTION
Update RegCool to version 2.022, fixing the package by using the new version hash.