### PR TITLE
[doc (nuspecs)] Improve IDA Plugins documentation

### DIFF
--- a/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
+++ b/packages/ida.plugin.capa.vm/ida.plugin.capa.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.capa.vm</id>
-    <version>9.2.1</version>
+    <version>9.2.1.20250715</version>
     <description>capa explorer is an IDAPython plugin that integrates capa with IDA Pro.</description>
     <authors>@mike-hunhoff, @williballenthin, @mr-tz</authors>
     <dependencies>
@@ -10,5 +10,6 @@
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/mandiant/capa</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
+++ b/packages/ida.plugin.comida.vm/ida.plugin.comida.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.comida.vm</id>
-    <version>0.0.0.20250213</version>
+    <version>0.0.0.20250715</version>
     <authors>Airbus CERT</authors>
-    <description>IDA Plugin that help analyzing modules using COM.</description>
+    <description>ComIDA is an IDAPython Plugin that help analyzing modules using COM.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/airbus-cert/comida</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
+++ b/packages/ida.plugin.dereferencing.vm/ida.plugin.dereferencing.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.dereferencing.vm</id>
-    <version>0.0.0.20250213</version>
+    <version>0.0.0.20250715</version>
     <authors>danigargu</authors>
-    <description>IDA Pro plugin that implements new registers and stack views.</description>
+    <description>deREferencing is an IDAPython plugin that enhances registers and stack views by adding dereferenced pointers, colors, and other useful information.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/danigargu/deREferencing</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
+++ b/packages/ida.plugin.diaphora.vm/ida.plugin.diaphora.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.diaphora.vm</id>
-    <version>3.2.1.20250522</version>
+    <version>3.2.1.20250715</version>
     <authors>joxeankoret</authors>
-    <description>Diaphora is a program diffing IDA plugin.</description>
+    <description>Diaphora is an IDAPython plugin that performs advanced program diffing by comparing assembler, pseudo-code, functions, and data structures.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/joxeankoret/diaphora</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
+++ b/packages/ida.plugin.flare.vm/ida.plugin.flare.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.flare.vm</id>
-    <version>0.0.0.20250213</version>
+    <version>0.0.0.20250715</version>
     <authors>Jay Smith</authors>
-    <description>IDA Pro plugins used by the FLARE team.</description>
+    <description>FLARE IDAPython plugins include Shellcode Hashes to find API calls from hashes and ApplyCalleeType to apply function prototypes to indirect calls.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/mandiant/flare-ida</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
+++ b/packages/ida.plugin.hashdb.vm/ida.plugin.hashdb.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.hashdb.vm</id>
-    <version>1.10.0.20250213</version>
+    <version>1.10.0.20250715</version>
     <authors>OALabs</authors>
-    <description>Malware string hash lookup plugin for IDA Pro</description>
+    <description>HashDB is an IDAPython plugin that connects to an online community library to look up hashes, identifying API names and strings in malware.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/OALabs/hashdb</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec
+++ b/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.hrtng.vm</id>
-    <version>2.4.30</version>
+    <version>2.4.30.20250715</version>
     <authors>KasperskyLab</authors>
-    <description>IDA Pro plugin with features such as decryption, automation, deobfuscation, patching, lib code recognition and pseudocode transformations.</description>
+    <description>hrtng is an IDA Pro plugin with features such as decryption, automation, deobfuscation, patching, lib code recognition and pseudocode transformations.</description>
     <dependencies>
       <dependency id="common.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/KasperskyLab/hrtng</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
+++ b/packages/ida.plugin.ifl.vm/ida.plugin.ifl.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.ifl.vm</id>
-    <version>1.4.4.20250213</version>
+    <version>1.4.4.20250715</version>
     <authors>hasherezade</authors>
-    <description>Interactive Functions List IDA Pro plugin.</description>
+    <description>IFL (Interactive Functions List) is an IDAPython plugin for navigating function references and importing reports from tools like PE-sieve.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/hasherezade/ida_ifl</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
+++ b/packages/ida.plugin.lighthouse.vm/ida.plugin.lighthouse.vm.nuspec
@@ -2,13 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.lighthouse.vm</id>
-    <version>0.0.0.20250213</version>
+    <version>0.0.0.20250715</version>
     <authors>gaasedelen</authors>
-    <description>A powerful coverage explorer.</description>
+    <description>Lighthouse is an IDAPython plugin that explores code coverage, providing interactive controls to study execution maps.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240429" />
       <dependency id="libraries.python3.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/gaasedelen/lighthouse</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.xray.vm/ida.plugin.xray.vm.nuspec
+++ b/packages/ida.plugin.xray.vm/ida.plugin.xray.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.xray.vm</id>
-    <version>0.0.0.20250213</version>
+    <version>0.0.0.20250715</version>
     <authors>patois</authors>
-    <description>Hexrays decompiler plugin that colorizes and filters the decompiler's output based on regular expressions</description>
+    <description>xray is an IDAPython plugin that filters and colorizes Hexrays decompiler output based on regular expressions to highlight interesting code patterns.</description>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20240509" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/patois/xray</projectUrl>
   </metadata>
 </package>

--- a/packages/ida.plugin.xrefer.vm/ida.plugin.xrefer.vm.nuspec
+++ b/packages/ida.plugin.xrefer.vm/ida.plugin.xrefer.vm.nuspec
@@ -2,8 +2,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.xrefer.vm</id>
-    <version>1.0.3.20250213</version>
-    <description>Custom navigation interface within IDA.</description>
+    <version>1.0.3.20250715</version>
+    <description>XRefer is an IDAPython plugin that provides a custom navigation interface with path graphs and Gemini-powered descriptions to speed up analysis.</description>
     <authors>Muhammad Umair</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20241029"/>
@@ -11,5 +11,6 @@
       <dependency id="openjdk.vm" />
     </dependencies>
     <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/mandiant/xrefer</projectUrl>
   </metadata>
 </package>


### PR DESCRIPTION
Enhance IDA Plugins descriptions ensuring they follow [our documentation](https://github.com/mandiant/VM-Packages/wiki/Chocolatey-packages#description):
> The description of the tool functionality. The description must be short (max 175 characters) and not include version specific details, license information, or other information that is likely to change in a future version. The description should start with the tool name and end with a `.`.

Add also the URL to the IDA Plugins home page.

The description is displayed in the FLARE-VM installer and both the description and the URL are displayed in the _Packages_ Wiki page, enhancing the IDA Plugins documentation.

Partially addresses https://github.com/mandiant/VM-Packages/issues/1231