### PR TITLE
Fix(ci): Ensure clean state between package tests

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -27,7 +27,7 @@ jobs:
             $package = $packagePath.Name
             $newVersion = 0
             # Test independently every type of update and commit what works
-            foreach ($UPDATE_TYPE in ('DEPENDENCIES', 'GITHUB_URL', 'VERSION_URL', 'DYNAMIC_URL', 'MSIXBUNDLE_URL')) {
+            foreach ($UPDATE_TYPE in ('GITHUB_URL', 'MSIXBUNDLE_URL', 'VERSION_URL', 'DYNAMIC_URL', 'DEPENDENCIES')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
               echo "$package $version"
@@ -49,6 +49,10 @@ jobs:
               # Clean changes and built packages
               git restore .
               Remove-Item built_pkgs -Recurse -ErrorAction Ignore
+              if ($tested) {
+                # Only allow 1 successful package install
+                break
+              }
             }
             if ($newVersion) {
               if ($finalUpdateType -eq 'DYNAMIC_URL') {


### PR DESCRIPTION
The package update workflow was vulnerable to state pollution, causing false-positive test results. A successful test of one version could leave artifacts on the file system that would cause a subsequent test of a new, broken version to incorrectly pass.

This was observed when a successful installation of `nmap v7.93` left on the system, which then caused the test for the broken `v7.94` package to succeed because the file already existed.

## Original (outdated) change
The original change/fix I came up with was to add a `choco uninstall` command after each test run. This ensures every package test starts in a clean environment, preventing artifacts from one test from influencing another and guaranteeing that installation failures are accurately detected.

Working change in logs showing `nmap v7.94` fails after uninstalling `v7.93`:
https://github.com/emtuls/VM-Packages/actions/runs/16158436802/job/45605392190#step:5:1028

New Workflow: https://github.com/emtuls/VM-Packages/actions/runs/16158436802/workflow

Previous version that shows `v7.93` and `v7.94` working in logs:
https://github.com/emtuls/VM-Packages/actions/runs/16158000438/job/45604210877#step:5:1138

Old Workflow: https://github.com/emtuls/VM-Packages/actions/runs/16158000438/workflow

### Problem
This left a secondary issue of taking the version of last `$UPDATE_TYPE` to succeed rather than the highest one if multiple types succeeded, which led to my second change, which is a bit more robust.
## 

## New (updated) change
I updated the workflow file to be slightly more improved so that it checks for and tests only the highest found version, as there is a possibility that multiple `$UPDATE_TYPE` could work and result in different versions, and the current workflow would select the last working update type even if the version was not the highest.

New run with update for finding and testing only highest version (linking directly to `nmap` to show that it correctly fails after finding and testing the latest version `7.94`):
https://github.com/emtuls/VM-Packages/actions/runs/16159022853/job/45606992656#step:5:587

Workflow File: https://github.com/emtuls/VM-Packages/actions/runs/16159022853/workflow

New Package Update PR that works: https://github.com/emtuls/VM-Packages/pull/2
##


This addresses the primary issue in https://github.com/mandiant/VM-Packages/issues/1366, but there is still the underlying issue that `nmap v7.94` fails to properly install `zenmap`, which seems to possibly be a known issue?

The PR is not from my fork due to some other issues in my repo I need to resolve after pulling the latest commits that would have caused issues with this PR.