### PR TITLE
[CI] Enable Python linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
         with:
           # fetch all history for all branches
           fetch-depth: 0
+      - name: Install dependencies
+        run: pip install black==25.* isort==6.* flake8==7.*
+      # Different line limits: Black/isort (120), Flake8 (150).
+      # Flake8 allows longer lines for better long string readability. Black doesn't enforce string length.
+      - name: Run black
+        run: black --line-length=120 --check --diff .
+      - name: Run flake8
+        run: flake8 --max-line-length=150
+      - name: Run isort
+        run: isort --check --diff --profile black --line-length=120 .
       - name: Run lint.py
         run: python scripts/test/lint.py packages
       - name: Run lint.ps1

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -20,14 +20,14 @@ Usage:
    $ python lint.py packages/
 """
 
-import os
-import sys
-import logging
-import pathlib
 import argparse
 import datetime
-import subprocess
+import logging
+import os
+import pathlib
 import re
+import subprocess
+import sys
 from typing import Dict
 from xml.dom import minidom
 
@@ -272,10 +272,9 @@ class PackageIdNotMatchingFolderOrNuspecName(Lint):
         nuspec = path.parts[-1]
         folder = path.parts[-2]
 
-        return not (pkg_id == folder == nuspec[:-len(".nuspec")])
-        
-        
-        
+        return not (pkg_id == folder == nuspec[: -len(".nuspec")])
+
+
 class UsesInvalidCategory(Lint):
     # The common.vm, debloat.vm, and installer.vm packages are special as they
     # assist with the installation and allow to share code between packages.
@@ -293,8 +292,8 @@ class UsesInvalidCategory(Lint):
         CATEGORIES = [line.rstrip() for line in file]
         logger.debug(CATEGORIES)
 
-    name = "Uses an invalid category"
-    recommendation = f"Place a category between <tags> and </tags> from {categories_txt} or exclude the package in the linter"
+    name = "uses an invalid category"
+    recommendation = f"use a category from {categories_txt} between <tags> and </tags>"
 
     def check(self, path):
         if any([exclusion in str(path) for exclusion in self.EXCLUSIONS]):
@@ -307,6 +306,7 @@ class UsesInvalidCategory(Lint):
         if not match or match.group("category") not in self.CATEGORIES:
             return True
         return False
+
 
 NUSPEC_LINTS = (
     IncludesRequiredFieldsOnly(),
@@ -382,21 +382,19 @@ class UsesCategoryFromNuspec(Lint):
         "dcode.vm",
     ]
 
-    
-
     name = "Doesn't use the function VM-Get-Category"
-    recommendation = f"Set '$category = VM-Get-Category($MyInvocation.MyCommand.Definition)' or exclude the package in the linter"
+    recommendation = "Set '$category = VM-Get-Category($MyInvocation.MyCommand.Definition)'"
 
     def check(self, path):
         if any([exclusion in str(path) for exclusion in self.EXCLUSIONS]):
             return False
-        
+
         # utf-8-sig ignores BOM
         file_content = open(path, "r", encoding="utf-8-sig").read()
 
         pattern = re.escape("$category = VM-Get-Category($MyInvocation.MyCommand.Definition)")
         match = re.search(pattern, file_content)
-        if not match: 
+        if not match:
             return True
         return False
 

--- a/scripts/utils/compare_myget.py
+++ b/scripts/utils/compare_myget.py
@@ -5,18 +5,19 @@ import re
 log_file = "wiki/MyGet-Version-Mismatches.md"
 source = "https://www.myget.org/F/vm-packages/api/v2"
 
+
 # Convert 1.02.0 to 1.2 to ensure we compare versions consistency
 def format_version(version):
-    version = re.sub("\.0(?P<digit>\d)", lambda x: f".{x.group('digit')}", version)
-    return re.sub("(\.0+)+$", "", version)
+    version = re.sub(r"\.0(?P<digit>\d)", lambda x: f".{x.group('digit')}", version)
+    return re.sub(r"(\.0+)+$", "", version)
 
 
 def get_remote_version(package_name):
     stream = os.popen(f"powershell.exe choco find -er {package_name} -s {source}")
     output = stream.read()
-    m = re.search(f"^{package_name}\|(?P<version>.+)", output, re.M)
+    m = re.search(rf"^{package_name}\|(?P<version>.+)", output, re.M)
     if not m:
-        return ''
+        return ""
     return m.group("version")
 
 
@@ -31,7 +32,7 @@ for nuspec in nuspecs:
     m = re.search("<id>(?P<name>[^<]+)</id>", nuspec_content)
     m2 = re.search("<version>(?P<version>[^<]+)</version>", nuspec_content)
 
-    if (m and m2):
+    if m and m2:
         name = m.group("name")
         local_version = m2.group("version")
         my_get_version = get_remote_version(name)
@@ -45,9 +46,10 @@ else:
     W1 = 40
     W2 = 25
     log_f.write("The following packages local version do not match the latest version in MyGet.\n\n")
-    log_f.write(f"| {'Package Name'.ljust(W1)} | {'MyGet version'.ljust(W2)} | {'Local version'.ljust(W2)} |\n|-|-|-|\n")
+    log_f.write(
+        f"| {'Package Name'.ljust(W1)} | {'MyGet version'.ljust(W2)} | {'Local version'.ljust(W2)} |\n|-|-|-|\n"
+    )
     for mismatch in mismatches:
         log_f.write(f"| {mismatch[0].ljust(W1)} | {mismatch[1].rjust(W2)} | {mismatch[2].rjust(W2)} |\n")
 
 print(len(mismatches))
-

--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -1,7 +1,7 @@
+import argparse
+import logging
 import os
 import sys
-import logging
-import argparse
 import textwrap
 import time
 
@@ -15,9 +15,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-root_path = os.path.abspath(os.path.join(__file__ ,"../../.."))
+root_path = os.path.abspath(os.path.join(__file__, "../../.."))
 with open(f"{root_path}/categories.txt") as file:
     CATEGORIES = [line.rstrip() for line in file]
+
 
 # If the dependency/tool's version uses the 4th segment, update the package's
 # version to use the current date (YYYYMMDD) in the 4th segment
@@ -25,8 +26,9 @@ def package_version(dependency_version):
     version_segments = dependency_version.split(".")
     if len(version_segments) < 4:
         return dependency_version
-    version_segments[3] =  time.strftime("%Y%m%d")
+    version_segments[3] = time.strftime("%Y%m%d")
     return ".".join(version_segments[:4])
+
 
 UNINSTALL_TEMPLATE_NAME = "chocolateyuninstall.ps1"
 INSTALL_TEMPLATE_NAME = "chocolateyinstall.ps1"
@@ -260,7 +262,6 @@ VM-Uninstall-With-Pip $toolName $category
 """
 
 
