### PR TITLE
Improve Packages Wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](packages)
+[![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Packages)
 [![Daily run failures Windows 2022](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2022_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![Daily run failures Windows 2025](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2025_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![MyGet version mismatches](https://gist.githubusercontent.com/vm-packages/dfe6ed22576b6c1d2fa749ff46f3bc6f/raw/myget_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/MyGet-Version-Mismatches)

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -8,7 +8,7 @@ DEFAULT_CONFIG_URL = "https://raw.githubusercontent.com/mandiant/flare-vm/main/c
 PACKAGE_URL_BASE = "https://github.com/mandiant/VM-Packages/tree/main/packages"
 
 
-def sort_write_wiki_content(file_path, packages_by_category, default_packages):
+def create_package_wiki_file(file_path, packages_by_category, default_packages):
     """Writes package information sorted by category to a Markdown wiki file.
 
     This function iterates through the `packages_by_category` dictionary, which
@@ -143,4 +143,4 @@ if __name__ == "__main__":
 
     default_packages = get_default_packages()
     packages_by_category = get_packages_by_category(args.packages)
-    sort_write_wiki_content(args.wiki, packages_by_category, default_packages)
+    create_package_wiki_file(args.wiki, packages_by_category, default_packages)

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -7,16 +7,18 @@ from collections import defaultdict
 # Dict[str (category), Dict[str (pkg_name, pkg_description)]]
 packages_by_category = defaultdict(dict)
 
+PACKAGE_URL_BASE = "https://github.com/mandiant/VM-Packages/tree/main/packages"
+
 
 def sort_write_wiki_content(file_path):
     """Writes package information sorted by category to a Markdown wiki file.
 
     This function iterates through the `packages_by_category` dictionary, which
     contains package information organized by category. For each category, it
-    generates a Markdown header and a table containing package names and
-    descriptions. Both the categories and the packages inside a category are
-    sorted alphabetically. The resulting Markdown content is then written to
-    the specified file.
+    generates a Markdown header and a table containing package names (with a
+    link to the package source code) and descriptions. Both the categories and
+    the packages inside a category are sorted alphabetically. The resulting
+    Markdown content is then written to the specified file.
 
     Args:
         file_path (str): The path to the output Markdown file.
@@ -30,7 +32,8 @@ Do not edit it manually.\n
         wikiContent += "| Package | Description |\n"
         wikiContent += "| ------- | ----------- |\n"
         for pkg_name, pkg_description in sorted(packages.items()):
-            wikiContent += f"| {pkg_name} | {pkg_description} |\n"
+            package_url = f"{PACKAGE_URL_BASE}/{pkg_name}"
+            wikiContent += f"| [{pkg_name}]({package_url}) | {pkg_description} |\n"
         wikiContent += "\n\n"
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(wikiContent)

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -26,8 +26,10 @@ def create_package_wiki_file(file_path, packages_by_category, default_packages):
     """
     wiki_content = f"""This page documents the available VM packages sorted by category.
 The packages in the [FLARE-VM default configuration]({DEFAULT_CONFIG_URL}) are marked in bold.
-This page is [generated automatically](https://github.com/mandiant/VM-Packages/blob/main/.github/workflows/generate_package_wiki.yml).
-Do not edit it manually.\n
+
+> **Note:**
+> This page is [generated automatically](https://github.com/mandiant/VM-Packages/blob/main/.github/workflows/generate_package_wiki.yml).
+> Do not edit it manually.\n
 """
     for category, packages in sorted(packages_by_category.items()):
         wiki_content += f"## {category}\n\n"

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 import pathlib
 import xml.etree.ElementTree as ET
 from collections import defaultdict
@@ -103,7 +102,7 @@ def process_packages_directory(packages_dir):
     Args:
         packages: directory where the packages reside.
     """
-    if not os.path.isdir(packages_dir):
+    if not pathlib.Path(packages_dir).is_dir():
         raise FileNotFoundError(f"Packages directory not found: {packages_dir}")
 
     for nuspec_path in pathlib.Path(packages_dir).glob("**/*.nuspec"):

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -24,14 +24,14 @@ def sort_write_wiki_content(file_path):
     Args:
         file_path (str): The path to the output Markdown file.
     """
-    wikiContent = """This page documents the available VM packages sorted by category.
+    wiki_content = """This page documents the available VM packages sorted by category.
 This page is [generated automatically](https://github.com/mandiant/VM-Packages/blob/main/.github/workflows/generate_package_wiki.yml).
 Do not edit it manually.\n
 """
     for category, packages in sorted(packages_by_category.items()):
-        wikiContent += f"## {category}\n\n"
-        wikiContent += "| Package | Description |\n"
-        wikiContent += "| ------- | ----------- |\n"
+        wiki_content += f"## {category}\n\n"
+        wiki_content += "| Package | Description |\n"
+        wiki_content += "| ------- | ----------- |\n"
 
         for pkg_name, pkg_info in sorted(packages.items()):
             description, project_url = pkg_info
@@ -42,11 +42,11 @@ Do not edit it manually.\n
             if project_url:
                 description = f"{description} [Link]({project_url})"
 
-            wikiContent += f"| [{pkg_name}]({package_url}) | {description} |\n"
+            wiki_content += f"| [{pkg_name}]({package_url}) | {description} |\n"
 
-        wikiContent += "\n\n"
+        wiki_content += "\n\n"
     with open(file_path, "w", encoding="utf-8") as f:
-        f.write(wikiContent)
+        f.write(wiki_content)
 
 
 def find_element_text(parent, tag_name):

--- a/scripts/utils/generate_package_wiki.py
+++ b/scripts/utils/generate_package_wiki.py
@@ -4,7 +4,7 @@ import pathlib
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 
-# Dict[str (category), Dict[str (pkg_name, pkg_description)]]
+# Dict[str (category), Dict[str (pkg_name, (pkg_description, project_url))]]
 packages_by_category = defaultdict(dict)
 
 PACKAGE_URL_BASE = "https://github.com/mandiant/VM-Packages/tree/main/packages"
@@ -16,9 +16,10 @@ def sort_write_wiki_content(file_path):
     This function iterates through the `packages_by_category` dictionary, which
     contains package information organized by category. For each category, it
     generates a Markdown header and a table containing package names (with a
-    link to the package source code) and descriptions. Both the categories and
-    the packages inside a category are sorted alphabetically. The resulting
-    Markdown content is then written to the specified file.
+    link to the package source code) and descriptions (including the project
+    URL). Both the categories and the packages inside a category are sorted
+    alphabetically. The resulting Markdown content is then written to the
+    specified file.
 
     Args:
         file_path (str): The path to the output Markdown file.
@@ -31,9 +32,18 @@ Do not edit it manually.\n
         wikiContent += f"## {category}\n\n"
         wikiContent += "| Package | Description |\n"
         wikiContent += "| ------- | ----------- |\n"
-        for pkg_name, pkg_description in sorted(packages.items()):
+
+        for pkg_name, pkg_info in sorted(packages.items()):
+            description, project_url = pkg_info
+
             package_url = f"{PACKAGE_URL_BASE}/{pkg_name}"
-            wikiContent += f"| [{pkg_name}]({package_url}) | {pkg_description} |\n"
+
+            # Append a link to the project's URL to the description
+            if project_url:
+                description = f"{description} [Link]({project_url})"
+
+            wikiContent += f"| [{pkg_name}]({package_url}) | {description} |\n"
+
         wikiContent += "\n\n"
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(wikiContent)
@@ -81,9 +91,10 @@ def process_packages_directory(packages_dir):
             # not contain a category
             if not category:
                 continue
-            description = find_element_text(nuspec_metadata, "description")
             package = find_element_text(nuspec_metadata, "id")
-            packages_by_category[category][package] = description
+            description = find_element_text(nuspec_metadata, "description")
+            project_url = find_element_text(nuspec_metadata, "projectUrl")
+            packages_by_category[category][package] = (description, project_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the _Packages_ wiki page generation script to:
- **Link each package name to its source code directory**, which improves code discoverability by allowing users to navigate directly from the _Packages_ wiki page  to the code.
- **Display the project URL as a link in the description** column of the packages table. This provides users with a convenient, direct link to a package's homepage or external documentation.
- **Bold packages in the default FLARE-VM configuration**.
- **Format the _do not edit_ warning as a Markdown blockquote** to make it stand out.
- **Refactor code** for consistency, code clarify and to make the code easier to maintain

You can see the resulting Wiki page in https://github.com/Ana06/VM-Packages/wiki/Packages.

Partially addresses https://github.com/mandiant/VM-Packages/issues/1231

Link _Packages_ Wiki page instead of the packages directory in the README. This automatically generated page documents the available VM packages and is more useful for the users than the packages directory with the source code.
