### PR TITLE
Update the ida plugin capa to version 9.0.0

### DIFF
--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.capa.vm</id>
-    <version>8.0.1.20250213</version>
+    <version>9.0.0</version>
     <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>

--- a/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.capa.vm/tools/chocolateyinstall.ps1
@@ -3,20 +3,20 @@ Import-Module vm.common -Force -DisableNameChecking
 
 try {
     # Install dependency: capa Python library
-    $version = "8.0.1"
+    $version = "9.0.0"
     VM-Pip-Install "flare-capa==$version"
 
     # Install plugin
     $pluginName = "capa_explorer.py"
     $pluginUrl = "https://raw.githubusercontent.com/mandiant/capa/v$version/capa/ida/plugin/capa_explorer.py"
-    $pluginSha256 = "bf6c9a0e5fd2c75a93bb3c19e0221c36cda441c878af3c23ea3aafef4fecf3e9"
+    $pluginSha256 = "0470f7dd693f3d974c71397a0b484ddc6a21a0ee4c971de2c2097509a093345d"
     VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256
 
 
     # Download capa rules
     $pluginsDir = VM-Get-IDA-Plugins-Dir
     $rulesUrl = "https://github.com/mandiant/capa-rules/archive/refs/tags/v$version.zip"
-    $rulesSha256 = "7c5f932b1da4e18eed50add117e7fc55c14dc51487495cb31e33e0b44c522fbc"
+    $rulesSha256 = "74f3a0fe6df6288b6292aef1360f64cf83084f9b5427dc85b462579d10c39662"
     $packageArgs = @{
         packageName    = ${Env:ChocolateyPackageName}
         unzipLocation  = $pluginsDir


### PR DESCRIPTION
Update must be done manually, tracked in
https://github.com/mandiant/VM-Packages/issues/1173
closes #1285