### PR TITLE
Add projectUrl and improve description of packages (2nd)

### DIFF
--- a/packages/bindiff.vm/bindiff.vm.nuspec
+++ b/packages/bindiff.vm/bindiff.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>bindiff.vm</id>
-    <version>8.0.0.20250219</version>
+    <version>8.0.0.20250505</version>
     <authors>Zynamics</authors>
-    <description>A comparison tool for binary files that assists in quickly finding differences and similarities in disassembled code</description>
+    <description>BinDiff is a comparison tool for binary files that finds differences and similarities in disassembled code.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="vcredist140.vm" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://github.com/google/bindiff</projectUrl>
   </metadata>
 </package>

--- a/packages/codetrack.vm/codetrack.vm.nuspec
+++ b/packages/codetrack.vm/codetrack.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>codetrack.vm</id>
-    <version>1.0.3.20250219</version>
+    <version>1.0.3.20250505</version>
     <authors>CodeTrack</authors>
-    <description>A free .NET Performance Profile and Execution Analyzer</description>
+    <description>CodeTrack is a free .NET Performance Profile and Execution Analyzer.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="codetrack" version="[1.0.3.301]" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://www.getcodetrack.com</projectUrl>
   </metadata>
 </package>

--- a/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
+++ b/packages/de4dot-cex.vm/de4dot-cex.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>de4dot-cex.vm</id>
-    <version>4.0.0.20250219</version>
+    <version>4.0.0.20250505</version>
     <authors>ViRb3</authors>
-    <description>A de4dot fork with full support for vanilla ConfuserEx</description>
+    <description>de4dot CEx is a de4dot fork with full support for vanilla ConfuserEx.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/ViRb3/de4dot-cex</projectUrl>
   </metadata>
 </package>

--- a/packages/die.vm/die.vm.nuspec
+++ b/packages/die.vm/die.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>die.vm</id>
-    <version>3.10.20250219</version>
+    <version>3.10.20250505</version>
     <authors>Hellsp@wn, horsicq</authors>
-    <description>Detect It Easy, or abbreviated "DIE" is a program for determining types of files.</description>
+    <description>DIE (Detect It Easy) is a tool for file type identification with signature-based and heuristic analysis.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://github.com/horsicq/Detect-It-Easy</projectUrl>
   </metadata>
 </package>

--- a/packages/dnlib.vm/dnlib.vm.nuspec
+++ b/packages/dnlib.vm/dnlib.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dnlib.vm</id>
-    <version>4.0.0.20250219</version>
+    <version>4.0.0.20250505</version>
     <authors>0xd4d</authors>
-    <description>.NET module/assembly reader/writer library</description>
+    <description>dnlib is a .NET module/assembly reader/writer library.</description>
     <dependencies>
     <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/0xd4d/dnlib</projectUrl>
   </metadata>
 </package>

--- a/packages/dnspyex.vm/dnspyex.vm.nuspec
+++ b/packages/dnspyex.vm/dnspyex.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dnspyex.vm</id>
-    <version>6.5.1.20250219</version>
+    <version>6.5.1.20250505</version>
     <authors>0xd4d, ElektroKill</authors>
-    <description>dnSpyEx is a unofficial continuation of the dnSpy project which is a debugger and .NET assembly editor. You can use it to edit and debug assemblies even if you don't have any source code available.</description>
+    <description>dnSpyEx is a unofficial continuation of the dnSpy project which is a debugger and .NET assembly editor.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/dnSpyEx/dnSpy</projectUrl>
   </metadata>
 </package>

--- a/packages/dotdumper.vm/dotdumper.vm.nuspec
+++ b/packages/dotdumper.vm/dotdumper.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dotdumper.vm</id>
-    <version>1.1.0.20250219</version>
+    <version>1.1.0.20250505</version>
     <authors>ThisIsLibra</authors>
