### PR TITLE
Update msixbundle related packages

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -27,7 +27,7 @@ jobs:
             $package = $packagePath.Name
             $newVersion = 0
             # Test independently every type of update and commit what works
-            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL', 'DYNAMIC_URL')) {
+            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL', 'DYNAMIC_URL', 'MSIXBUNDLE_URL')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
               echo "$package $version"

--- a/packages/windbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/windbg.vm/tools/chocolateyinstall.ps1
@@ -5,8 +5,7 @@ try {
     $toolName = 'WinDbg'
     $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-    $bundleVersion = "1-2502-25002"
-    $bundleUrl = "https://windbg.download.prss.microsoft.com/dbazure/prod/$bundleVersion-0/windbg.msixbundle"
+    $bundleUrl = "https://windbg.download.prss.microsoft.com/dbazure/prod/1-2502-25002-0/windbg.msixbundle"
     $bundleSha256 = "2802c9da1eccdfd488d1364aa601170d44dc37e2c8354be514f5f5a40c9cfcda"
 
     $packageArgs = @{

--- a/packages/windbg.vm/windbg.vm.nuspec
+++ b/packages/windbg.vm/windbg.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>windbg.vm</id>
-    <version>1.2502.25002.20250411</version>
+    <version>1.2502.25002.20250422</version>
     <authors>Microsoft</authors>
     <description>WinDbg is a debugger that can be used to analyze crash dumps, debug live user-mode and kernel-mode code, and examine CPU registers and memory.</description>
     <dependencies>


### PR DESCRIPTION
This is to fix #1331

Tested using `ttd.vm`:

```
python3 scripts/utils/update_package.py ttd.vm
1-11-481-0
```

The script will update `ttd.vm.nuspec` and `chocolateyinstall.ps1` with latest version, uri and sha256.

```diff
diff --git a/packages/ttd.vm/ttd.vm.nuspec b/packages/ttd.vm/ttd.vm.nuspec
index adb84eb..a3f2eca 100644
--- a/packages/ttd.vm/ttd.vm.nuspec
+++ b/packages/ttd.vm/ttd.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ttd.vm</id>
-    <version>1.11.319.20250219</version>
+    <version>1.11.481</version>
     <authors>Microsoft</authors>
     <description>Time travel debugging command line utility.</description>
     <dependencies>
```

```diff
diff --git a/packages/ttd.vm/tools/chocolateyinstall.ps1 b/packages/ttd.vm/tools/chocolateyinstall.ps1
index 961d15b..c197e3b 100644
--- a/packages/ttd.vm/tools/chocolateyinstall.ps1
+++ b/packages/ttd.vm/tools/chocolateyinstall.ps1
@@ -6,8 +6,8 @@ try {
     $category = VM-Get-Category($MyInvocation.MyCommand.Definition)

     # From https://aka.ms/ttd/download
-    $bundleUrl = "https://windbg.download.prss.microsoft.com/dbazure/prod/1-11-319-0/TTD.msixbundle"
-    $bundleSha256 = "f7b80731c3a6994b3763c4100073b101965327d6556fa4bfb553d70ce49be366"
+    $bundleUrl = "https://windbg.download.prss.microsoft.com/dbazure/prod/1-11-481-0/TTD.msixbundle"
+    $bundleSha256 = "1216e4516b2e43047c65558b8df90d31a3d02f358da82b379842625860ab105b"

     $packageArgs = @{
         packageName   = ${Env:ChocolateyPackageName}
```

sha256sum verified correctly:
```
curl -sL https://windbg.download.prss.microsoft.com/dbazure/prod/1-11-481-0/TTD.msixbundle | sha256sum
1216e4516b2e43047c65558b8df90d31a3d02f358da82b379842625860ab105b
```