### PR TITLE
[CI] Remove windows-2019, add windows-2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -48,15 +48,10 @@ jobs:
       - name: Build and test all modified packages
         id: test
         # It runs only if there are modified files
-        # We specifically test for "microsoft-windows-terminal.vm" in 'windows-2019' because it requires at least Windows 10 version 1903/OS build 18362
         if: steps.files.outputs.added_modified_renamed != ''
         run: |
           $os = "${{ matrix.os }}"
           $packages = "${{ steps.files.outputs.added_modified_renamed }}".Split(" ") | Foreach-Object { (Get-Item $_).Directory.Name }
-          if ($os -eq 'windows-2019') {
-            $excludedPackages = @("microsoft-windows-terminal.vm")
-            $packages = $packages | Where-Object { $_ -notin $excludedPackages }
-          }
           $packages = ("common.vm " + $packages -join " ").Trim()
           scripts/test/test_install.ps1 "$packages"
       - name: Upload logs to artifacts

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,12 +17,12 @@ jobs:
       # Updating the wiki fails if between the checkout of the wiki and the push of the update the other job pushes its update
       max-parallel: 1
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022, windows-2025]
         include:
           - os: windows-2022
             os_name: Win22
-          - os: windows-2019
-            os_name: Win19
+          - os: windows-2025
+            os_name: Win25
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](packages)
 [![Daily run failures Windows 2022](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2022_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
-[![Daily run failures Windows 2019](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2019_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
+[![Daily run failures Windows 2025](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2025_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![MyGet version mismatches](https://gist.githubusercontent.com/vm-packages/dfe6ed22576b6c1d2fa749ff46f3bc6f/raw/myget_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/MyGet-Version-Mismatches)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 

--- a/scripts/utils/generate_daily_results.py
+++ b/scripts/utils/generate_daily_results.py
@@ -15,7 +15,7 @@ with open(result_file) as result_f:
     result = json.load(result_f)
 
 url = f"https://github.com/{repository}"
-# Short OS (windows-2019 -> Win19) for nicer table display
+# Short OS (windows-2025 -> Win25) for nicer table display
 run = f"[#{run_number}]({url}/actions/runs/{run_id}) Win{os[-2:]}"
 date = datetime.today().strftime("%Y-%m-%d %H:%M")
 log_line = f"| {run} | {date} | {result['failure']}/{result['total']} |"


### PR DESCRIPTION
`windows-2019` has been deprecated and will be removed by the end of the month: https://github.com/actions/runner-images/issues/12045 Add the newly added `windows-2025`: https://github.com/actions/runner-images/issues/11228