### PR TITLE
[CI: daily] Reduce tries to 3

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test all packages
         continue-on-error: true
-        run: scripts/test/test_install.ps1 -all -max_tries 3
+        run: scripts/test/test_install.ps1 -all
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
       - name: Checkout wiki code


### PR DESCRIPTION
Reduce the maximum number of times we try to install a package from 3 to 2. The re-try tries to avoid that tools fails because a URL is temporary unavailable, but it unnecessarily increases the run time when there are broken tools that need long to install. The default re-try (2) is a good compromise and it is also consistent with the `ci.yml` workflow.

Closes https://github.com/mandiant/VM-Packages/issues/1448