### PR TITLE
fix(winscp): Correct executable path and modernize uninstall

### DIFF
--- a/packages/winscp.vm/tools/chocolateyinstall.ps1
+++ b/packages/winscp.vm/tools/chocolateyinstall.ps1
@@ -4,11 +4,9 @@ Import-Module vm.common -Force -DisableNameChecking
 try {
   $toolName = 'WinSCP'
   $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
-  $shimPath = '\bin\winscp.exe'
-
   $shortcutDir = Join-Path ${Env:TOOL_LIST_DIR} $category
   $shortcut = Join-Path $shortcutDir "$toolName.lnk"
-  $executablePath = Join-Path ${Env:ChocolateyInstall} $shimPath -Resolve
+  $executablePath = Join-Path ${Env:ProgramFiles(x86)} "$toolName\$toolName.exe" -Resolve
   Install-BinFile -Name $toolName -Path $executablePath
 
   Install-ChocolateyShortcut -shortcutFilePath $shortcut -targetPath $executablePath -RunAsAdmin

--- a/packages/winscp.vm/tools/chocolateyuninstall.ps1
+++ b/packages/winscp.vm/tools/chocolateyuninstall.ps1
@@ -4,4 +4,4 @@ Import-Module vm.common -Force -DisableNameChecking
 $toolName = 'WinSCP'
 $category = VM-Get-Category($MyInvocation.MyCommand.Definition)
 
-VM-Remove-Tool-Shortcut $toolName $category
+VM-Uninstall $toolName $category

--- a/packages/winscp.vm/winscp.vm.nuspec
+++ b/packages/winscp.vm/winscp.vm.nuspec
@@ -2,11 +2,11 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>winscp.vm</id>
-    <version>6.5.1</version>
+    <version>6.5.1.20250724</version>
     <authors>Martin Přikryl</authors>
     <description>WinSCP is an open source free SFTP client, SCP client, FTPS client and FTP client for Windows. Its main function is file transfer between a local and a remote computer.</description>
     <dependencies>
-      <dependency id="common.vm"  version="0.0.0.20250206" />
+      <dependency id="common.vm"  version="0.0.0.20250509" />
       <dependency id="winscp" version="[6.5.1]" />
     </dependencies>
     <tags>Utilities</tags>


### PR DESCRIPTION
Fixes broken desktop shortcut by pointing to the correct WinSCP executable in the installation script. Updates the uninstallation script to use modern practices.

Fixes https://github.com/mandiant/VM-Packages/issues/1382.