-    <description>An automatic unpacker and logger for DotNet Framework targeting files</description>
+    <description>DotDumper is an automatic unpacker and logger for DotNet Framework targeting files.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/advanced-threat-research/DotDumper</projectUrl>
   </metadata>
 </package>

--- a/packages/dotnet-6.vm/dotnet-6.vm.nuspec
+++ b/packages/dotnet-6.vm/dotnet-6.vm.nuspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <!-- Metapackage for .NET6 to ensure all packages use the same version.-->
   <metadata>
     <id>dotnet-6.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250505</version>
     <authors>Microsoft</authors>
-    <description>Metapackage for .NET6 to ensure all packages use the same version.</description>
+    <description>.NET 6.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="dotnet-6.0-desktopruntime" version="[6.0.14, 6.1)" />

--- a/packages/dotnet-8.vm/dotnet-8.vm.nuspec
+++ b/packages/dotnet-8.vm/dotnet-8.vm.nuspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <!-- Metapackage for .NET8 to ensure all packages use the same version.-->
   <metadata>
     <id>dotnet-8.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250505</version>
     <authors>Microsoft</authors>
-    <description>Metapackage for .NET8 to ensure all packages use the same version.</description>
+    <description>.NET 8.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="dotnet-8.0-desktopruntime" version="[8, 8.1)" />

--- a/packages/dotnet-9.vm/dotnet-9.vm.nuspec
+++ b/packages/dotnet-9.vm/dotnet-9.vm.nuspec
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <!-- Metapackage for .NET9 to ensure all packages use the same version.-->
   <metadata>
     <id>dotnet-9.vm</id>
-    <version>0.0.0.20250411</version>
+    <version>0.0.0.20250505</version>
     <authors>Microsoft</authors>
-    <description>Metapackage for .NET9 to ensure all packages use the same version.</description>
+    <description>.NET 9.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="dotnet-9.0-desktopruntime" version="[9, 9.1)" />

--- a/packages/exeinfope.vm/exeinfope.vm.nuspec
+++ b/packages/exeinfope.vm/exeinfope.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exeinfope.vm</id>
-    <version>0.0.7.20250219</version>
+    <version>0.0.7.20250505</version>
     <authors>A.S.L Soft</authors>
-    <description>Displays metadata for a variety of file types and identifies many executable packers</description>
+    <description>Exeinfo PE displays metadata for a variety of file types and identifies many executable packers.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://github.com/ExeinfoASL/ASL</projectUrl>
   </metadata>
 </package>

--- a/packages/exiftool.vm/exiftool.vm.nuspec
+++ b/packages/exiftool.vm/exiftool.vm.nuspec
@@ -2,14 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>exiftool.vm</id>
-    <version>13.27.0</version>
+    <version>13.27.0.20250504</version>
     <authors>Phil Harvey</authors>
-    <description>A tool for reeding and writing file metadata</description>
+    <description>ExifTool is a tool for reading, writing and manipulating metadata.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="exiftool" version="[13.27.0]" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://exiftool.org/</projectUrl>
   </metadata>
 </package>
 

--- a/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
+++ b/packages/extreme_dumper.vm/extreme_dumper.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>extreme_dumper.vm</id>
-    <version>4.0.0.20250219</version>
+    <version>4.0.0.20250505</version>
     <authors>wwh1004</authors>
-    <description>.NET Assembly Dumper from memory of processes.</description>
+    <description>ExtremeDumper is a .NET Assembly Dumper from memory of processes.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://gitee.com/keyestore/ExtremeDumper</projectUrl>
   </metadata>
 </package>

--- a/packages/file.vm/file.vm.nuspec
+++ b/packages/file.vm/file.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>file.vm</id>
-    <version>0.0.0.20250220</version>
-    <description>A Windows port of the Linux `file` utility for checking header magics</description>
+    <version>0.0.0.20250505</version>
+    <description>file is a Windows port of the Linux `file` utility for checking header magics.</description>
     <authors>Nolen Scaiffe</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://github.com/nscaife/file-windows</projectUrl>
   </metadata>
 </package>

