### PR TITLE
Add try-catch block to ida.plugin.diaphora.vm

### DIFF
--- a/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
+++ b/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.diaphora.vm</id>
-    <version>3.2.1.20250213</version>
+    <version>3.2.1.20250522</version>
     <authors>joxeankoret</authors>
     <description>Diaphora is a program diffing IDA plugin.</description>
     <dependencies>

--- a/packages/ida.plugin.diaphora.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.diaphora.vm/tools/chocolateyinstall.ps1
@@ -1,34 +1,38 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-$toolName = 'diaphora'
-$toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
+try {
+    $toolName = 'diaphora'
+    $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
-$pluginUrl = 'https://github.com/joxeankoret/diaphora/archive/refs/tags/3.2.1.zip'
-$pluginSha256 = '5ae160e6bb1534bde8d990577390e609d7e616a869abece3ee6c73865018a54b'
+    $pluginUrl = 'https://github.com/joxeankoret/diaphora/archive/refs/tags/3.2.1.zip'
+    $pluginSha256 = '5ae160e6bb1534bde8d990577390e609d7e616a869abece3ee6c73865018a54b'
 
-# Remove files from previous zips for upgrade
-VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
+    # Remove files from previous zips for upgrade
+    VM-Remove-PreviousZipPackage ${Env:chocolateyPackageFolder}
 
-# Download and unzip
-$packageArgs = @{
-    packageName    = ${Env:ChocolateyPackageName}
-    unzipLocation  = $toolDir
-    url            = $pluginUrl
-    checksum       = $pluginSha256
-    checksumType   = 'sha256'
+    # Download and unzip
+    $packageArgs = @{
+        packageName    = ${Env:ChocolateyPackageName}
+        unzipLocation  = $toolDir
+        url            = $pluginUrl
+        checksum       = $pluginSha256
+        checksumType   = 'sha256'
+    }
+    Install-ChocolateyZipPackage @packageArgs | Out-Null
+    VM-Assert-Path $toolDir
+
+    # There is an inner folder in the zip whose name changes as it includes the version
+    $dirList = Get-ChildItem $toolDir -Directory
+    $toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
+
+    $pluginName = "diaphora_plugin.py"
+    $pluginsDir = VM-Get-IDA-Plugins-Dir
+    $pluginFile = Get-Item "$toolDir\plugin\$pluginName" -ea 0
+    Copy-Item "$pluginFile" "$pluginsDir"
+
+    $cfgFile = Join-Path $pluginsDir "diaphora_plugin.cfg"
+    "[Diaphora]`npath=$toolDir" | out-file -encoding ASCII "$cfgFile"
+} catch {
+    VM-Write-Log-Exception $_
 }
-Install-ChocolateyZipPackage @packageArgs | Out-Null
-VM-Assert-Path $toolDir
-
-# There is an inner folder in the zip whose name changes as it includes the version
-$dirList = Get-ChildItem $toolDir -Directory
-$toolDir = Join-Path $toolDir $dirList[0].Name -Resolve
-
-$pluginName = "diaphora_plugin.py"
-$pluginsDir = VM-Get-IDA-Plugins-Dir
-$pluginFile = Get-Item "$toolDir\plugin\$pluginName" -ea 0
-Copy-Item "$pluginFile" "$pluginsDir"
-
-$cfgFile = Join-Path $pluginsDir "diaphora_plugin.cfg"
-"[Diaphora]`npath=$toolDir" | out-file -encoding ASCII "$cfgFile"


### PR DESCRIPTION
closes #1204 

If this try-catch block is desired in all packages, note that around 150 of the packages do not contain a try-catch in their respective chocolateyinstall.ps1. Should i open another issue listing all affected packages? @Ana06