### PR TITLE
Fix MyGet version mismatches

### DIFF
--- a/packages/map.vm/map.vm.nuspec
+++ b/packages/map.vm/map.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>map.vm</id>
-    <version>0.0.0.20250107</version>
+    <version>0.0.0.20250507</version>
     <authors>David Zimmer</authors>
     <description>Handful of small utility type applications useful for analyzing malicious code.</description>
     <dependencies>

--- a/packages/memprocfs.vm/memprocfs.vm.nuspec
+++ b/packages/memprocfs.vm/memprocfs.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>memprocfs.vm</id>
-    <version>5.14</version>
+    <version>5.14.11</version>
     <authors>Ulf Frisk</authors>
     <description>MemProcFS is an easy and convenient way of viewing physical memory as files in a virtual file system.</description>
     <dependencies>

--- a/packages/memprocfs.vm/tools/chocolateyinstall.ps1
+++ b/packages/memprocfs.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MemProcFS'
 $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14/MemProcFS_files_and_binaries_v5.14.9-win_x64-20250411.zip'
-$zipSha256 = 'ef13fb54fb4a44a1ac758684d3fe473ad91f5c3195f8862de2844860b4bd627d'
+$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14/MemProcFS_files_and_binaries_v5.14.11-win_x64-20250501.zip'
+$zipSha256 = '40ce4ac604933dd919444a9cee42431b3fe43813fa4155bef17466b7db03d764'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false


### PR DESCRIPTION
Fix version mismatches (local version do not match the latest version in MyGet):
- map.vm version was incorrectly decreased (instead of increased) in #1333
- The previously used release of memprocfs seems to have been deleted. Update it to fix the package. This also fixes a version mismatch: The bot wrongly updated the version of memprocfs.vm from 5.14.9 to 5.14 in https://github.com/mandiant/VM-Packages/pull/1361 because of a bug in [update_package.py](https://github.com/mandiant/VM-Packages/blob/main/scripts/utils/update_package.py). I created https://github.com/mandiant/VM-Packages/issues/1398 to make [update_package.py](https://github.com/mandiant/VM-Packages/blob/main/scripts/utils/update_package.py) more robust to avoid this happens again. 