### PR TITLE
Improve shortcut creation in visualstudio.vm and microsoft-office.vm

### DIFF
--- a/packages/microsoft-office.vm/microsoft-office.vm.nuspec
+++ b/packages/microsoft-office.vm/microsoft-office.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-office.vm</id>
-    <version>0.0.0.20250218</version>
+    <version>0.0.0.20250423</version>
     <description>Microsoft Office ProPlus2024Retail.</description>
     <authors>Microsoft</authors>
     <dependencies>

--- a/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
+++ b/packages/microsoft-office.vm/tools/chocolateyinstall.ps1
@@ -9,7 +9,6 @@ try {
         @{name = 'OneNote'; executable = 'ONENOTE.EXE'}
     )
     $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
-    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
 
     # Install with choco instead as dependency to provide params such the product
     choco install microsoft-office-deployment --params="'/DisableUpdate:TRUE  /Product:ProPlus2024Retail'" --no-progress
@@ -20,9 +19,7 @@ try {
     # Ensure the tools are installed and create shortcuts
     forEach ($tool in $tools) {
         $executablePath = Join-Path $officeDirectory $($tool.executable) -Resolve
-        $shortcut = Join-Path $shortcutDir "$($tool.name).lnk"
-        Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-        VM-Assert-Path $shortcut
+        VM-Install-Shortcut -toolName $tool.name -category $category -executablePath $executablePath
     }
 } catch {
     VM-Write-Log-Exception $_

--- a/packages/visualstudio.vm/tools/chocolateyinstall.ps1
+++ b/packages/visualstudio.vm/tools/chocolateyinstall.ps1
@@ -12,10 +12,7 @@ try {
     choco install visualstudio2022community --params "--add Microsoft.VisualStudio.Component.CoreEditor --add Microsoft.VisualStudio.Workload.NativeDesktop --add Microsoft.VisualStudio.Workload.ManagedDesktop --includeRecommended" --execution-timeout 6000 --no-progress
 
     $executablePath = Join-Path ${Env:ProgramFiles} "Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe" -Resolve
-    $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
-    $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath
-    VM-Assert-Path $shortcut
+    VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath
 
     # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
     VM-Refresh-Desktop

--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1.20250219</version>
-    <description>IDE.</description>
+    <version>17.6.1.20250423</version>
+    <description>Visual Studio is an IDE, installed with useful components and workloads.</description>
     <authors>Microsoft</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />


### PR DESCRIPTION
Use the `VM-Install-Shortcut` helper function to create the Visual Studio shortcut simplifying the code.
 
This hopefully fixes the issues in https://github.com/mandiant/flare-vm/pull/660#issuecomment-2657169466 and closes https://github.com/mandiant/VM-Packages/issues/1371, but I need to do some more testing to verify this. This is a nice enhancement even if it does not fix the issues.