--- a/packages/floss.vm/floss.vm.nuspec
+++ b/packages/floss.vm/floss.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>floss.vm</id>
-    <version>3.1.1.20250220</version>
-    <description>FLOSS uses advanced static analysis techniques to automatically deobfuscate strings from malware binaries. You can use it just like strings.exe to enhance basic static analysis of unknown binaries.</description>
+    <version>3.1.1.20250505</version>
+    <description>FLOSS automatically deobfuscates strings in malware using advanced static analysis, enhancing basic static analysis like strings.exe.</description>
     <authors>@williballenthin, @mr-tz</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://github.com/mandiant/flare-floss</projectUrl>
   </metadata>
 </package>

--- a/packages/garbageman.vm/garbageman.vm.nuspec
+++ b/packages/garbageman.vm/garbageman.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>garbageman.vm</id>
-    <version>0.2.4.20250425</version>
+    <version>0.2.4.20250505</version>
     <authors>alphillips-lab</authors>
-    <description>A set of tools designed for .NET heap analysis.</description>
+    <description>GarbageMan is a set of tools designed for .NET heap analysis.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="dotnet-5.0-desktopruntime" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/WithSecureLabs/GarbageMan</projectUrl>
   </metadata>
 </package>

--- a/packages/goresym.vm/goresym.vm.nuspec
+++ b/packages/goresym.vm/goresym.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>goresym.vm</id>
-    <version>3.0.2.20250411</version>
+    <version>3.0.2.20250505</version>
     <authors>stevemk14ebr</authors>
-    <description>Go symbol recovery tool</description>
+    <description>GoReSym is a Go symbol recovery tool.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Go</tags>
+    <projectUrl>https://github.com/mandiant/GoReSym</projectUrl>
   </metadata>
 </package>

--- a/packages/gostringungarbler.vm/gostringungarbler.vm.nuspec
+++ b/packages/gostringungarbler.vm/gostringungarbler.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gostringungarbler.vm</id>
-    <version>1.0.0</version>
+    <version>1.0.0.20250505</version>
     <authors>Chuong Dong</authors>
-    <description>GoStringUngarbler deobfuscates strings in Go binaries obfuscated by garble</description>
+    <description>GoStringUngarbler deobfuscates strings in Go binaries obfuscated by garble.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="python3.vm" />
     </dependencies>
     <tags>Go</tags>
+    <projectUrl>https://github.com/mandiant/gostringungarbler</projectUrl>
   </metadata>
 </package>

--- a/packages/hasher.vm/hasher.vm.nuspec
+++ b/packages/hasher.vm/hasher.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>hasher.vm</id>
-    <version>2.1.0.20250219</version>
+    <version>2.1.0.20250505</version>
     <authors>Eric Zimmerman</authors>
-    <description>Hash all the things</description>
+    <description>Hasher is a tool to calculate hashes.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="netfx-4.8" version="[4.8.0.20220524]" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://ericzimmerman.github.io</projectUrl>
   </metadata>
 </package>

--- a/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
+++ b/packages/hashmyfiles.vm/hashmyfiles.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>hashmyfiles.vm</id>
-    <version>0.0.0.20250219</version>
-    <description>HashMyFiles is small utility that allows you to calculate the MD5 and SHA1 hashes of one or more files in your system. You can easily copy the MD5/SHA1 hashes list into the clipboard, or save them into text/html/xml file.</description>
+    <version>0.0.0.20250505</version>
+    <description>HashMyFiles calculates and exports various file hashes (MD5, SHA256, etc.) to clipboard and multiple file formats.</description>
     <authors>Nir Sofer</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://www.nirsoft.net/utils/hash_my_files.html</projectUrl>
   </metadata>
 </package>

--- a/packages/ilspy.vm/ilspy.vm.nuspec
+++ b/packages/ilspy.vm/ilspy.vm.nuspec
@@ -2,14 +2,15 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ilspy.vm</id>
-    <version>9.1.0</version>
+    <version>9.1.0.20250505</version>
     <authors>SharpDevelop Team</authors>
