### PR TITLE
Add broken hash fix automation

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -26,8 +26,8 @@ jobs:
           foreach ($packagePath in (Get-ChildItem packages)){
             $package = $packagePath.Name
             $newVersion = 0
-            # Test indepdendly every type of update and commit what works
-            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL')) {
+            # Test independently every type of update and commit what works
+            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL', 'DYNAMIC_URL')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
               echo "$package $version"
@@ -39,6 +39,8 @@ jobs:
                 if ($tested) {
                   git add "packages/$package/"
                   $newVersion = $version
+                  # Save the update type to use it in the commit
+                  $finalUpdateType = $UPDATE_TYPE
                 } else {
                   echo "$package $version FAILED"
                   git diff
@@ -49,7 +51,12 @@ jobs:
               Remove-Item built_pkgs -Recurse -ErrorAction Ignore
             }
             if ($newVersion) {
+              if ($finalUpdateType -eq 'DYNAMIC_URL') {
+                git commit -m "Fix broken hash in $package"
+              }
+              else {
               git commit -m "Update $package to $newVersion"
+              }
             }
           }
           Exit(0)

--- a/packages/mftecmd.vm/mftecmd.vm.nuspec
+++ b/packages/mftecmd.vm/mftecmd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>mftecmd.vm</id>
-    <version>1.3.0.20250219</version>
+    <version>0.0.0.20250219</version>
     <authors>Eric Zimmerman</authors>
     <description>$MFT, $Boot, $J, $SDS, $I30, and $LogFile (coming soon) parser. Handles locked files</description>
     <dependencies>


### PR DESCRIPTION
related to https://github.com/mandiant/VM-Packages/issues/1270
Changes made -
- added a workflow that can be manually dispatched to find broken hashes and create PR. 👍 
- added DYNAMIC_URL functionality in the update_package.py that is invoked by the above workflow 👍 
- made changes to pestudio.vm to create a test case for the workflow. After PR merge, we can execute the workflow manually to test if pestudio.vm broken hash can be captured. 👍 
- made changes to mftecmd.vm to check the workflow but there is failure, the cause is still unknown to me. 👎 

I have tested the workflow by introducing some changes in pestudio.vm, it works fine.
![image](https://github.com/user-attachments/assets/03ddba4f-a56f-417a-beec-378c67ece2a1)
The workflow is also creating the PR as required. (the PR is created by bot, but PR creation name is coming as me, that I am not sure how to change)
![image](https://github.com/user-attachments/assets/0a01d5d5-c79e-4bbe-accf-bdf07d5a484c)

I also tested the workflow with mftecmd.vm but I am not sure why it is failing. I have done this testing in my own personal Github fork of this repository.
Workflow logs - 
![image](https://github.com/user-attachments/assets/2bfe9035-3420-4d84-8f7a-37eaa1de704b)
git diff shows hash and version change, but the workflow logs state that failure is due to wrong hash and it is showing the older hash not the newer hash.
![image](https://github.com/user-attachments/assets/30f4688a-a351-4b9d-baef-0dc4db4a1f94)

Closes https://github.com/mandiant/VM-Packages/issues/1270