### PR TITLE
Add category in dcode to the nuspec package

### DIFF
--- a/packages/dcode.vm/dcode.vm.nuspec
+++ b/packages/dcode.vm/dcode.vm.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dcode.vm</id>
-    <version>5.6.24123.20240507</version>
+    <version>5.6.24123.20250408</version>
     <authors>Digital Detective Group</authors>
     <description>Utility for converting data found on desktop and mobile devices into human-readable timestamps.</description>
     <dependencies>
       <dependency id="common.vm" />
     </dependencies>
+    <tags>Forensic</tags>
   </metadata>
 </package>

--- a/packages/dcode.vm/tools/chocolateyinstall.ps1
+++ b/packages/dcode.vm/tools/chocolateyinstall.ps1
@@ -2,7 +2,7 @@ $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DCode'
-$category = 'Forensic'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 $url = 'https://www.digital-detective.net/download/download.php?downcode=ae2znu5994j1lforlh03'
 $sha256 = '9ffe1106ee9d9f55b53d5707621d5990f493604e20f3dbdb0d22ec1b8ecb2458'

--- a/packages/dcode.vm/tools/chocolateyuninstall.ps1
+++ b/packages/dcode.vm/tools/chocolateyuninstall.ps1
@@ -2,6 +2,6 @@ $ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $toolName = 'DCode'
-$category = 'Forensic'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
 VM-Uninstall $toolName $category


### PR DESCRIPTION
Package has been fixed therefore we can apply the changes such as adding the category to the nuspec and remove it from the install scripts.
linter updated in #1337