### PR TITLE
Add max description field to the linter

### DIFF
--- a/packages/c3.vm/c3.vm.nuspec
+++ b/packages/c3.vm/c3.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>c3.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250506</version>
     <authors>WithSecureLabs</authors>
-    <description>C3 (Custom Command and Control) is a tool that allows Red Teams to rapidly develop and utilise esoteric command and control channels (C2). It's a framework that extends other red team tooling, such as the commercial Cobalt Strike (CS) product via ExternalC2.</description>
+    <description>C3 (Custom Command and Control) enables rapid prototyping of custom C2 channels, integrating with existing offensive toolkits.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Command and Control</tags>
+    <projectUrl>https://github.com/WithSecureLabs/C3</projectUrl>
   </metadata>
 </package>

--- a/packages/covenant.vm/covenant.vm.nuspec
+++ b/packages/covenant.vm/covenant.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>covenant.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250505</version>
     <authors>cobbr</authors>
-    <description>Covenant is a .NET command and control framework that aims to highlight the attack surface of .NET, make the use of offensive .NET tradecraft easier, and serve as a collaborative command and control platform for red teamers.</description>
+    <description>Covenant is a collaborative .NET C2 framework for red teamers..</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Command and Control</tags>
+    <projectUrl>https://github.com/cobbr/Covenant</projectUrl>
   </metadata>
 </package>

--- a/packages/dokan.vm/dokan.vm.nuspec
+++ b/packages/dokan.vm/dokan.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dokan.vm</id>
-    <version>2.3.0</version>
+    <version>2.3.0.20250505</version>
     <authors>kacos2000</authors>
-    <description>Dokan simplifies the creation of custom file systems on Windows without the complexity of developing kernel-level drivers, offering an accessible solution for file system development, similar to FUSE on Linux.</description>
+    <description>Dokan simplifies Windows custom file system creation, similar to Linux's FUSE, without requiring device drivers.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Productivity Tools</tags>
+    <projectUrl>https://github.com/dokan-dev/dokany</projectUrl>
   </metadata>
 </package>

--- a/packages/dumpert.vm/dumpert.vm.nuspec
+++ b/packages/dumpert.vm/dumpert.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>dumpert.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250506</version>
     <authors>outflank</authors>
-    <description>This tool demonstrates the use of direct System Calls and API unhooking and combines these techniques in a proof of concept code which can be used to create a LSASS memory dump using Cobalt Strike.</description>
+    <description>Dumpert is a LSASS memory dumper using direct system calls and API unhooking.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Credential Access</tags>
+    <projectUrl>https://github.com/outflanknl/Dumpert</projectUrl>
   </metadata>
 </package>

--- a/packages/ftk-imager.vm/ftk-imager.vm.nuspec
+++ b/packages/ftk-imager.vm/ftk-imager.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ftk-imager.vm</id>
-    <version>4.7.1.20250220</version>
+    <version>4.7.1.20250506</version>
     <authors>AccessData</authors>
-    <description>The tool provides full disk imaging capabilities, mount images, preview data from forensic images, and seamlessly export files in common forensic formats, with an option for RAM capture.</description>
+    <description>FTK Imager is a data preview and imaging tool used to acquire electronic evidence in a forensically sound manner.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Forensic</tags>
+    <projectUrl>https://www.exterro.com/digital-forensics-software/ftk-imager</projectUrl>
   </metadata>
 </package>

--- a/packages/gowitness.vm/gowitness.vm.nuspec
+++ b/packages/gowitness.vm/gowitness.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gowitness.vm</id>
-    <version>3.0.5.20250219</version>
+    <version>3.0.5.20250506</version>
     <authors>sensepost</authors>
-    <description>Website screenshot utility written in Golang, that uses Chrome Headless to generate screenshots of web interfaces using the command line, with a handy report viewer to process results.</description>
+    <description>gowitness uses Chrome Headless for website screenshots and provides a built-in report viewer.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="googlechrome.vm" />
     </dependencies>
     <tags>Reconnaissance</tags>
+    <projectUrl>https://github.com/sensepost/gowitness</projectUrl>
   </metadata>
 </package>

