### PR TITLE
Update description of metapackage vcbuildtools.vm

### DIFF
--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,11 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20250219</version>
-    <description>Metapackage that requires the dependencies below:
-- visualstudio2017buildtools
-- visualstudio2017-workload-vctools
-</description>
+    <version>0.0.0.20250228</version>
+    <description>Metapackage that requires the dependencies visualstudio2017buildtools and visualstudio2017-workload-vctools</description>
     <authors>Mandiant, Microsoft</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />


### PR DESCRIPTION
The description contained an unordered list with -, that caused a formatting issue to display the Wiki categories