### PR TITLE
[CI] Remove windows-2025 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-2025]
+        # TODO: Add windows-2025, see https://github.com/mandiant/VM-Packages/issues/1447
+        os: [windows-2022]
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -58,8 +59,8 @@ jobs:
         uses: ./.github/actions/upload-logs
         if: always()
       - name: Push all built packages to MyGet
-        # Only push packages on master if they were built (not if testing was skipped) and
-        # only with one version of Windows (otherwise it would be pushed 3 times)
+        # Only push packages if they were built (not if testing was skipped)
+        # and only with one version of Windows
         if: steps.test.outcome == 'success' && github.event_name == 'push' && matrix.os == 'windows-2022'
         run: |
           $built_pkgs = Get-ChildItem built_pkgs

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,12 +17,11 @@ jobs:
       # Updating the wiki fails if between the checkout of the wiki and the push of the update the other job pushes its update
       max-parallel: 1
       matrix:
-        os: [windows-2022, windows-2025]
+        # TODO: Add windows-2025, see https://github.com/mandiant/VM-Packages/issues/1447
+        os: [windows-2022]
         include:
           - os: windows-2022
             os_name: Win22
-          - os: windows-2025
-            os_name: Win25
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Packages](https://gist.githubusercontent.com/vm-packages/0e28118f551692f3401ac669e1d6761d/raw/packages_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Packages)
 [![Daily run failures Windows 2022](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2022_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
-[![Daily run failures Windows 2025](https://gist.githubusercontent.com/vm-packages/7d6b2592948d916eb5529350308f01d1/raw/windows-2025_daily_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/Daily-Failures)
 [![MyGet version mismatches](https://gist.githubusercontent.com/vm-packages/dfe6ed22576b6c1d2fa749ff46f3bc6f/raw/myget_badge.svg)](https://github.com/mandiant/VM-Packages/wiki/MyGet-Version-Mismatches)
 [![CI](https://github.com/mandiant/VM-packages/workflows/CI/badge.svg)](https://github.com/mandiant/VM-packages/actions?query=workflow%3ACI+branch%3Amain)
 


### PR DESCRIPTION
Remove windows-2025 until we have found a solution for the disk space issue in https://github.com/mandiant/VM-Packages/issues/1447.