### PR TITLE
Add option to install and uninstall specified files for IDA plugins

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_IDA_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/new_IDA_plugin.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Package type
       description: |
-        - **`IDA_PLUGIN`** - IDA plugin distributed as a single file or ZIP containing a plugin (and supporting files/directories) that need to be copied to the IDA plugins directory. For ZIPs, we check if there is an inner folder (this is the case for GH ZIPs) and if there is a directory called `plugins`. We copy all files in this directory (the root directory, the inner folder or the `plugins` directory depending what is present) with the exception of the README and the LICENSE file (often present in GH repos). The copied files must include the file `plugin name` specified below.
+        - **`IDA_PLUGIN`** - IDA plugin distributed as a single file or ZIP containing a plugin (and supporting files/directories) that need to be copied to the IDA plugins directory. For ZIPs, we check if there is an inner folder (this is the case for GH ZIPs) and if there is a directory called `plugins`. We copy all files in this directory (the root directory, the inner folder or the `plugins` directory depending what is present) with the exception of the README and the LICENSE file (often present in GH repos). The copied files must include the file `plugin name` specified below. If you need to be more specific in which files to copy, supply them in the `files` field below.
         - **`OTHER/UNKNOWN`** - An IDA plugin distributed in a different way than `IDA_PLUGIN`. It is required that you provide details of how the plugin is installed in the `Extra information` section. Note this type does not support automation, a PR would be appreciated!
       options:
         - IDA_PLUGIN
@@ -79,6 +79,12 @@ body:
       label: Download SHA256 Hash
       description: |
         SHA256 hash of the file or ZIP downloaded from the download url introduced in the previous field. The hash is used for verification purposes. Example: `62af5cce80dbbf5cdf961ec9515549334a2112056d4168fced75c892c24baa95`
+  - type: input
+    id: files
+    attributes:
+      label: Files to copy
+      description: |
+        A comma separated list of files and/or directories to copy into the plugin directory. Only necessary for plugins with awkward repository layouts. Example: `awkward_directory/awesomeplugin.py, `awkward_directory/awesomeplugin_libs`,
   - type: textarea
     id: why
     attributes:

--- a/scripts/utils/create_package_template.py
+++ b/scripts/utils/create_package_template.py
@@ -186,7 +186,7 @@ VM-Install-Single-Ps1 $toolName $category $ps1Url -ps1Sha256 $ps1Sha256
 
 """
 Needs the following format strings:
-    tool_name="...", target_url="...", target_hash="..."
+    tool_name="...", target_url="...", target_hash="...", files="..."
 """
 IDA_PLUGIN_TEMPLATE = r"""$ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
@@ -194,8 +194,9 @@ Import-Module vm.common -Force -DisableNameChecking
 $pluginName = '{tool_name}'
 $pluginUrl = '{target_url}'
 $pluginSha256 = '{target_hash}'
+$pluginFiles = @({files})
 
-VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256
+VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256 -pluginFiles $pluginFiles
 """
 
 """
@@ -249,7 +250,8 @@ IDA_PLUGIN_UNINSTALL_TEMPLATE = r"""$ErrorActionPreference = 'Continue'
 Import-Module vm.common -Force -DisableNameChecking
 
 $pluginName = '{tool_name}'
-VM-Uninstall-IDA-Plugin -pluginName $pluginName
+$pluginFiles = @({files})
+VM-Uninstall-IDA-Plugin -pluginName $pluginName -pluginFiles $pluginFiles
 
 """
 PIP_UNINSTALL_TEMPLATE = r"""$ErrorActionPreference = 'Continue'
@@ -356,6 +358,7 @@ def create_ida_plugin_template(packages_path, **kwargs):
         tool_name=kwargs.get("tool_name"),
         target_url=kwargs.get("target_url"),
         target_hash=kwargs.get("target_hash"),
+        files=kwargs.get("files"),
     )
 
 
@@ -393,6 +396,7 @@ def create_template(
     console_app="",
     inner_folder="",
     arguments="",
+    files="",
 ):
     pkg_path = os.path.join(packages_path, f"{pkg_name}.vm")
     try:
@@ -430,11 +434,12 @@ def create_template(
                 shim_path=shim_path,
                 console_app=console_app,
                 inner_folder=inner_folder,
+                files=files,
             )
         )
 
     with open(os.path.join(tools_path, UNINSTALL_TEMPLATE_NAME), "w") as f:
-        f.write(uninstall_template.format(tool_name=tool_name))
+        f.write(uninstall_template.format(tool_name=tool_name, files=files))
 
 
 def get_script_directory():
@@ -645,6 +650,9 @@ def main(argv=None):
     parser.add_argument(
         "--arguments", type=str, required=False, default="", help="Command-line arguments for the execution"
     )
+    parser.add_argument(
+        "--files", type=str, required=False, help="Comma separated list of files to copy to the installation directory"
+    )
     args = parser.parse_args(args=argv)
 
     if args.type is None:
@@ -666,6 +674,9 @@ def main(argv=None):
 
     # remove type before passing to template create function
     del args.type
+
+    # fixup the files argument
+    args.files = ", ".join(repr(name.strip()) for name in args.files.split(","))
 
     create_type_template_cb(packages_path, **vars(args))
 


### PR DESCRIPTION
As discussed in https://github.com/mandiant/VM-Packages/issues/1230.

Adds the `-pluginFiles` argument to both `VM-Install-IDA-Plugin` and `VM-Uninstall-IDA-Plugin` to more finely manage the installed plugin files. This allows for more flexible plugin packages without having to make a custom `chocolateyInstall.ps1` for those.

Currently a bunch of plugins will fail to reinstall after an uninstall because of leftover files (a reinstall will complain about already existing files), so if this gets merged we probably want to update those plugins with this argument.