### PR TITLE
Fix update version script for autopsy

### DIFF
--- a/scripts/utils/update_package.py
+++ b/scripts/utils/update_package.py
@@ -116,12 +116,12 @@ def update_github_url(package):
     # Use findall as some packages have two URLs (for 32 and 64 bits), we need to update both
     # Match URLs like https://github.com/mandiant/capa/releases/download/v4.0.1/capa-v4.0.1-windows.zip
     matches = re.findall(
-        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/v?(?P<version>[^/]+)/[^\"']+)[\"']",
+        r"[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/releases/download/[^/]*?(?P<version>\d+(?:\.\d+)+)/[^\"']+)[\"']",
         content,
     )
     # Match also URLs like https://github.com/joxeankoret/diaphora/archive/refs/tags/3.0.zip
     matches += re.findall(
-        "[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/archive/refs/tags/v?(?P<version>[^/]+).zip)[\"']",
+        r"[\"'](?P<url>https://github.com/(?P<org>[^/]+)/(?P<project>[^/]+)/archive/refs/tags/[^/]*?(?P<version>\d+(?:\.\d+)+)\.zip)[\"']",
         content,
     )
 


### PR DESCRIPTION
This fixes the issue we ran into for `autopsy` updates having odd commit messages: https://github.com/mandiant/VM-Packages/issues/1367

The original regex captured `autopsy-4.22.1` because it was too general. Specifically, the `[^/]` after `<version>`:
  * `^/`: The `^` inside the brackets means NOT, so `[^/]` means "match any single character that is not a forward slash."
  * `+`: This means "one or more times."
  * When you combine them, `[^/]+` tells the regex engine to "grab a continuous block of every character until you hit a forward slash.", which is what grabs `autopsy-4.22.1` from `https://github.com/sleuthkit/autopsy/releases/download/autopsy-4.22.1/autopsy-4.22.1-64bit.msi`


Changes:
* `[^/]*?`: This is a non-capturing and non-greedy pattern that matches any characters leading up to the version number within that part of the URL path (e.g., `autopsy-`). 
  * It is non-greedy `(*?)` so it stops as soon as the next part of the pattern can match.

* `(?P<version>\d+(?:\.\d+)+)`: This is the new version capture group.
  * `\d+` matches one or more digits.
  * `(?:\.\d+)+` is a non-capturing group that matches a dot followed by digits, repeated one or more times.

Here is a screenshot of me testing both original and updated regex matches to show that other packages are not effected by this change:
![image](https://github.com/user-attachments/assets/f0b7ca50-ecce-4174-91ab-c6443e5ef5e2)