### PR TITLE
Fix(nmap): Correctly create admin shortcut for Zenmap

### DIFF
--- a/packages/nmap.vm/nmap.vm.nuspec
+++ b/packages/nmap.vm/nmap.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>nmap.vm</id>
-    <version>7.93.20230418.20250225</version>
+    <version>7.94</version>
     <authors>Fyodor, Nmap Project</authors>
     <description>Port scanning utility and nc replacement with extended features</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
       <dependency id="npcap.vm" />
-      <dependency id="autohotkey" version="[1.1.37.1]" />
+      <dependency id="autohotkey" version="[2.0.19]" />
       <dependency id="vcredist140.vm" />
     </dependencies>
     <tags>Networking</tags>

--- a/packages/nmap.vm/tools/chocolateyinstall.ps1
+++ b/packages/nmap.vm/tools/chocolateyinstall.ps1
@@ -7,8 +7,8 @@ try {
     $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
     $toolDir = Join-Path ${Env:RAW_TOOLS_DIR} $toolName
 
-    $exeUrl = 'https://nmap.org/dist/nmap-7.93-setup.exe'
-    $exeSha256 = 'f1160a33fb79c764cdc4c023fa700054ae2945ed91880e37348a17c010ca716f'
+    $exeUrl = 'https://nmap.org/dist/nmap-7.94-setup.exe'
+    $exeSha256 = 'b99c4535e1603a2150e4dd97933b69bfddf23e8cceff5c36606ec0327c6f7193'
     $installerName = Split-Path -Path $exeUrl -Leaf
 
     $packageArgs = @{
@@ -44,11 +44,12 @@ try {
     }
 
     # Add shortcut for Zenmap
-    $executablePath = Join-Path $toolDir "zenmap.exe" -Resolve
-    $shortcut = Join-Path $shortcutDir "zenmap.lnk"
-    Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -WorkingDirectory $executableDir -RunAsAdmin
-    VM-Assert-Path $shortcut
-    Install-BinFile -Name "zenmap" -Path $executablePath
+    $originalShortcut = Join-Path $toolDir "zenmap.lnk"
+    VM-Assert-Path $originalShortcut
+    # Add run as admin shortcut to $shortcutDir
+    $newAdminShortcut = Join-Path $shortcutDir "zenmap.lnk"
+    Install-ChocolateyShortcut -shortcutFilePath $newAdminShortcut -targetPath $originalShortcut -WorkingDirectory $toolDir -RunAsAdmin
+    VM-Assert-Path $newAdminShortcut
 } catch {
     VM-Write-Log-Exception $_
 }


### PR DESCRIPTION
The Nmap installation script was failing because it treated the `zenmap` file as a standard executable. However, as of `7.94`, the installer creates a Windows shortcut (.lnk) at this path, not a binary.

This commit adapts the script to handle the shortcut correctly. It now creates a new admin shortcut that targets the original shortcut file. This shortcut-to-a-shortcut approach ensures Zenmap launches with the correct commands and arguments while applying the 'Run as Administrator' setting.

The creation of a command-line shim for Zenmap has been removed, as the primary goal is a functioning GUI shortcut.

This closes https://github.com/mandiant/VM-Packages/issues/1441.