### PR TITLE
[installer.vm] Always create failed_packages.txt

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20241002</version>
+    <version>0.0.0.20250207</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -76,8 +76,9 @@ try {
     $cache = "${Env:LocalAppData}\ChocoCache"
     Remove-Item $cache -Recurse -Force
 
-    # Construct failed packages file path
+    # Construct failed packages file path and create the file
     $failedPackages = Join-Path $Env:VM_COMMON_DIR "failed_packages.txt"
+    New-Item $failedPackages
     $failures = @{}
 
     # Check and list failed packages from "lib-bad"


### PR DESCRIPTION
Ensure `failed_packages.txt` is always created (empty if no failures). This provides a predictable file structure for automated build scripts, allowing them to rely on the presence of this file to determine FLARE-VM installation completion.