-
 def create_zip_exe_template(packages_path, **kwargs):
     create_template(
         ZIP_EXE_TEMPLATE,
@@ -356,7 +357,8 @@ def create_ida_plugin_template(packages_path, **kwargs):
         target_url=kwargs.get("target_url"),
         target_hash=kwargs.get("target_hash"),
     )
-    
+
+
 def create_pip_template(packages_path, **kwargs):
     create_template(
         PIP_TEMPLATE,
@@ -371,6 +373,7 @@ def create_pip_template(packages_path, **kwargs):
         category=kwargs.get("category"),
         arguments=kwargs.get("arguments"),
     )
+
 
 def create_template(
     template="",
@@ -394,13 +397,13 @@ def create_template(
     pkg_path = os.path.join(packages_path, f"{pkg_name}.vm")
     try:
         os.makedirs(pkg_path)
-    except:
+    except FileExistsError:
         logger.debug(f"Directory already exists: {pkg_path}")
 
     tools_path = os.path.join(pkg_path, "tools")
     try:
         os.makedirs(tools_path)
-    except:
+    except FileExistsError:
         logger.debug(f"Directory already exists: {tools_path}")
 
     with open(os.path.join(pkg_path, NUSPEC_TEMPLATE_NAME.format(pkg_name)), "w") as f:
@@ -411,8 +414,8 @@ def create_template(
                 authors=authors,
                 description=description,
                 dependency=dependency,
-                dependency_version = version,
-                category = category,
+                dependency_version=version,
+                category=category,
             )
         )
 
@@ -426,7 +429,7 @@ def create_template(
                 target_hash=target_hash,
                 shim_path=shim_path,
                 console_app=console_app,
-                inner_folder=inner_folder
+                inner_folder=inner_folder,
             )
         )
 
@@ -605,20 +608,43 @@ def main(argv=None):
         nargs="?",
         help="Installation template type, see descriptions via %(prog)s --type",
     )
