### PR TITLE
[CI] Fix daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
+          token: ${{ secrets.REPO_TOKEN }}
+          fetch-depth: 0
       - name: Add results to wiki
         run: python scripts/utils/generate_daily_results.py ${{ github.repository }} ${{ github.sha }} ${{ github.run_number }} ${{ github.run_id }} ${{ matrix.os }}
       - name: Commit changes


### PR DESCRIPTION
Provide the repo token when checking out the wiki code to fix a permission error when pushing the daily results to the wiki.  As in the MyGet automation (fixed in https://github.com/mandiant/VM-Packages/pull/1436), the action started failing 2 months ago, likely because a change in the workflow permissions in the mandiant organization.