### PR TITLE
Add projecturl and improve description packages

### DIFF
--- a/packages/capesolo.vm/capesolo.vm.nuspec
+++ b/packages/capesolo.vm/capesolo.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>capesolo.vm</id>
-    <version>0.4.23.20250220</version>
+    <version>0.4.23.20250430</version>
     <authors>kevoreilly, enzok, doomedraven</authors>
-    <description>Standalone sandbox tool with unpacker and debugger</description>
+    <description>Capesolo is an standalone sandbox tool with unpacker and debugger.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="python3.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/CAPESandbox/CAPEsolo</projectUrl>
   </metadata>
 </package>

--- a/packages/cutter.vm/cutter.vm.nuspec
+++ b/packages/cutter.vm/cutter.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>cutter.vm</id>
-    <version>2.3.4.20250219</version>
+    <version>2.3.4.20250430</version>
     <authors>Rizin</authors>
-    <description>Cutter is a FOSS dissassembler/decompiler</description>
+    <description>Cutter is a FOSS dissassembler/decompiler.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="vcredist140.vm" />
     </dependencies>
     <tags>Disassemblers</tags>
+    <projectUrl>https://github.com/rizinorg/cutter</projectUrl>
   </metadata>
 </package>

--- a/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
+++ b/packages/didier-stevens-beta.vm/didier-stevens-beta.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-beta.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250430</version>
     <authors>Didier Stevens</authors>
-    <description>Beta versions of Didier Stevens's software</description>
+<description>DidierStevensSuiteBeta is a collection of beta malware analysis tools by Didier Stevens.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="python3.vm" version="0.0.0.20240726"/>
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://github.com/DidierStevens/Beta</projectUrl>
   </metadata>
 </package>

--- a/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
+++ b/packages/didier-stevens-suite.vm/didier-stevens-suite.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>didier-stevens-suite.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250430</version>
     <authors>Didier Stevens</authors>
-    <description>Tools collection by Didier Stevens</description>
+<description>DidierStevensSuite is a collection of malware analysis tools by Didier Stevens.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="python3.vm" version="0.0.0.20240726"/>
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://github.com/DidierStevens/DidierStevensSuite</projectUrl>
   </metadata>
 </package>

--- a/packages/ezviewer.vm/ezviewer.vm.nuspec
+++ b/packages/ezviewer.vm/ezviewer.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ezviewer.vm</id>
-    <version>2.0.0.20250219</version>
+    <version>2.0.0.20250430</version>
     <authors>Eric Zimmerman</authors>
-    <description>Standalone, zero dependency viewer for .doc, .docx, .xls, .xlsx, .txt, .log, .rtf, .otd, .htm, .html, .mht, .csv, and .pdf. Any non-supported files are shown in a hex editor (with data interpreter!)</description>
+<description>Ezviewer is a standalone, zero dependency document viewer and hex editor.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="dotnet-6.vm" />
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://ericzimmerman.github.io</projectUrl>
   </metadata>
 </package>

--- a/packages/ghidra.vm/ghidra.vm.nuspec
+++ b/packages/ghidra.vm/ghidra.vm.nuspec
@@ -2,14 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ghidra.vm</id>
-    <version>11.3.2</version>
+    <version>11.3.2.20250430</version>
     <authors>National Security Agency</authors>
-    <description>A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.</description>
+    <description>Ghidra is a software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="ghidra" version="[11.3.2]" />
       <dependency id="openjdk.vm" />
     </dependencies>
     <tags>Disassemblers</tags>
+    <projectUrl>https://www.nsa.gov/ghidra</projectUrl>
   </metadata>
 </package>

--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>8.4.0.20250219</version>
+    <version>8.4.0.20250430</version>
     <authors>Hex-Rays</authors>
-    <description>Free version of IDA Pro, a powerful Interactive DisAssembler and debugger.</description>
+    <description>IDA Free is the free version of IDA Pro, a powerful Interactive DisAssembler and debugger.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Disassemblers</tags>
+    <projectUrl>https://hex-rays.com/ida-free</projectUrl>
   </metadata>
 </package>