-    parser.add_argument("--raw", action="store_true", help="Create package files like .nuspec with raw placeholder data")
-    parser.add_argument("--pkg_name", type=str.lower, default="", help="Package name without suffix (i.e., no '.vm' needed)")
+    parser.add_argument(
+        "--raw", action="store_true", help="Create package files like .nuspec with raw placeholder data"
+    )
+    parser.add_argument(
+        "--pkg_name", type=str.lower, default="", help="Package name without suffix (i.e., no '.vm' needed)"
+    )
     parser.add_argument("--version", type=str, default="", help="Tool's version number")
     parser.add_argument("--authors", type=str, default="", help="Comma separated list of authors for tool")
-    parser.add_argument("--tool_name", type=str, default="", help="Name of tool (usually the file name with the '.exe') or plugin (the .py or .dll plugin file)")
+    parser.add_argument(
+        "--tool_name",
+        type=str,
+        default="",
+        help="Name of tool (usually the file name with the '.exe') or plugin (the .py or .dll plugin file)",
+    )
     parser.add_argument("--category", type=str, default="", choices=CATEGORIES, help="Category for tool")
     parser.add_argument("--description", type=str, default="", help="Description for tool")
     parser.add_argument("--dependency", type=str, default="", help="Metapackage dependency")
     parser.add_argument("--target_url", type=str, default="", help="URL to target file (zip or executable)")
     parser.add_argument("--target_hash", type=str, default="", help="SHA256 hash of target file (zip or executable)")
     parser.add_argument("--shim_path", type=str, default="", help="Metapackage shim path")
-    parser.add_argument("--console_app", type=str, default="false", choices=["false", "true"],  help="The tool is a console application, the shortcut should run it with `cmd /K $toolPath --help` to be able to see the output.")
-    parser.add_argument("--inner_folder", type=str, default="false", choices=["false", "true"],  help="The ZIP file unzip to a single folder that contains all the tools.")
-    parser.add_argument("--arguments", type=str, required=False, default="", help="Command-line arguments for the execution")
+    parser.add_argument(
+        "--console_app",
+        type=str,
+        default="false",
+        choices=["false", "true"],
+        help="The tool is a console application, the shortcut should run it with `cmd /K $toolPath --help` to be able to see the output.",
+    )
+    parser.add_argument(
+        "--inner_folder",
+        type=str,
+        default="false",
+        choices=["false", "true"],
+        help="The ZIP file unzip to a single folder that contains all the tools.",
+    )
+    parser.add_argument(
+        "--arguments", type=str, required=False, default="", help="Command-line arguments for the execution"
+    )
     args = parser.parse_args(args=argv)
 
     if args.type is None:

--- a/scripts/utils/create_package_template_from_json.py
+++ b/scripts/utils/create_package_template_from_json.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import json
 import argparse
+import json
 
 import create_package_template
 
@@ -25,7 +25,7 @@ def main():
     for k, v in pkg.items():
         if k in ("why", "dependencies", "info"):
             continue
-        # Use "--argument=<value>" format to avoid issues with if the value contains "-" 
+        # Use "--argument=<value>" format to avoid issues with if the value contains "-"
         cmd_args.append(f"--{k}={v}")
 
     create_package_template.main(cmd_args)

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -4,7 +4,6 @@ import pathlib
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 
-
 # Dict[str (category), Dict[str (pkg_name, pkg_description)]]
 packages_by_category = defaultdict(dict)
 
@@ -27,7 +26,7 @@ This page is [generated automatically](https://github.com/mandiant/VM-Packages/b
 Do not edit it manually.\n
 """
     for category, packages in sorted(packages_by_category.items()):
-        wikiContent += f"## {category }\n\n"
+        wikiContent += f"## {category}\n\n"
         wikiContent += "| Package | Description |\n"
         wikiContent += "| ------- | ----------- |\n"
         for pkg_name, pkg_description in sorted(packages.items()):


### PR DESCRIPTION
Enable Python linters and format checkers as in FLARE-VM: 
- https://github.com/mandiant/flare-vm/blob/main/.github/workflows/linter.yml

Fix offenses detected by the linters. isort and black were used to solve their offenses. The flake8 offenses were fixed manually. Because of that I would appreciate a thoughtful review to ensure I haven't introduced any bug.