### PR TITLE
[CI] Update Ubuntu version in action

### DIFF
--- a/.github/workflows/sync_badge.yml
+++ b/.github/workflows/sync_badge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_badge:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
ubuntu-20.04 has been deprecated causing our sync badge action to fail: https://github.com/actions/runner-images/issues/11101