### PR TITLE
[garbageman] Fix dependency

### DIFF
--- a/packages/garbageman.vm/garbageman.vm.nuspec
+++ b/packages/garbageman.vm/garbageman.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>garbageman.vm</id>
-    <version>0.2.4.20250219</version>
+    <version>0.2.4.20250425</version>
     <authors>alphillips-lab</authors>
     <description>A set of tools designed for .NET heap analysis.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="dotnet5-desktop-runtime" version="5.0.6" />
+      <dependency id="dotnet-5.0-desktopruntime" />
     </dependencies>
     <tags>dotNet</tags>
   </metadata>


### PR DESCRIPTION
dotnet5-desktop-runtime community package is not available anymore, breaking the package. Replace it with dotnet-5.0-desktopruntime.

I have tested locally and the tool installs and starts correctly. But I am not sure if it works as expected. Does someone know a good way to test it? :confused: 

Closes https://github.com/mandiant/VM-Packages/issues/1383