### PR TITLE
Make the create package script compatible with the new package

### DIFF
--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -46,6 +46,7 @@ NUSPEC_TEMPLATE = r"""<?xml version="1.0" encoding="utf-8"?>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
     </dependencies>
+    <tags>{category}</tags>
   </metadata>
 </package>
 """
@@ -61,6 +62,7 @@ NUSPEC_TEMPLATE_NODE = r"""<?xml version="1.0" encoding="utf-8"?>
       <dependency id="common.vm" version="0.0.0.20240514" />
       <dependency id="nodejs.vm" version="0.0.0.20240516" />
     </dependencies>
+    <tags>{category}</tags>
   </metadata>
 </package>
 """
@@ -76,6 +78,7 @@ NUSPEC_TEMPLATE_PIP = r"""<?xml version="1.0" encoding="utf-8"?>
       <dependency id="common.vm" version="0.0.0.20241209" />
       <dependency id="python3.vm" />
     </dependencies>
+    <tags>{category}</tags>
   </metadata>
 </package>
 """
@@ -95,6 +98,7 @@ NUSPEC_TEMPLATE_METAPACKAGE = r"""<?xml version="1.0" encoding="utf-8"?>
       <dependency id="common.vm" />
       <dependency id="{dependency}" version="[{dependency_version}]" />
     </dependencies>
+    <tags>{category}</tags>
   </metadata>
 </package>
 """
@@ -103,7 +107,7 @@ ZIP_EXE_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 $zipUrl = '{target_url}'
 $zipSha256 = '{target_hash}'
@@ -120,7 +124,7 @@ NODE_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 $arguments = '{arguments}'
 
 VM-Install-Node-Tool -toolName $toolName -category $category -arguments $arguments
@@ -135,7 +139,7 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {{
   $toolName = '{tool_name}'
-  $category = '{category}'
+  $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
   $shimPath = '{shim_path}'
 
   $executablePath = Join-Path ${{Env:ChocolateyInstall}} $shimPath -Resolve
@@ -153,7 +157,7 @@ SINGLE_EXE_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 $exeUrl = '{target_url}'
 $exeSha256 = '{target_hash}'
@@ -170,7 +174,7 @@ SINGLE_PS1_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 $ps1Url = '{target_url}'
 $ps1Sha256 = '{target_hash}'
@@ -201,7 +205,7 @@ PIP_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 $version = '=={version}'
 $arguments = '{arguments}'
 
@@ -217,7 +221,7 @@ GENERIC_UNINSTALL_TEMPLATE = r"""$ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 VM-Uninstall $toolName $category
 """
@@ -230,7 +234,7 @@ METAPACKAGE_UNINSTALL_TEMPLATE = r"""$ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 VM-Remove-Tool-Shortcut $toolName $category
 """
@@ -250,7 +254,7 @@ PIP_UNINSTALL_TEMPLATE = r"""$ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = '{tool_name}'
-$category = '{category}'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 VM-Uninstall-With-Pip $toolName $category
 """
@@ -408,6 +412,7 @@ def create_template(
                 description=description,
                 dependency=dependency,
                 dependency_version = version,
+                category = category,
             )
         )
 
@@ -416,7 +421,6 @@ def create_template(
             template.format(
                 tool_name=tool_name,
                 version=version,
-                category=category,
                 arguments=arguments,
                 target_url=target_url,
                 target_hash=target_hash,
@@ -427,7 +431,7 @@ def create_template(
         )
 
     with open(os.path.join(tools_path, UNINSTALL_TEMPLATE_NAME), "w") as f:
-        f.write(uninstall_template.format(tool_name=tool_name, category=category))
+        f.write(uninstall_template.format(tool_name=tool_name))
 
 
 def get_script_directory():


### PR DESCRIPTION
The nuspec packages must contain the category and the install and uninstall scripts must obtain the category from the nuspec