### PR TITLE
Modify uninstall script of kernel-ost-viewer

### DIFF
--- a/packages/kernel-ost-viewer.vm/kernel-ost-viewer.vm.nuspec
+++ b/packages/kernel-ost-viewer.vm/kernel-ost-viewer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>kernel-ost-viewer.vm</id>
-    <version>21.1.20250218</version>
+    <version>21.1.20250220</version>
     <authors>Kernel Data Recovery</authors>
     <description>Facilitates efficient OST file recovery with features such as advanced message search, snapshot management and diverse file format saving.</description>
     <dependencies>

--- a/packages/kernel-ost-viewer.vm/tools/chocolateyuninstall.ps1
+++ b/packages/kernel-ost-viewer.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'Kernel OST Viewer'
-$category = 'Forensic'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 VM-Uninstall $toolName $category


### PR DESCRIPTION
The package failed during the update of the nuspec package. 
It retrieves the category in the uninstall script from the nuspec.