--- a/packages/idapro.vm/idapro.vm.nuspec
+++ b/packages/idapro.vm/idapro.vm.nuspec
@@ -2,14 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idapro.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250430</version>
     <authors>Hex-Rays</authors>
-    <description>IDA Pro 9 is an interactive DisAssembler and debugger. The installation requires an IDA Pro installer `ida-pro_9*.exe` (and optionally a license file) in the Desktop. Get your installer from https://hex-rays.com/ida-pro.</description>
+    <description>IDA Pro 9 is an interactive DisAssembler and debugger. Requires `ida-pro_9*.exe` (optional `.hexlic`) from https://hex-rays.com/ida-pro in the Desktop.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <!-- IDA Pro requires Python3 and the rpyc library -->
       <dependency id="libraries.python3.vm" version="0.0.0.20241213" />
     </dependencies>
     <tags>Disassemblers</tags>
+    <projectUrl>https://hex-rays.com/ida-pro</projectUrl>
   </metadata>
 </package>

--- a/packages/idr.vm/idr.vm.nuspec
+++ b/packages/idr.vm/idr.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idr.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250430</version>
     <authors>crypto</authors>
-    <description>Interactive Delphi Reconstructor</description>
+    <description>IDR (Interactive Delphi Reconstructor) is a decompiler for Delphi-written Windows32 EXEs and DLLs.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Delphi</tags>
+    <projectUrl>https://github.com/crypto2011/IDR</projectUrl>
   </metadata>
 </package>

--- a/packages/offvis.vm/offvis.vm.nuspec
+++ b/packages/offvis.vm/offvis.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>offvis.vm</id>
-    <version>1.0.0.20250219</version>
+    <version>1.0.0.20250430</version>
     <authors>Microsoft</authors>
     <description>The Microsoft Office Visualization Tool (OffVis) is a tool from Microsoft that helps understanding the Microsoft Office binary file format in order to deconstruct .doc-, .xls- and .ppt-based targeted attacks.</description>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="dotnet3.5" />
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://msrc.microsoft.com/blog/2009/07/announcing-offvis-1-0-beta/</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg.plugin.ollydumpex.vm/ollydbg.plugin.ollydumpex.vm.nuspec
+++ b/packages/ollydbg.plugin.ollydumpex.vm/ollydbg.plugin.ollydumpex.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg.plugin.ollydumpex.vm</id>
-    <version>1.84.0.20250219</version>
-    <description>This plugin is process memory dumper for OllyDbg and Immunity Debugger. OllyDumpEx = OllyDump + PE Dumper - obsoleted + useful features</description>
+    <version>1.84.0.20250430</version>
+    <description>Ollydumpex plugin is process memory dumper for OllyDbg and Immunity Debugger.</description>
     <authors>low-priority</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="ollydbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://low-priority.appspot.com/ollydumpex/</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg.plugin.scyllahide.vm/ollydbg.plugin.scyllahide.vm.nuspec
+++ b/packages/ollydbg.plugin.scyllahide.vm/ollydbg.plugin.scyllahide.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg.plugin.scyllahide.vm</id>
-    <version>1.4.0.20250219</version>
+    <version>1.4.0.20250430</version>
     <description>ScyllaHide is an advanced open-source x64/x86 user mode Anti-Anti-Debug library.</description>
     <authors>x64dbg</authors>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="ollydbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/x64dbg/ScyllaHide</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg.vm/ollydbg.vm.nuspec
+++ b/packages/ollydbg.vm/ollydbg.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg.vm</id>
-    <version>1.10.0.20250219</version>
+    <version>1.10.0.20250430</version>
     <description>OllyDbg is a 32-bit assembler level analysing debugger for Windows. Emphasis on binary code analysis makes it particularly useful in cases where source is unavailable.</description>
     <authors>Oleh Yuschuk</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://www.ollydbg.de</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg2.plugin.ollydumpex.vm/ollydbg2.plugin.ollydumpex.vm.nuspec
