### PR TITLE
Re-try package installation on failure

### DIFF
--- a/packages/installer.vm/installer.vm.nuspec
+++ b/packages/installer.vm/installer.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>installer.vm</id>
-    <version>0.0.0.20250207</version>
+    <version>0.0.0.20250424</version>
     <authors>Mandiant</authors>
     <description>Generic installer for custom virtual machines.</description>
     <dependencies>

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -2,6 +2,46 @@ $ErrorActionPreference = 'Continue'
 $global:VerbosePreference = "SilentlyContinue"
 Import-Module vm.common -Force -DisableNameChecking
 
+# Get the names of the packages that failed to install as an array of strings
+function Get-Failed-Packages() {
+    $failedPackages = @{}
+
+    # Check and list failed packages from "lib-bad"
+    $chocoLibBad = Join-Path ${Env:ProgramData} "chocolatey\lib-bad"
+    if ((Test-Path $chocoLibBad) -and (Get-ChildItem -Path $chocoLibBad | Measure-Object).Count -gt 0) {
+        Get-ChildItem -Path $chocoLibBad | Foreach-Object {
+            $failedPackages[$_.Name] = $true
+        }
+    }
+
+    # Cross-compare packages to install versus installed packages to find failed packages
+    $installedPackages = VM-Get-InstalledPackages
+    foreach ($package in $packagesToInstall) {
+        if ($installedPackages.Name -notcontains $package) {
+            $failedPackages[$package] = $true
+        }
+    }
+
+    [string[]] $failedPackages.Keys
+}
+
+# Install the packages provided as parameter, displaying log information
+function Install-Packages([object] $packagesToInstall) {
+    try {
+        foreach ($package in $packagesToInstall) {
+            VM-Write-Log "INFO" "Installing: $package"
+            choco install "$package" -y
+            if ($LASTEXITCODE) {
+              VM-Write-Log "ERROR" "`t$package has not been installed"
+            } else {
+              VM-Write-Log "INFO" "`t$package has been installed"
+            }
+        }
+    } catch {
+        VM-Write-Log-Exception $_
+    }
+}
+
 try {
     # Gather packages to install
     $installedPackages = (VM-Get-InstalledPackages).Name
@@ -17,19 +57,15 @@ try {
     Start-Sleep 1
 
     # Install the packages
-    try {
-        foreach ($package in $packagesToInstall) {
-            VM-Write-Log "INFO" "Installing: $package"
-            choco install "$package" -y
-            if ($LASTEXITCODE) {
-              VM-Write-Log "ERROR" "`t$package has not been installed"
-            } else {
-              VM-Write-Log "INFO" "`t$package has been installed"
-            }
-        }
-    } catch {
-        VM-Write-Log-Exception $_
+    Install-Packages($packagesToInstall)
+
+    # Re-install failed packages
+    $failedPackages = Get-Failed-Packages
+    if ($failedPackages) {
+      VM-Write-Log "WARN" "`nReinstalling failed packages: $failedPackages`n"
+      Install-Packages($failedPackages)
     }
+
     VM-Write-Log "INFO" "Packages installation complete"
 
     # Set Profile/Version specific configurations
@@ -69,48 +105,31 @@ try {
                 Start-Process "attrib" -ArgumentList " +h +s $desktopIniPath" -Wait
             }
     }
+
     # Refresh the desktop
     VM-Refresh-Desktop
 
-    # Remove Chocolatey cache
+    # Remove Chocolatey cache folder
     $cache = "${Env:LocalAppData}\ChocoCache"
     Remove-Item $cache -Recurse -Force
-
-    # Construct failed packages file path and create the file
-    $failedPackages = Join-Path $Env:VM_COMMON_DIR "failed_packages.txt"
-    New-Item $failedPackages
-    $failures = @{}
-
-    # Check and list failed packages from "lib-bad"
-    $chocoLibBad = Join-Path ${Env:ProgramData} "chocolatey\lib-bad"
-    if ((Test-Path $chocoLibBad) -and (Get-ChildItem -Path $chocoLibBad | Measure-Object).Count -gt 0) {
-        Get-ChildItem -Path $chocoLibBad | Foreach-Object {
-            $failures[$_.Name] = $true
-        }
-    }
-
-    # Cross-compare packages to install versus installed packages to find failed packages
-    $installedPackages = VM-Get-InstalledPackages
-    foreach ($package in $packagesToInstall) {
-        if ($installedPackages.Name -notcontains $package) {
-            $failures[$package] = $true
-        }
-    }
 
     # Write installed packages to log file
     foreach ($package in $installedPackages){
         VM-Write-Log "INFO" "Package installed:  $($package.Name) | $($package.Version)"
     }
 
-    # Write each failed package to failure file
-    foreach ($package in $failures.Keys) {
-        VM-Write-Log "ERROR" "Failed to install: $package"
-        Add-Content $failedPackages $package
-    }
+    # Write failed packages to file. Always create this file even if there are no failed packages,
+    # as we use it in FLARE-VM unattended installation to check if the installation has finished.
+    $failedPackagesFile = Join-Path $Env:VM_COMMON_DIR "failed_packages.txt"
+    New-Item $failedPackagesFile
 
-    # Log additional info if we found failed packages
-    $logPath = Join-Path ${Env:VM_COMMON_DIR} "log.txt"
-    if ($failures.Count -gt 0) {
+    $failedPackages = Get-Failed-Packages
+    if ($failedPackages) {
+        foreach ($package in $failedPackages) {
+            VM-Write-Log "ERROR" "Failed to install: $package"
+            Add-Content $failedPackagesFile $package
+        }
+
         VM-Write-Log "ERROR" "For each failed package, you may attempt a manual install via: choco install -y <package_name>"
         VM-Write-Log "ERROR" "Failed package list saved to: $failedPackages"
         VM-Write-Log "ERROR" "Please check the following logs for additional errors:"
@@ -120,6 +139,7 @@ try {
     }
 
     # Display installer log if available
+    $logPath = Join-Path ${Env:VM_COMMON_DIR} "log.txt"
     if ((Test-Path $logPath)) {
         Write-Host "[-] Please check the following logs for any errors:" -ForegroundColor Yellow
         Write-Host "`t[-] $logPath" -ForegroundColor Yellow

--- a/packages/installer.vm/tools/chocolateyinstall.ps1
+++ b/packages/installer.vm/tools/chocolateyinstall.ps1
@@ -110,7 +110,7 @@ try {
 
     # Log additional info if we found failed packages
     $logPath = Join-Path ${Env:VM_COMMON_DIR} "log.txt"
-    if ((Test-Path $failedPackages)) {
+    if ($failures.Count -gt 0) {
         VM-Write-Log "ERROR" "For each failed package, you may attempt a manual install via: choco install -y <package_name>"
         VM-Write-Log "ERROR" "Failed package list saved to: $failedPackages"
         VM-Write-Log "ERROR" "Please check the following logs for additional errors:"


### PR DESCRIPTION
Try to install failed packages after completing all packages installation. This way packages have more chances to get installed,
facilitating automated FLARE-VM installations (without manual interaction).

Introduces the functions `Get-Failed-Packages` and `Install-Packages` to avoid duplicating code.

In addition, this PR also fixes a bug introduced in PR https://github.com/mandiant/VM-Packages/pull/1274 where we started to always create `failed_packages.txt` to signal installation completion for automation. It also inadvertently caused the installer to always log additional failure information, regardless of actual package failures, because of checking for the existence of the (now always present) file. The detailed failure messages are now only displayed when one or more packages have failed to install.

Closes https://github.com/mandiant/VM-Packages/issues/1219.

@mandiant/vms I would appreciate a review if anyone has time, as any error in the installer breaks Commando-VM and FLARE-VM. I have tested locally, but an extra pair of :eyes: would be good.