### PR TITLE
[regcool.vm] Use 0.0.0.YYYYDDMM version format

### DIFF
--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>2.032</version>
+    <version>0.0.0.20250430</version>
     <authors>Kurt Zimmermann</authors>
     <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
     <dependencies>


### PR DESCRIPTION
As the tool download URL does not include the version, use the `0.0.0.YYYYDDMM` version format so that the package is automatically updated by the CI. This requires deleting the current version from MyGet. I have just deleted it.