### PR TITLE
[internet_detector] Fix: Install dependency

### DIFF
--- a/packages/internet_detector.vm/internet_detector.vm.nuspec
+++ b/packages/internet_detector.vm/internet_detector.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>internet_detector.vm</id>
-    <version>1.0.0.20250425</version>
+    <version>1.0.0.20250426</version>
     <authors>Elliot Chernofsky and Ana Martinez Gomez</authors>
     <description>Tool that changes the background and a taskbar icon if it detects internet connectivity</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="libraries.python3.vm" version="0.0.0.20250414" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
       <dependency id="fakenet-ng.vm" version="3.5.0.20250415" />
     </dependencies>
     <tags>Networking</tags>

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20250414</version>
+    <version>0.0.0.20250425</version>
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -34,6 +34,11 @@
     <module name="yara-python"/>
     <module name="frida"/>
     <module name="frida-tools"/>
+    <!-- Dependencies of the internet detector tool that are also useful for malware analysis
+      The internet detector needs to build the Python executable with a version of pyinstaller capable of executing in admin cmd.
+      Fix also the version of pywin32 and icmplib to avoid issues
+    -->
     <module name="pyinstaller==6.10.0"/>
-    <module name="pywin32"/>
+    <module name="pywin32==308"/>
+    <module name="icmplib==3.0.4"/>
 </modules>


### PR DESCRIPTION
The internet_detector needs icmplib, which was removed by accident in: https://github.com/mandiant/VM-Packages/issues/1386 Add icmplib to libraries.python3.vm to fix the issue. Document also which libraries are needed by the internet detector to prevent issues in the future.

Closes https://github.com/mandiant/VM-Packages/issues/1386