+++ b/packages/ollydbg2.plugin.ollydumpex.vm/ollydbg2.plugin.ollydumpex.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.plugin.ollydumpex.vm</id>
-    <version>1.84.0.20250219</version>
-    <description>This plugin is process memory dumper for OllyDbg2 and Immunity Debugger. OllyDumpEx = OllyDump + PE Dumper - obsoleted + useful features</description>
+    <version>1.84.0.20250430</version>
+    <description>Ollydumpex plugin is process memory dumper for OllyDbg2 and Immunity Debugger.</description>
     <authors>low-priority</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="ollydbg2.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://low-priority.appspot.com/ollydumpex/</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg2.plugin.scyllahide.vm/ollydbg2.plugin.scyllahide.vm.nuspec
+++ b/packages/ollydbg2.plugin.scyllahide.vm/ollydbg2.plugin.scyllahide.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.plugin.scyllahide.vm</id>
-    <version>1.4.0.20250219</version>
+    <version>1.4.0.20250430</version>
     <description>ScyllaHide is an advanced open-source x64/x86 user mode Anti-Anti-Debug library.</description>
     <authors>x64dbg</authors>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="ollydbg2.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/x64dbg/ScyllaHide</projectUrl>
   </metadata>
 </package>

--- a/packages/ollydbg2.vm/ollydbg2.vm.nuspec
+++ b/packages/ollydbg2.vm/ollydbg2.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ollydbg2.vm</id>
-    <version>2.01.0.20250219</version>
+    <version>2.01.0.20250430</version>
     <description>OllyDbg2 is a 32-bit assembler level analysing debugger for Windows. Emphasis on binary code analysis makes it particularly useful in cases where source is unavailable.</description>
     <authors>Oleh Yuschuk</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>http://www.ollydbg.de/</projectUrl>
   </metadata>
 </package>

--- a/packages/onenoteanalyzer.vm/onenoteanalyzer.vm.nuspec
+++ b/packages/onenoteanalyzer.vm/onenoteanalyzer.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>onenoteanalyzer.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250430</version>
     <authors>neeraj</authors>
-    <description>A C# based tool for analyzing malicious OneNote documents.</description>
+    <description>OneNoteAnalyzer is a C# based tool for analyzing malicious OneNote documents.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://github.com/knight0x07/OneNoteAnalyzer</projectUrl>
   </metadata>
 </package>

--- a/packages/pdfstreamdumper.vm/pdfstreamdumper.vm.nuspec
+++ b/packages/pdfstreamdumper.vm/pdfstreamdumper.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdfstreamdumper.vm</id>
-    <version>0.9.634.20250219</version>
+    <version>0.9.634.20250430</version>
     <authors>David Zimmer</authors>
     <description>PDFStreamDumper is a free, open source tool to analyze malicious PDF documents.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Documents</tags>
+    <projectUrl>https://github.com/zha0/pdfstreamdumper</projectUrl>
   </metadata>
 </package>

--- a/packages/ttd.vm/ttd.vm.nuspec
+++ b/packages/ttd.vm/ttd.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ttd.vm</id>
-    <version>1.11.319.20250219</version>
+    <version>1.11.319.20250430</version>
     <authors>Microsoft</authors>
-    <description>Time travel debugging command line utility.</description>
+    <description>TTD is a time travel debugging command line utility.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://learn.microsoft.com/en-us/windows-hardware/drivers/debuggercmds/time-travel-debugging-overview</projectUrl>
   </metadata>
 </package>

--- a/packages/windbg.vm/windbg.vm.nuspec
+++ b/packages/windbg.vm/windbg.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>windbg.vm</id>
-    <version>1.2502.25002.20250422</version>
+    <version>1.2502.25002.20250430</version>
     <authors>Microsoft</authors>
     <description>WinDbg is a debugger that can be used to analyze crash dumps, debug live user-mode and kernel-mode code, and examine CPU registers and memory.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/</projectUrl>
   </metadata>
 </package>
 

