### PR TITLE
Update autopsy.vm to 4.22.1

### DIFF
--- a/packages/autopsy.vm/autopsy.vm.nuspec
+++ b/packages/autopsy.vm/autopsy.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>autopsy.vm</id>
-    <version>4.21.0.20250402</version>
+    <version>4.22.1</version>
     <authors>The Sleuth Kit</authors>
     <description>Autopsy is a graphical interface to The Sleuth Kit and other open source digital forensics tools.</description>
     <dependencies>

--- a/packages/autopsy.vm/tools/chocolateyinstall.ps1
+++ b/packages/autopsy.vm/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'Autopsy'
 $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-$exeUrl = "https://github.com/sleuthkit/autopsy/releases/download/autopsy-4.22.0/autopsy-4.22.0-64bit.msi"
-$exeSha256 = '3071d1f92402fba84329cee59680cf940bdbec0d5ad8470655dc8f9ae0b93610'
+$exeUrl = "https://github.com/sleuthkit/autopsy/releases/download/autopsy-4.22.1/autopsy-4.22.1-64bit.msi"
+$exeSha256 = '371897fbc40786e1e263391a226ef3c3622462234601268e3118fd3d3ce97521'
 
 $toolDir = Join-Path ${Env:ProgramFiles} $toolName
 $executablePath = Join-Path $toolDir "bin\autopsy64.exe"


### PR DESCRIPTION
Manual update of autopsy to version 4.22.1, package gets updated by the script `package_update.py`, however the version in the nuspec file and the commit messages are not correct.
Created #1367 to investigate
tested locally