### PR TITLE
Add new PIP package keystone-engine

### DIFF
--- a/packages/keystone.vm/keystone.vm.nuspec
+++ b/packages/keystone.vm/keystone.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>keystone.vm</id>
+    <version>0.9.2</version>
+    <authors>Nguyen Anh Quynh</authors>
+    <description>Keystone is a Python library providing a multi-platform, multi-architecture assembler.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20250407" />
+      <dependency id="python3.vm" />
+    </dependencies>
+    <tags>Utilities</tags>
+  </metadata>
+</package>

--- a/packages/keystone.vm/tools/chocolateyinstall.ps1
+++ b/packages/keystone.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'keystone-engine'
+$version = '==0.9.2'
+
+VM-Pip-Install $toolName$version

--- a/packages/keystone.vm/tools/chocolateyuninstall.ps1
+++ b/packages/keystone.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'keystone-engine'
+
+VM-Pip-Uninstall $toolName

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -376,6 +376,7 @@ class UsesCategoryFromNuspec(Lint):
         "x64dbgpy.vm",
         "vscode.extension.",
         "chrome.extensions.vm",
+        "keystone.vm",
     ]
 
     name = "Doesn't use the function VM-Get-Category"


### PR DESCRIPTION
The framework keystone-engine does not have a cli or tool exposed therefore no shorcut is needed in the Tools directory.
closes #1264