### PR TITLE
Fix My Get mismatches automation

### DIFF
--- a/.github/workflows/compare_myget.yml
+++ b/.github/workflows/compare_myget.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
+          token: ${{ secrets.REPO_TOKEN }}
+          fetch-depth: 0
       - name: Add results to wiki
         run: |
           $mismatches=$(python scripts/utils/compare_myget.py)


### PR DESCRIPTION
Provide the repo token when checking out the wiki code to fix a permission error when pushing to the wiki. The action started failing 2 months ago, likely because a change in the workflow permissions in the mandiant organization.