### PR TITLE
[idafree] Update to IDA 9

### DIFF
--- a/packages/idafree.vm/idafree.vm.nuspec
+++ b/packages/idafree.vm/idafree.vm.nuspec
@@ -2,11 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idafree.vm</id>
-    <version>8.4.0.20250430</version>
+    <version>9.1</version>
     <authors>Hex-Rays</authors>
     <description>IDA Free is the free version of IDA Pro, a powerful Interactive DisAssembler and debugger.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
+      <!-- 7zip.vm needed to unzip ida_installer.7z -->
+      <dependency id="7zip.vm" />
     </dependencies>
     <tags>Disassemblers</tags>
     <projectUrl>https://hex-rays.com/ida-free</projectUrl>

--- a/packages/idafree.vm/tools/chocolateyinstall.ps1
+++ b/packages/idafree.vm/tools/chocolateyinstall.ps1
@@ -5,39 +5,57 @@ try {
   $toolName = 'ida'
   $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
+  # Download IDA .7z with the IDA installer and the FLARE-VM license
+  $idaZipPath = Join-Path ${Env:TEMP} "ida_installer.7z"
+  $idaZipSource = "https://hex-rays.com/hubfs/FlareVM/ida_installer.7z"
+  $idaZipChecksum = "d5e463cb13359707303442e16408351af7cff08f2b51ed12cacb7b5ddda0d165"
+  Get-ChocolateyWebFile -PackageName $toolName -fileFullPath $idaZipPath -Url $idaZipSource -Checksum $idaZipChecksum -ChecksumType "sha256"
+  VM-Assert-Path $idaZipPath
+
+  # Unzip downloaded .7z with the IDA installer and the FLARE-VM license
+  $idaUnzippedDir = Join-Path ${Env:TEMP} $toolName
+  7z x $idaZipPath -o"$idaUnzippedDir" -y -bd | Out-Null
+
+  $installerPath = Get-ChildItem -Path  "$idaUnzippedDir\ida-free-*.exe"
+  VM-Assert-Path $installerPath
+
   $packageArgs = @{
     packageName  = ${Env:ChocolateyPackageName}
     fileType     = 'exe'
     silentArgs   = '--mode unattended'
-    url          = 'https://out7.hex-rays.com/files/idafree84_windows.exe'
-    checksum     = 'a2fc7eae91860a6d05c946d1ee8ab59afd061e8fc5f965de4112d66b16ac2091'
-    checksumType = 'sha256'
+    file         = $installerPath
   }
   Install-ChocolateyPackage @packageArgs
 
-  $toolDir = Join-Path ${Env:ProgramFiles} "IDA Freeware 8.4" -Resolve
-  $executablePath = Join-Path $toolDir "ida64.exe" -Resolve
+  # Wait for IDA to be installed
+  Start-Sleep -Seconds 10
+
+  $toolDir = Get-ChildItem -Path "${Env:ProgramFiles}\IDA Free*" -Directory
+  $executablePath = Join-Path $toolDir "ida.exe" -Resolve
 
   Install-BinFile -Name $toolname -Path $executablePath
 
-  # Delete Desktop shortcut
-  $desktopShortcut = Resolve-Path "${Env:Public}\Desktop\IDA Freeware*"
-  if ($null -ne $desktopShortcut) { Remove-Item $desktopShortcut -Force -ea 0 }
+  # Add ida to the Tools directory, use directly (instead of ida_launcher.exe) to avoid taskbar duplication
+  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $executablePath
 
   # Download ida_launcher.exe to assist with taskbar and right click option and store it in %RAW_TOOLS_DIR%
   # ida_launcher.exe is a custom binary that searches for the latest ida64.exe and executes it
   $launcherName = 'ida_launcher'
-  $launcherSource = 'https://raw.githubusercontent.com/mandiant/VM-Packages/119ba385de053b01b0d1732d60ad1b1152496dc2/ida_launcher/ida_launcher.exe'
+  $launcherSource = 'https://github.com/mandiant/VM-Packages/raw/ab43abbebf0f58abf579775e0794c2888285dee1/ida_launcher/ida_launcher.exe'
   $launcherPath = Join-Path ${Env:RAW_TOOLS_DIR} "$launcherName.exe"
-  $launcherChecksum = "a98241e476150d053d67d149c1b54816c8306db51e0987613ec25a0f8ad22006"
+  $launcherChecksum = "e6d6799254985a4db1098806515a9bcf4b818bde246d37839769874ecf7a2a84"
   Get-ChocolateyWebFile -PackageName $launcherName -FileFullPath $launcherPath -Url $launcherSource -Checksum $launcherChecksum -ChecksumType "sha256"
   VM-Assert-Path $launcherPath
 
-  $icon = Join-Path $toolDir "$toolName.ico" -Resolve
-  VM-Install-Shortcut -toolName $toolName -category $category -executablePath $launcherPath -IconLocation $icon
-
-  # ida64.exe supports both 32 bit and 64 bit in IDA >= 8.2
+  # Use ida_launcher.exe in the right click option "Open with IDA"
+  $icon = Join-Path $toolDir "ida.ico" -Resolve
   VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$icon"
+
+  # Create IDA user directory and copy flare-vm@google.com license
+  $idaDir = "${Env:APPDATA}\Hex-Rays\IDA Pro"
+  New-Item $idaDir -ItemType "directory" -Force | Out-Null
+  $licensePath = Get-ChildItem -Path "$idaUnzippedDir\idafree_9*.hexlic"
+  Copy-Item $licensePath $idaDir
 
   # Refresh Desktop as shortcut is used in FLARE-VM LayoutModification.xml
   VM-Refresh-Desktop

--- a/packages/idapro.vm/idapro.vm.nuspec
+++ b/packages/idapro.vm/idapro.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>idapro.vm</id>
-    <version>0.0.0.20250430</version>
+    <version>0.0.0.20250612</version>
     <authors>Hex-Rays</authors>
     <description>IDA Pro 9 is an interactive DisAssembler and debugger. Requires `ida-pro_9*.exe` (optional `.hexlic`) from https://hex-rays.com/ida-pro in the Desktop.</description>
     <dependencies>

--- a/packages/idapro.vm/tools/chocolateyinstall.ps1
+++ b/packages/idapro.vm/tools/chocolateyinstall.ps1
@@ -28,8 +28,9 @@ try {
 
   # Wait for IDA to be installed
   Start-Sleep -Seconds 10
-  $executablePath = Resolve-Path "${Env:ProgramFiles}\IDA Professional 9*\ida.exe"
-  VM-Assert-Path $executablePath
+
+  $toolDir = Get-ChildItem -Path "${Env:ProgramFiles}\IDA Professional 9*" -Directory
+  $executablePath = Join-Path $toolDir "ida.exe" -Resolve
 
   Install-BinFile -Name $toolname -Path $executablePath
 
@@ -44,14 +45,14 @@ try {
   # Download ida_launcher.exe and store it in %RAW_TOOLS_DIR%
   # ida_launcher.exe is a custom binary that searches for the latest ida64.exe and executes it
   $launcherName = 'ida_launcher'
-  $launcherSource = 'https://raw.githubusercontent.com/mandiant/VM-Packages/119ba385de053b01b0d1732d60ad1b1152496dc2/ida_launcher/ida_launcher.exe'
+  $launcherSource = 'https://github.com/mandiant/VM-Packages/raw/ab43abbebf0f58abf579775e0794c2888285dee1/ida_launcher/ida_launcher.exe'
   $launcherPath = Join-Path ${Env:RAW_TOOLS_DIR} "$launcherName.exe"
-  $launcherChecksum = "a98241e476150d053d67d149c1b54816c8306db51e0987613ec25a0f8ad22006"
+  $launcherChecksum = "e6d6799254985a4db1098806515a9bcf4b818bde246d37839769874ecf7a2a84"
   Get-ChocolateyWebFile -PackageName $launcherName -FileFullPath $launcherPath -Url $launcherSource -Checksum $launcherChecksum -ChecksumType "sha256"
   VM-Assert-Path $launcherPath
 
   # Use ida_launcher.exe in the right click option "Open with IDA"
-  $icon = Resolve-Path "${Env:ProgramFiles}\IDA*\$toolName.ico" | Select-Object -last 1
+  $icon = Join-Path $toolDir "ida.ico" -Resolve
   VM-Add-To-Right-Click-Menu $launcherName 'Open with IDA' "`"$launcherPath`" `"%1`"" "$icon"
 
 


### PR DESCRIPTION
HexRays has provided an installer and IDA license for IDA Free 9 that we are allowed to used in FLARE-VM. :tada: 

I did some small modifications in idapro.vm to keep both packages on sync.

Closes https://github.com/mandiant/VM-Packages/issues/1150

Needs https://github.com/mandiant/VM-Packages/issues/1415 for the IDA launcher to work.