-    <description>The open-source .NET assembly browser and decompiler.</description>
+    <description>ILSpy is a .NET assembly browser and decompiler.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="ilspy" version="[9.1.0]" />
       <dependency id="dotnet-8.vm" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/icsharpcode/ILSpy</projectUrl>
   </metadata>
 </package>

--- a/packages/magika.vm/magika.vm.nuspec
+++ b/packages/magika.vm/magika.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>magika.vm</id>
-    <version>0.5.0.20250219</version>
+    <version>0.5.0.20250505</version>
     <authors>Yanick Fratantonio, Luca Invernizzi, Marina Zhang, Giancarlo Metitieri, Thomas Kurt, Francois Galilee, Alexandre Petit-Bianco, Loua Farah, Ange Albertini, Elie Bursztein</authors>
     <description>Magika is an AI powered file type detection tool that uses deep learning to provide accurate detection.</description>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="python3.vm" />
     </dependencies>
     <tags>File Information</tags>
+    <projectUrl>https://google.github.io/magika/</projectUrl>
   </metadata>
 </package>

--- a/packages/net-reactor-slayer.vm/net-reactor-slayer.vm.nuspec
+++ b/packages/net-reactor-slayer.vm/net-reactor-slayer.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>net-reactor-slayer.vm</id>
-    <version>6.4.0.20250415</version>
+    <version>6.4.0.20250505</version>
     <authors>SychicBoy</authors>
-    <description>NETReactorSlayer is an open source (GPLv3) deobfuscator and unpacker for Eziriz .NET Reactor.</description>
+    <description>NETReactorSlayer is a deobfuscator and unpacker for Eziriz .NET Reactor.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="net-reactor-slayer" version="[6.4.0]" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/SychicBoy/NETReactorSlayer</projectUrl>
   </metadata>
 </package>

--- a/packages/psnotify.vm/psnotify.vm.nuspec
+++ b/packages/psnotify.vm/psnotify.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>psnotify.vm</id>
-    <version>0.2.4.20250219</version>
+    <version>0.2.4.20250505</version>
     <authors>alphillips-lab</authors>
-    <description>A POC tool to fight .NET anti-dumping tricks.</description>
+    <description>psnotify is a POC tool to fight .NET anti-dumping tricks.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/WithSecureLabs/GarbageMan/tree/master/psnotify</projectUrl>
   </metadata>
 </package>

--- a/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
+++ b/packages/rundotnetdll.vm/rundotnetdll.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>rundotnetdll.vm</id>
-    <version>2.2.0.20250219</version>
-    <description>A simple utility to list all methods of a given .NET Assembly and to invoke them.</description>
+    <version>2.2.0.20250505</version>
+    <description>RunDotNetDll is a utility to list all methods of a given .NET Assembly and to invoke them.</description>
     <authors>Antonio Parata</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/enkomio/RunDotNetDll</projectUrl>
   </metadata>
 </package>

--- a/packages/sfextract.vm/sfextract.vm.nuspec
+++ b/packages/sfextract.vm/sfextract.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sfextract.vm</id>
-    <version>2.1.0.20250219</version>
+    <version>2.1.0.20250505</version>
     <authors>Joery Droppers</authors>
-    <description>command-line utility to extract files from single file bundles in .NET</description>
+    <description>sfextract extracts contents (assemblies, configuration, etc.) from .NET single file bundles.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="dotnet-6.0-sdk" version="[6.0.400, 6.1)" />
     </dependencies>
     <tags>dotNet</tags>
+    <projectUrl>https://github.com/Droppers/SingleFileExtractor</projectUrl>
   </metadata>
 </package>


### PR DESCRIPTION
Change nuspec files for categories: dotNet, File Information and Go
Move description to comment in metapackages dotnet-6 to dotnet-9
Needs to be rebased after #1393 has been merged due to the linter update