### PR TITLE
Fix hash in vb-decompiler-lite.vm

### DIFF
--- a/packages/vb-decompiler-lite.vm/tools/chocolateyinstall.ps1
+++ b/packages/vb-decompiler-lite.vm/tools/chocolateyinstall.ps1
@@ -5,7 +5,7 @@ $toolName = 'VB Decompiler'
 $category = 'Visual Basic'
 
 $zipUrl = 'https://www.vb-decompiler.org/files/vb_decompiler_lite.zip'
-$zipSha256 = '099760dcae9daa4c83885a3817cf6f17442ce709de0105993bfbb4f17db87e62'
+$zipSha256 = 'ec754e61a55c6d4dfe1c5606749334abfbfd9e7a8b5363baf75aec8b5cde9811'
 
 $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 $executablePath = (Join-Path $toolDir "$toolName.exe")

--- a/packages/vb-decompiler-lite.vm/vb-decompiler-lite.vm.nuspec
+++ b/packages/vb-decompiler-lite.vm/vb-decompiler-lite.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vb-decompiler-lite.vm</id>
-    <version>12.4</version>
+    <version>12.5</version>
     <authors>DotFix Software</authors>
     <description>Visual Basic decompiler</description>
     <dependencies>


### PR DESCRIPTION
Update Visual Basic decompiler to version 12.5, fixing the package by using the new version hash. I have tested locally.