--- a/packages/networkminer.vm/networkminer.vm.nuspec
+++ b/packages/networkminer.vm/networkminer.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>networkminer.vm</id>
-    <version>3.0.0.20250404</version>
+    <version>3.0.0.20250505</version>
     <authors>Netresec</authors>
-    <description>NetworkMiner is an open source Network Forensic Analysis Tool for Windows, but also works in Linux or Mac OS X. NetworkMiner can be used as a passive network sniffer in order to detect operating systems, sessions, hostnames, open ports etc. without putting any traffic on the network. NetworkMiner can also parse PCAP files for off-line analysis and to reassemble transmitted files and certificates from PCAP files.</description>
+    <description>NetworkMiner is a network forensics tool for extracting artifacts (files, images, emails, passwords) from PCAP files and live traffic. </description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Networking</tags>
+    <projectUrl>https://www.netresec.com/?page=NetworkMiner</projectUrl>
   </metadata>
 </package>

--- a/packages/offvis.vm/offvis.vm.nuspec
+++ b/packages/offvis.vm/offvis.vm.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>offvis.vm</id>
-    <version>1.0.0.20250430</version>
+    <version>1.0.0.20250505</version>
     <authors>Microsoft</authors>
-    <description>The Microsoft Office Visualization Tool (OffVis) is a tool from Microsoft that helps understanding the Microsoft Office binary file format in order to deconstruct .doc-, .xls- and .ppt-based targeted attacks.</description>
+    <description>OffVis is an office visualization tool for understanding and deconstructing targeted attacks in .doc, .xls, and .ppt files.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="dotnet3.5" />

--- a/packages/powerupsql.vm/powerupsql.vm.nuspec
+++ b/packages/powerupsql.vm/powerupsql.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powerupsql.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250505</version>
     <authors>NetSPI</authors>
-    <description>PowerUpSQL includes functions that support SQL Server discovery, weak configuration auditing, privilege escalation on scale, and post exploitation actions such as OS command execution.</description>
+    <description>PowerUpSQL helps with SQL Server discovery, weak config audits, privilege escalation, and post-exploitation OS command execution.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Exploitation</tags>
+    <projectUrl>https://github.com/NetSPI/PowerUpSQL</projectUrl>
   </metadata>
 </package>

--- a/packages/regcool.vm/regcool.vm.nuspec
+++ b/packages/regcool.vm/regcool.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regcool.vm</id>
-    <version>0.0.0.20250430</version>
+    <version>0.0.0.20250506</version>
     <authors>Kurt Zimmermann</authors>
-    <description>In addition to all the features that you can find in RegEdit and RegEdt32, RegCool adds many powerful features that allow you to work faster and more efficiently with registry related tasks</description>
+    <description>RegCool is a flexible editor for the Windows registry database.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Registry</tags>
+    <projectUrl>https://kurtzimmermann.com</projectUrl>
   </metadata>
 </package>

--- a/packages/regshot.vm/regshot.vm.nuspec
+++ b/packages/regshot.vm/regshot.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>regshot.vm</id>
-    <version>1.9.1.20250219</version>
+    <version>1.9.1.20250506</version>
     <authors>maddes, regshot, xhmikosr</authors>
-    <description>Regshot is a small, free and open-source registry compare utility that allows you to quickly take a snapshot of your registry and then compare it with a second one - done after doing system changes or installing a new software product.</description>
+    <description>Regshot is a registry comparison tool for tracking system changes by comparing registry snapshots.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Registry</tags>
+    <projectUrl>https://sourceforge.net/projects/regshot</projectUrl>
   </metadata>
 </package>

--- a/packages/routesixtysink.vm/routesixtysink.vm.nuspec
+++ b/packages/routesixtysink.vm/routesixtysink.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>routesixtysink.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250506</version>
     <authors>Dillon Franke, Michael Maturi</authors>
