### PR TITLE
[debloat.vm] Disable Office key

### DIFF
--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>debloat.vm</id>
-    <version>0.0.0.20250407</version>
+    <version>0.0.0.20250423</version>
     <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -140,6 +140,7 @@
         <registry-item name="Disable Windows Update Automatic Download" path="HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" value="AUOptions" type="DWord" data="2" />
         <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
         <registry-item name="Disable Microsoft Connectivity Test (msftconnecttest.com)" path="HKLM:\SYSTEM\CurrentControlSet\services\NlaSvc\Parameters\Internet" value="EnableActiveProbing" type="DWord" data="0" />
+        <registry-item name="Disable key to open Office application (as it conflicts with Hyper key set)" path="HKCU:\SOFTWARE\Classes\ms-officeapp\Shell\Open\Command" value="(Default)" type="String" data="rundll32" />
     </registry-items>
     <path-items>
         <!--


### PR DESCRIPTION
Add registry item to the Windows 10 debloat configuration to disable the key to open Office application as it conflicts with Hyper key set.

Closes https://github.com/mandiant/flare-vm/issues/519.

I have only added it in Windows 10. @binjo do you know if this work in Windows 11 as well? @mandiant/vms can someone test it? I do not have a Windows 11 VM set up at the moment.