### PR TITLE
Update package versions and Python references across multiple .nuspec and YAML files

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_python_tool_pip.yml
+++ b/.github/ISSUE_TEMPLATE/new_python_tool_pip.yml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: Tool Name
       description: |
-        The name of the tool being installed with `py -3.10 -m pip install <tool_name><version>`, Example: `autoit-ripper`.
+        The name of the tool being installed with `py -3.13 -m pip install <tool_name><version>`, Example: `autoit-ripper`.
       placeholder: ex. autoit-ripper
     validations:
       required: true
@@ -32,7 +32,7 @@ body:
     attributes:
       label: Package type
       description: |
-        - **`PIP`** - A Python tool installed with `py -3.10 -m pip install <tool_name><version>`. Example: `py -3.10 -m pip install magika==0.5.0`
+        - **`PIP`** - A Python tool installed with `py -3.13 -m pip install <tool_name><version>`. Example: `py -3.13 -m pip install magika==0.6.2`
 
         For other types of tools, use a different issue template.
       options:

--- a/packages/asar.vm/asar.vm.nuspec
+++ b/packages/asar.vm/asar.vm.nuspec
@@ -6,8 +6,8 @@
     <authors>@electron/asar contributors</authors>
     <description>asar decompresses .asar archives</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="nodejs.vm" version="0.0.0.20240516" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs.vm" version="0.0.0.20250219" />
     </dependencies>
     <tags>Packers</tags>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1871,7 +1871,7 @@ function VM-Pip-Install {
 
     	ForEach ($library in $libraries.Split(",")) {
         	# Ignore warning with `-W ignore` to avoid warnings like deprecation to fail the installation
-        	Invoke-Expression "py -3.10 -W ignore -m pip install $library --disable-pip-version-check 2>&1 >> $outputFile"
+        	Invoke-Expression "py -3.13 -W ignore -m pip install $library --disable-pip-version-check 2>&1 >> $outputFile"
     	}
     } catch {
         VM-Write-Log-Exception $_
@@ -1908,7 +1908,7 @@ function VM-Pip-Uninstall {
     param (
         [string]$package
     )
-    Invoke-Expression "py -3.10 -m pip uninstall $package -y --disable-pip-version-check 2>&1"
+    Invoke-Expression "py -3.13 -m pip uninstall $package -y --disable-pip-version-check 2>&1"
 }
 
 # Uninstall tool using Pip and remove shortcut in the Tools directory

--- a/packages/dotnet-6.vm/dotnet-6.vm.nuspec
+++ b/packages/dotnet-6.vm/dotnet-6.vm.nuspec
@@ -8,8 +8,8 @@
     <description>.NET 6.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="dotnet-6.0-desktopruntime" version="[6.0.14, 6.1)" />
-      <dependency id="dotnet-6.0-runtime" version="[6.0.14, 6.1)" />
+      <dependency id="dotnet-6.0-desktopruntime" version="[6.0.36]" />
+      <dependency id="dotnet-6.0-runtime" version="[6.0.36]" />
     </dependencies>
     <tags>dotNet</tags>
   </metadata>

--- a/packages/dotnet-8.vm/dotnet-8.vm.nuspec
+++ b/packages/dotnet-8.vm/dotnet-8.vm.nuspec
@@ -8,7 +8,7 @@
     <description>.NET 8.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="dotnet-8.0-desktopruntime" version="[8, 8.1)" />
+      <dependency id="dotnet-8.0-desktopruntime" version="[8.0.16]" />
     </dependencies>
     <tags>dotNet</tags>
   </metadata>

--- a/packages/dotnet-9.vm/dotnet-9.vm.nuspec
+++ b/packages/dotnet-9.vm/dotnet-9.vm.nuspec
@@ -8,7 +8,7 @@
     <description>.NET 9.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="dotnet-9.0-desktopruntime" version="[9, 9.1)" />
+      <dependency id="dotnet-9.0-desktopruntime" version="[9.0.5]" />
     </dependencies>
     <tags>dotNet</tags>
   </metadata>

--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -7,7 +7,7 @@
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240424" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
+++ b/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
@@ -7,7 +7,7 @@
     <description>IDA Plugin that help analyzing modules using COM.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
+++ b/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
@@ -7,7 +7,7 @@
     <description>IDA Pro plugin that implements new registers and stack views.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
+++ b/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
@@ -7,7 +7,7 @@
     <description>Diaphora is a program diffing IDA plugin.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
+++ b/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
@@ -7,7 +7,7 @@
     <description>IDA Pro plugins used by the FLARE team.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
+++ b/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
@@ -7,7 +7,7 @@
     <description>Malware string hash lookup plugin for IDA Pro</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
+++ b/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
@@ -7,7 +7,7 @@
     <description>Interactive Functions List IDA Pro plugin.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
+++ b/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
@@ -7,7 +7,7 @@
     <description>A powerful coverage explorer.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>IDA Plugins</tags>
   </metadata>

--- a/packages/js-beautify.vm/js-beautify.vm.nuspec
+++ b/packages/js-beautify.vm/js-beautify.vm.nuspec
@@ -6,8 +6,8 @@
     <authors>beautifier.io</authors>
     <description>JavaScript beautifier and deobfuscator.</description>
     <dependencies>
-      <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="nodejs.vm" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs.vm" version="0.0.0.20250219" />
     </dependencies>
     <tags>Javascript</tags>
   </metadata>

--- a/packages/js-deobfuscator.vm/js-deobfuscator.vm.nuspec
+++ b/packages/js-deobfuscator.vm/js-deobfuscator.vm.nuspec
@@ -6,8 +6,8 @@
     <authors>ben-sb</authors>
     <description>Deobfuscator to remove common JS obfuscation techniques.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="nodejs.vm" version="0.0.0.20240516" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs.vm" version="0.0.0.20250219" />
     </dependencies>
     <tags>Javascript</tags>
   </metadata>

--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -6,7 +6,7 @@
     <description>Metapackage to install common Python libraries</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
       <dependency id="vcbuildtools.vm" />
       <dependency id="python3.vm" />
     </dependencies>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -7,7 +7,7 @@ try {
     $modulesXml = [xml](Get-Content $modulesPath)
 
     # Fix pip version
-    VM-Pip-Install "pip~=23.2.1"
+    VM-Pip-Install "pip~=25.1.1"
 
     $failures = @()
     $modules = $modulesXml.modules.module
@@ -21,16 +21,16 @@ try {
         VM-Pip-Install $installValue
 
         if ($LastExitCode -eq 0) {
-            Write-Host "`t[+] Installed Python 3.10 module: $($module.name)" -ForegroundColor Green
+            Write-Host "`t[+] Installed Python 3.13 module: $($module.name)" -ForegroundColor Green
         } else {
-            Write-Host "`t[!] Failed to install Python 3.10 module: $($module.name)" -ForegroundColor Red
+            Write-Host "`t[!] Failed to install Python 3.13 module: $($module.name)" -ForegroundColor Red
             $failures += $module.Name
         }
     }
 
     if ($failures.Count -gt 0) {
         foreach ($module in $failures) {
-            VM-Write-Log "ERROR" "Failed to install Python 3.10 module: $module"
+            VM-Write-Log "ERROR" "Failed to install Python 3.13 module: $module"
         }
         $outputFile = $outputFile.replace('lib\', 'lib-bad\')
         VM-Write-Log "ERROR" "Check $outputFile for more information"

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -38,7 +38,7 @@
       The internet detector needs to build the Python executable with a version of pyinstaller capable of executing in admin cmd.
       Fix also the version of pywin32 and icmplib to avoid issues
     -->
-    <module name="pyinstaller==6.10.0"/>
-    <module name="pywin32==308"/>
+    <module name="pyinstaller==6.13.0"/>
+    <module name="pywin32==310"/>
     <module name="icmplib==3.0.4"/>
 </modules>

--- a/packages/nodejs.vm/nodejs.vm.nuspec
+++ b/packages/nodejs.vm/nodejs.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nodejs.vm</id>
-    <version>0.0.0.20250219</version>
+    <version>24.1.0</version>
     <authors>Node.js Foundation</authors>
     <description>Metapackage for Node.js to ensure all packages use the same Node.js version.</description>
     <dependencies>
-      <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="nodejs" version="[20.7.0, 20.8.0)" />
-      <dependency id="git" version="[2.45.0,)" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs" version="[24.1.0]" />
+      <dependency id="git" version="[2.49.0]" />
     </dependencies>
     <tags>Javascript</tags>
   </metadata>

--- a/packages/obfuscator-io-deobfuscator.vm/obfuscator-io-deobfuscator.vm.nuspec
+++ b/packages/obfuscator-io-deobfuscator.vm/obfuscator-io-deobfuscator.vm.nuspec
@@ -6,8 +6,8 @@
     <authors>ben-sb</authors>
     <description>A deobfuscator for scripts obfuscated by Obfuscator.io</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="nodejs.vm" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs.vm" version="0.0.0.20250219" />
     </dependencies>
     <tags>Javascript</tags>
   </metadata>

--- a/packages/openjdk.vm/openjdk.vm.nuspec
+++ b/packages/openjdk.vm/openjdk.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>openjdk.vm</id>
-    <version>0.0.0.20250218</version>
+    <version>22.0.2</version>
     <authors>Oracle</authors>
     <description>Metapackage for OpenJDK to ensure all packages use the same OpenJDK version.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="openjdk" version="[21.0.1, 21.0.2)" />
+      <dependency id="openjdk" version="[22.0.2]" />
     </dependencies>
     <tags>Java and Android</tags>
   </metadata>

--- a/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
+++ b/packages/pkg-unpacker.vm/pkg-unpacker.vm.nuspec
@@ -6,8 +6,8 @@
     <authors>LockBlock-dev</authors>
     <description>Unpacker for pkg applications.</description>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="nodejs.vm" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="nodejs.vm" version="0.0.0.20250219" />
     </dependencies>
     <tags>Packers</tags>
   </metadata>

--- a/packages/python3.vm/python3.vm.nuspec
+++ b/packages/python3.vm/python3.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>python3.vm</id>
-    <version>0.0.0.20250218</version>
+    <version>3.13.3</version>
     <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
     <authors>Mandiant</authors>
     <dependencies>
-      <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="python3" version="[3.10.0, 3.11.0)" />
+      <dependency id="common.vm" version="0.0.0.20250509" />
+      <dependency id="python3" version="[3.13.3]" />
     </dependencies>
     <tags>Python</tags>
   </metadata>

--- a/packages/sfextract.vm/sfextract.vm.nuspec
+++ b/packages/sfextract.vm/sfextract.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>sfextract.vm</id>
-    <version>2.1.0.20250505</version>
+    <version>2.1.0.20250527</version>
     <authors>Joery Droppers</authors>
     <description>sfextract extracts contents (assemblies, configuration, etc.) from .NET single file bundles.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="dotnet-6.0-sdk" version="[6.0.400, 6.1)" />
+      <dependency id="dotnet-6.0-sdk" version="[6.0.428]" />
     </dependencies>
     <tags>dotNet</tags>
     <projectUrl>https://github.com/Droppers/SingleFileExtractor</projectUrl>

--- a/packages/unpyc3.vm/unpyc3.vm.nuspec
+++ b/packages/unpyc3.vm/unpyc3.vm.nuspec
@@ -7,7 +7,7 @@
     <description>A decompiler for Python 3.7+.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
-      <dependency id="libraries.python3.vm" />
+      <dependency id="libraries.python3.vm" version="0.0.0.20250425" />
     </dependencies>
     <tags>Python</tags>
   </metadata>

--- a/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
+++ b/packages/vcbuildtools.vm/vcbuildtools.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcbuildtools.vm</id>
-    <version>0.0.0.20250228</version>
+    <version>0.0.0.20250509</version>
     <description>Metapackage that requires the dependencies visualstudio2017buildtools and visualstudio2017-workload-vctools</description>
     <authors>Mandiant, Microsoft</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="visualstudio2017buildtools" version="[15.9.58, 15.9.59)" />
+      <dependency id="visualstudio2017buildtools" version="[15.9.73]" />
       <dependency id="visualstudio2017-workload-vctools" version="[1.3.3]" />
     </dependencies>
     <tags>Productivity Tools</tags>

--- a/packages/vcredist140.vm/vcredist140.vm.nuspec
+++ b/packages/vcredist140.vm/vcredist140.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>vcredist140.vm</id>
-    <version>0.0.0.20250220</version>
-    <description>Metapackage for Python 3 to ensure all packages use the same Python version.</description>
+    <version>14.44.35112</version>
+    <description>Metapackage for Visual C++ Redistributable to ensure all packages use the same version.</description>
     <authors>Mandiant</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="vcredist140" version="[14.42.34433, 14.43)" />
+      <dependency id="vcredist140" version="[14.44.35112.1]" />
     </dependencies>
     <tags>Productivity Tools</tags>
   </metadata>


### PR DESCRIPTION
There are many packages with a bad format version specified like this one with a parenthesis:
```
<dependency id="dotnet-6.0-desktopruntime" version="[6.0.14, 6.1)" />
```

And it is fixed in all of them for a success execution of CI script that update packages automatically, replacing parenthesis for closing square bracket:
```
<dependency id="dotnet-6.0-desktopruntime" version="[6.0.14, 6.1]" />
```

Also I updated some references to python with latest versions.