--- a/packages/x64dbg.plugin.dbgchild.vm/x64dbg.plugin.dbgchild.vm.nuspec
+++ b/packages/x64dbg.plugin.dbgchild.vm/x64dbg.plugin.dbgchild.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>x64dbg.plugin.dbgchild.vm</id>
-    <version>20250219</version>
+    <version>20250430</version>
     <description>DbgChild is an x64dbg plugin to automatically attach to spawned child processes.</description>
     <authors>Dreg (David Reguera Garcia)</authors>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="x64dbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/therealdreg/DbgChild</projectUrl>
   </metadata>
 </package>

--- a/packages/x64dbg.plugin.ollydumpex.vm/x64dbg.plugin.ollydumpex.vm.nuspec
+++ b/packages/x64dbg.plugin.ollydumpex.vm/x64dbg.plugin.ollydumpex.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>x64dbg.plugin.ollydumpex.vm</id>
-    <version>1.84.0.20250219</version>
-    <description>This plugin is process memory dumper for OllyDbg and Immunity Debugger. OllyDumpEx = OllyDump + PE Dumper - obsoleted + useful features</description>
+    <version>1.84.0.20250430</version>
+    <description>Ollydumpex is process memory dumper for OllyDbg and Immunity Debugger.</description>
     <authors>low-priority</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="x64dbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://low-priority.appspot.com/ollydumpex/</projectUrl>
   </metadata>
 </package>

--- a/packages/x64dbg.plugin.scyllahide.vm/x64dbg.plugin.scyllahide.vm.nuspec
+++ b/packages/x64dbg.plugin.scyllahide.vm/x64dbg.plugin.scyllahide.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>x64dbg.plugin.scyllahide.vm</id>
-    <version>1.4.20250219</version>
+    <version>1.4.20250430</version>
     <description>ScyllaHide is an advanced open-source x64/x86 user mode Anti-Anti-Debug library.</description>
     <authors>x64dbg</authors>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="x64dbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/x64dbg/ScyllaHide</projectUrl>
   </metadata>
 </package>

--- a/packages/x64dbg.plugin.x64dbgpy.vm/x64dbg.plugin.x64dbgpy.vm.nuspec
+++ b/packages/x64dbg.plugin.x64dbgpy.vm/x64dbg.plugin.x64dbgpy.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>x64dbg.plugin.x64dbgpy.vm</id>
-    <version>1.0.59.20250220</version>
-    <description>Automating x64dbg using Python.</description>
+    <version>1.0.59.20250430</version>
+    <description>X64dbgpy is a a plugin to access the API of x64dbg using Python.</description>
     <authors>mrexodia, RealGame (Tomer Zait)</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="x64dbg.vm" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://github.com/x64dbg/x64dbgpy</projectUrl>
   </metadata>
 </package>

--- a/packages/x64dbg.vm/x64dbg.vm.nuspec
+++ b/packages/x64dbg.vm/x64dbg.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>x64dbg.vm</id>
-    <version>2025.03.15.20250411</version>
-    <description>An open-source x64/x32 debugger for Windows.</description>
+    <version>2025.03.15.20250430</version>
+    <description>X64dbg is an open-source x64/x32 debugger for Windows.</description>
     <authors>mrexodia</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
+    <projectUrl>https://sourceforge.net/projects/x64dbg/</projectUrl>
   </metadata>
 </package>

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -95,6 +95,7 @@ class IncludesRequiredFieldsOnly(Lint):
         "authors",
         "dependencies",
         "tags",
+        "projectUrl",
     ]
     recommendation = f"Only include required fields: {', '.join(allowed_fields)}"
 


### PR DESCRIPTION
Add `projectUrl` to nuspec files and improve description, of packages with categories:
Debuggers, Delphi, Disassemblers and Documents.
Partially resolves #1231 