### PR TITLE
Fix to issue #1398 in update_package.py

### DIFF
--- a/packages/memprocfs.vm/memprocfs.vm.nuspec
+++ b/packages/memprocfs.vm/memprocfs.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>memprocfs.vm</id>
-    <version>5.14.11</version>
+    <version>5.14.13</version>
     <authors>Ulf Frisk</authors>
     <description>MemProcFS is an easy and convenient way of viewing physical memory as files in a virtual file system.</description>
     <dependencies>

--- a/packages/memprocfs.vm/tools/chocolateyinstall.ps1
+++ b/packages/memprocfs.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MemProcFS'
 $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14.13/MemProcFS_files_and_binaries_v5.14.9-win_x64-20250411.zip'
+$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14/MemProcFS_files_and_binaries_v5.14.13-win_x64-20250612.zip'
 $zipSha256 = '53036def133480a1d68bc5d9cbd74fc03125b508c5a98910a5dd9c8bec43f722'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false

--- a/packages/memprocfs.vm/tools/chocolateyinstall.ps1
+++ b/packages/memprocfs.vm/tools/chocolateyinstall.ps1
@@ -4,7 +4,8 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'MemProcFS'
 $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14/MemProcFS_files_and_binaries_v5.14.11-win_x64-20250501.zip'
-$zipSha256 = '40ce4ac604933dd919444a9cee42431b3fe43813fa4155bef17466b7db03d764'
+$zipUrl = 'https://github.com/ufrisk/MemProcFS/releases/download/v5.14.13/MemProcFS_files_and_binaries_v5.14.9-win_x64-20250411.zip'
+$zipSha256 = '53036def133480a1d68bc5d9cbd74fc03125b508c5a98910a5dd9c8bec43f722'
 
 VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -innerFolder $false
+

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -25,9 +25,7 @@ def replace_version(latest_version, nuspec_content):
         except ValueError:
             # not all tools use symver, observed examples: `cp_1.1.0` or `current`
             print(f"unusual version format: {latest_version}")
-            print(
-                "reusing old version with updated date, manual fixing may be appropriate"
-            )
+            print("reusing old version with updated date, manual fixing may be appropriate")
             latest_version = version
     # If same version add date
     if version == latest_version:
@@ -41,16 +39,12 @@ def replace_version(latest_version, nuspec_content):
 
 # Get latest version from GitHub releases
 def get_latest_version(org, project, version):
-    response = requests.get(
-        f"https://api.github.com/repos/{org}/{project}/releases/latest"
-    )
+    response = requests.get(f"https://api.github.com/repos/{org}/{project}/releases/latest")
     if not response.ok:
         print(f"GitHub API response not ok: {response.status_code}")
         return None
     if org == "ufrisk" and project == "MemProcFS":
-        latest_version = re.search(
-            r"v\d+\.\d+\.\d+", response.json()["assets"][4]["browser_download_url"]
-        )
+        latest_version = re.search(r"v\d+\.\d+\.\d+", response.json()["assets"][4]["browser_download_url"])
         if latest_version.group().startswith("v"):
             return (
                 latest_version.group()[1:],
@@ -162,9 +156,7 @@ def update_github_url(package):
             latest_sha256 = get_sha256(latest_url)
             if not latest_sha256:
                 return None
-            content = content.replace(sha256, latest_sha256).replace(
-                sha256.upper(), latest_sha256
-            )
+            content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
             break
 
@@ -182,9 +174,7 @@ def update_github_url(package):
         # Hash can be uppercase or downcase
         if not latest_sha256:
             return None
-        content = content.replace(sha256, latest_sha256).replace(
-            sha256.upper(), latest_sha256
-        )
+        content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
     if org == "ufrisk" and project == "MemProcFS":
         content = content.replace(url, latest_url)
@@ -290,9 +280,7 @@ def update_version_url(package):
         latest_version = latest_version_match
         sha256 = get_sha256(url)
         # Hash can be uppercase or downcase
-        content = content.replace(sha256, latest_sha256).replace(
-            sha256.upper(), latest_sha256
-        )
+        content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
     content = content.replace(version, latest_version)
     with open(install_script_path, "w") as file:
@@ -363,9 +351,7 @@ def update_dynamic_url(package):
             if latest_sha256.lower() == sha256.lower():
                 return None
 
-            content = content.replace(sha256, latest_sha256).replace(
-                sha256.upper(), latest_sha256
-            )
+            content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
         # write back the changed chocolateyinstall.ps1
         with open(install_script_path, "w") as file:
@@ -406,9 +392,7 @@ def update_msixbundle_url(package):
     sha256 = sha256_m.group("sha256")
     # Hash can be uppercase or downcase
     content = (
-        content.replace(sha256, latest_sha256)
-        .replace(sha256.upper(), latest_sha256)
-        .replace(version, latest_version)
+        content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256).replace(version, latest_version)
     )
 
     with open(install_script_path, "w") as file:

--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -150,6 +150,7 @@ def update_github_url(package):
             if not latest_sha256:
                return None
             content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
+
             break
             
 
@@ -169,6 +170,15 @@ def update_github_url(package):
             return None
         content = content.replace(sha256, latest_sha256).replace(sha256.upper(), latest_sha256)
 
+    if org == 'ufrisk' and project == 'MemProcFS':
+         content = content.replace(url, latest_url)
+         with open(install_script_path, "w") as file:
+              file.write(content)
+         update_nuspec_version(package, latest_version)
+
+         return latest_version
+         
+        
     content = content.replace(version, latest_version)
     with open(install_script_path, "w") as file:
         file.write(content)


### PR DESCRIPTION
the script Now directly pastes Memprocfs the link extracted from github api and fetches the version directly from link and not from tag_name . I have done it now only for Memprocfs as it is the problematic one , i am currently testing for others