### PR TITLE
Update arsenalimagemounter.vm to 3.11.306

### DIFF
--- a/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
+++ b/packages/arsenalimagemounter.vm/arsenalimagemounter.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>arsenalimagemounter.vm</id>
-    <version>3.11.293.20250219</version>
+    <version>3.11.306</version>
     <authors>Arsenal Recon</authors>
     <description>Mounts the contents of disk images as complete disks in Windows.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="dotnet-8.vm" />
-      <dependency id="arsenalimagemounter" version="[3.11.293.1]" />
+      <dependency id="dotnet-9.vm" />
+      <dependency id="arsenalimagemounter" version="[3.11.306]" />
       <dependency id="dokan.vm" />
     </dependencies>
     <tags>Forensic</tags>

--- a/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
+++ b/packages/arsenalimagemounter.vm/tools/chocolateyinstall.ps1
@@ -5,13 +5,13 @@ try {
   ###################################
   # Install of drivers dependencies #
   ###################################
-  $zipCliUrl = 'https://github.com/ArsenalRecon/Arsenal-Image-Mounter/raw/master/Command%20line%20applications/aim_ll.zip'
-  $zipCliSha256 = '21c32aed320eca532969590b67dc8151bddd6aebe9699abd09cc3e026fd01a29'
+  $zipCliUrl = 'https://github.com/ArsenalRecon/Arsenal-Image-Mounter/raw/5961f922c5b99ec29acc4af4b60b909b402eed95/Command%20line%20applications/aim_ll.zip'
+  $zipCliSha256 = 'a628fd0bb4b1657b2b89fd8972937b4d9c4b1292ea16764208fa63fc0ce84d54'
   $tempCliDownloadDir = Join-Path ${Env:chocolateyPackageFolder} "aim_ll"
   $toolCli = "aim_ll.exe"
 
-  $zipDriverUrl = 'https://github.com/ArsenalRecon/Arsenal-Image-Mounter/raw/63801fc2b51f899244e43f1bf5275d2ac92a2477/DriverSetup/DriverFiles.zip'
-  $zipDriverSha256 = 'c5de8e5d5a2c0231baf2cdb74fb0b0f4047658c69105bcab28990734b3979ee3'
+  $zipDriverUrl = 'https://github.com/ArsenalRecon/Arsenal-Image-Mounter/raw/5961f922c5b99ec29acc4af4b60b909b402eed95/DriverSetup/DriverFiles.zip'
+  $zipDriverSha256 = 'cc03472b689f23b1c66d1764b7a12e7212146b5c1f70e2613666efcd93b97192'
   $tempDriverDownloadDir = Join-Path ${Env:TEMP} "temp_$([guid]::NewGuid())"
 
   $packageArgs = @{

--- a/packages/dotnet-9.vm/dotnet-9.vm.nuspec
+++ b/packages/dotnet-9.vm/dotnet-9.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>dotnet-9.vm</id>
+    <version>0.0.0.20250411</version>
+    <authors>Microsoft</authors>
+    <description>Metapackage for .NET9 to ensure all packages use the same version.</description>
+    <dependencies>
+      <dependency id="common.vm"  version="0.0.0.20250206" />
+      <dependency id="dotnet-9.0-desktopruntime" version="[9, 9.1)" />
+    </dependencies>
+    <tags>dotNet</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Fix CI and update packages to 3.11.306. Using commit ID should prevent other CI fail in the future.