-    <description>Route Sixty-Sink is an open source tool that enables defenders and security researchers alike to quickly identify vulnerabilities in any .NET assembly using automated source-to-sink analysis.</description>
+    <description>Route Sixty-Sink identifies .NET assembly vulnerabilities using automated source-to-sink analysis.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Reconnaissance</tags>
+    <projectUrl>https://github.com/mandiant/route-sixty-sink</projectUrl>
   </metadata>
 </package>

--- a/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
+++ b/packages/situational-awareness-bof.vm/situational-awareness-bof.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>situational-awareness-bof.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250506</version>
     <authors>trustedsec</authors>
-    <description>Provides a set of basic situational awareness commands implemented in a Beacon Object File (BOF). This allows you to perform some checks on a host before you begin executing commands that may be more invasive.</description>
+    <description>Situational Awareness BOF offers basic host checks in a Beacon Object File, enabling pre-execution reconnaissance before more invasive commands.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Reconnaissance</tags>
+    <projectUrl>https://github.com/trustedsec/CS-Situational-Awareness-BOF</projectUrl>
   </metadata>
 </package>

--- a/packages/streamdivert.vm/streamdivert.vm.nuspec
+++ b/packages/streamdivert.vm/streamdivert.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>streamdivert.vm</id>
-    <version>1.1.0.20250219</version>
+    <version>1.1.0.20250505</version>
     <authors>jellever</authors>
-    <description>StreamDivert has the ability to relay all incoming SMB connections to port 445 to another server, or only relay specific incoming SMB connections from a specific set of source IP's to another server.</description>
+    <description>StreamDivert is a tool to man-in-the-middle or relay in and outgoing network connections on a system.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Networking</tags>
+    <projectUrl>https://github.com/jellever/StreamDivert</projectUrl>
   </metadata>
 </package>

--- a/packages/whisker.vm/whisker.vm.nuspec
+++ b/packages/whisker.vm/whisker.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>whisker.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250505</version>
     <authors>Elad Shamir</authors>
-    <description>Whisker is a C# tool for taking over Active Directory user and computer accounts by manipulating their msDS-KeyCredentialLink attribute, effectively adding "Shadow Credentials" to the target account.</description>
+    <description>Whisker is a C# tool for Active Directory account takeover via shadow credential injection through msDS-KeyCredentialLink manipulation.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
     </dependencies>
     <tags>Exploitation</tags>
+    <projectUrl>https://github.com/eladshamir/Whisker</projectUrl>
   </metadata>
 </package>

--- a/packages/wmimplant.vm/wmimplant.vm.nuspec
+++ b/packages/wmimplant.vm/wmimplant.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>wmimplant.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>0.0.0.20250506</version>
     <authors>RedSiege</authors>
-    <description>WMImplant is a PowerShell based tool that leverages WMI to both perform actions against targeted machines, but also as the C2 channel for issuing commands and receiving results.</description>
+    <description>WMImplant is a PowerShell tool using WMI for remote actions and as a C2 channel.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Command and Control</tags>
+    <projectUrl>https://github.com/RedSiege/WMImplant</projectUrl>
   </metadata>
 </package>

--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -86,6 +86,20 @@ def run_cmd(cmd):
     return out
 
 
+class InvalidDescriptionLength(Lint):
+    max_length = 175
+    name = "the description length is invalid"
+    recommendation = f"the description must be limited to {max_length} characters maximum."
+
+    def check(self, path):
+        dom = minidom.parse(str(path))
+        description = dom.getElementsByTagName("description")[0].firstChild.data
+        if len(description) > self.max_length:
+            print(f"The description has invalid length: {len(description)}")
+            return True
+        return False
+
+
 class IncludesRequiredFieldsOnly(Lint):
     name = "file lists non-required fields"
     allowed_fields = [
@@ -315,6 +329,7 @@ NUSPEC_LINTS = (
     VersionNotUpdated(),
     PackageIdNotMatchingFolderOrNuspecName(),
     UsesInvalidCategory(),
+    InvalidDescriptionLength(),
 )
 
 


### PR DESCRIPTION
Introduce a linter that checks that the description is not shorter than 10 characters or longer of 175 characters.
Fix all the packages whose description lenght was greater than the 175 characters. Add projectUrl in all these packages.
needs to be rebased after #1395 
closes #1328