### PR TITLE
Add size & time info to descriptions

### DIFF
--- a/packages/010editor.vm/010editor.vm.nuspec
+++ b/packages/010editor.vm/010editor.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>010editor.vm</id>
-    <version>15.0.2</version>
-    <description>Professional text and hex editor with Binary Templates technology.</description>
+    <version>15.0.2.20250509</version>
+    <description>010 Editor is a text and hex editor with Binary Templates technology. Takes long to install.</description>
     <authors>SweetScape</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Hex Editors</tags>
+    <projectUrl>https://www.sweetscape.com/010editor/</projectUrl>
   </metadata>
 </package>

--- a/packages/pdbresym.vm/pdbresym.vm.nuspec
+++ b/packages/pdbresym.vm/pdbresym.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdbresym.vm</id>
-    <version>1.3.6.20250219</version>
+    <version>1.3.6.20250509</version>
     <authors>Stephen Eckels</authors>
-    <description>Download PDBs</description>
+    <description>PDBReSym simplifies and optimizes interacting with the Microsoft Symbol Server to download PDBs.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="vcredist140.vm" />
     </dependencies>
     <tags>Utilities</tags>
+    <projectUrl>https://github.com/mandiant/STrace</projectUrl>
   </metadata>
 </package>

--- a/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
+++ b/packages/pdbs.pdbresym.vm/pdbs.pdbresym.vm.nuspec
@@ -2,9 +2,9 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pdbs.pdbresym.vm</id>
-    <version>0.0.0.20250220</version>
+    <version>0.0.0.20250624</version>
     <authors>Stephen Eckels</authors>
-    <description>Download PDBs</description>
+    <description>PDBs downloaded using PDBReSym. Requires substantial disk space.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
       <dependency id="pdbresym.vm" version="1.3.3.20240415" />

--- a/packages/visualstudio.vm/visualstudio.vm.nuspec
+++ b/packages/visualstudio.vm/visualstudio.vm.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visualstudio.vm</id>
-    <version>17.6.1.20250423</version>
-    <description>Visual Studio is an IDE, installed with useful components and workloads.</description>
+    <version>17.6.1.20250509</version>
+    <description>Visual Studio is an IDE, installed with useful components and workloads. Takes long to install and requires substantial disk space.</description>
     <authors>Microsoft</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />


### PR DESCRIPTION
Changed descriptions for packages that either take too long to install or require substantial disk space.
Added `projectUrl` in the nuspec.
closes #1391