### PR TITLE
[CI] Fix update_packages.yml and improve its log output

### DIFF
--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -49,17 +49,18 @@ jobs:
               # Clean changes and built packages
               git restore .
               Remove-Item built_pkgs -Recurse -ErrorAction Ignore
-              if ($tested) {
-                # Only allow 1 successful package install
+
+              # Commit changes if new version update was sucessfull
+              if ($newVersion) {
+                if ($finalUpdateType -eq 'DYNAMIC_URL') {
+                  git commit -m "Fix broken hash in $package"
+                }
+                else {
+                  git commit -m "Update $package to $newVersion"
+                }
+
+                # Only allow 1 type of package update
                 break
-              }
-            }
-            if ($newVersion) {
-              if ($finalUpdateType -eq 'DYNAMIC_URL') {
-                git commit -m "Fix broken hash in $package"
-              }
-              else {
-              git commit -m "Update $package to $newVersion"
               }
             }
           }

--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -25,24 +25,25 @@ jobs:
           New-Item test_logs -itemType Directory | Out-Null
           foreach ($packagePath in (Get-ChildItem packages)){
             $package = $packagePath.Name
+            echo $package
+
             $newVersion = 0
             # Test independently every type of update and commit what works
             foreach ($UPDATE_TYPE in ('GITHUB_URL', 'MSIXBUNDLE_URL', 'VERSION_URL', 'DYNAMIC_URL', 'DEPENDENCIES')) {
               $version = python scripts\utils\update_package.py $package --update_type $UPDATE_TYPE
               $updated = $?
-              echo "$package $version"
               if ($updated -and $version) {
                 # Test package before committing
-                scripts\test\test_install.ps1 -max_tries 1 $package | out-null
+                scripts\test\test_install.ps1 -max_tries 1 $package *>$null
                 $tested = $?
                 cd $root
                 if ($tested) {
-                  git add "packages/$package/"
+                  git add "packages/$package/" | Out-Null
                   $newVersion = $version
                   # Save the update type to use it in the commit
                   $finalUpdateType = $UPDATE_TYPE
                 } else {
-                  echo "$package $version FAILED"
+                  echo "$package $version FAILED ($UPDATE_TYPE)"
                   git diff
                 }
               }
@@ -52,11 +53,12 @@ jobs:
 
               # Commit changes if new version update was sucessfull
               if ($newVersion) {
+                echo "$package $version SUCCEEDED ($UPDATE_TYPE)"
                 if ($finalUpdateType -eq 'DYNAMIC_URL') {
-                  git commit -m "Fix broken hash in $package"
+                  git commit -m "Fix broken hash in $package" | Out-Null
                 }
                 else {
-                  git commit -m "Update $package to $newVersion"
+                  git commit -m "Update $package to $newVersion" | Out-Null
                 }
 
                 # Only allow 1 type of package update


### PR DESCRIPTION
A bug introduced in https://github.com/mandiant/VM-Packages/pull/1439 caused that we only tested the first update type instead of stopping after the first successful update. Fix the issue and refactor the code for better readability.

Improve also the log output in `update_package.yml` to make it easier to read:
- Print the name of the package only once and a second message with the
  test status in case of an update
- Print the type of update
- Remove output from run scripts and commands

You can see the new package update working in:
- https://github.com/Ana06/VM-Packages/actions/runs/16571333771
- https://github.com/Ana06/VM-Packages/pull/31

## Log output example
### Before
```
010editor.vm 
010editor.vm 
010editor.vm 
010editor.vm 
010editor.vm 
7zip.vm 
7zip.vm 
7zip.vm 
7zip.vm 
7zip.vm 
adconnectdump.vm 
adconnectdump.vm 
adconnectdump.vm 
adconnectdump.vm 
adconnectdump.vm 
aleapp.vm 
aleapp.vm 
aleapp.vm 
aleapp.vm 
aleapp.vm 
amcacheparser.vm 
amcacheparser.vm 
amcacheparser.vm 
amcacheparser.vm 
amcacheparser.vm 
angr.vm 
angr.vm 
angr.vm 
angr.vm 
angr.vm 
apimonitor.vm 
apimonitor.vm 
apimonitor.vm 
apimonitor.vm 
apimonitor.vm 
apktool.vm 
apktool.vm 2.12.0

SUCCESS:1
FAILURE:0

Writing success/failure/total and failing packages to success_failure.json
apktool.vm 
apktool.vm 
apktool.vm 
[main 6fcd129] Update apktool.vm to 2.12.0
 2 files changed, 3 insertions(+), 3 deletions(-)
appcompatcacheparser.vm 
appcompatcacheparser.vm 
appcompatcacheparser.vm 
appcompatcacheparser.vm 
appcompatcacheparser.vm 
arsenalimagemounter.vm 
arsenalimagemounter.vm 
arsenalimagemounter.vm 
arsenalimagemounter.vm 
arsenalimagemounter.vm 
asar.vm 
asar.vm 
asar.vm 
asar.vm 
asar.vm 
asreproast.vm 
asreproast.vm 
asreproast.vm 
asreproast.vm 
asreproast.vm 
autoit-ripper.vm 
autoit-ripper.vm 
autoit-ripper.vm 
autoit-ripper.vm 
autoit-ripper.vm 
autopsy.vm 
autopsy.vm GitHub API response not ok: 403
autopsy.vm 
autopsy.vm 
autopsy.vm 
azurehound.vm 
azurehound.vm GitHub API response not ok: 403
azurehound.vm 
azurehound.vm 
azurehound.vm 
badassmacros.vm 
badassmacros.vm GitHub API response not ok: 403
badassmacros.vm 
badassmacros.vm 
badassmacros.vm 
binaryninja.vm 
binaryninja.vm 
binaryninja.vm 
binaryninja.vm 
binaryninja.vm 
bindiff.vm 
bindiff.vm 
bindiff.vm 
bindiff.vm 
bindiff.vm 
blobrunner.vm 
blobrunner.vm GitHub API response not ok: 403
blobrunner.vm 
blobrunner.vm 
blobrunner.vm 
blobrunner64.vm 
blobrunner64.vm GitHub API response not ok: 403
blobrunner64.vm 
blobrunner64.vm 
blobrunner64.vm 
bloodhound-custom-queries.vm 
bloodhound-custom-queries.vm 
bloodhound-custom-queries.vm 
bloodhound-custom-queries.vm 
bloodhound-custom-queries.vm 
bloodhound.vm 
bloodhound.vm GitHub API response not ok: 403
bloodhound.vm 
bloodhound.vm 
bloodhound.vm 
bstrings.vm 
bstrings.vm 
bstrings.vm 
bstrings.vm 
bstrings.vm 
burp-free.vm 
burp-free.vm 
burp-free.vm 
burp-free.vm 
burp-free.vm 
bytecodeviewer.vm 
bytecodeviewer.vm GitHub API response not ok: 403
bytecodeviewer.vm 
bytecodeviewer.vm 
bytecodeviewer.vm 
c3.vm 
c3.vm 
c3.vm 
c3.vm 
c3.vm 
capa-explorer-web.vm 
capa-explorer-web.vm 
capa-explorer-web.vm 
capa-explorer-web.vm 
capa-explorer-web.vm 
capa.vm 
capa.vm GitHub API response not ok: 403
capa.vm 
capa.vm 
capa.vm 
capesolo.vm 
capesolo.vm 
capesolo.vm 
capesolo.vm 
capesolo.vm 
certify.vm 
certify.vm 
certify.vm 
certify.vm 
certify.vm 
chainsaw.vm 
chainsaw.vm GitHub API response not ok: 403
chainsaw.vm 
chainsaw.vm 
chainsaw.vm 
chrome.extensions.vm 
chrome.extensions.vm 
chrome.extensions.vm 
chrome.extensions.vm 
chrome.extensions.vm 
cmder.vm 
cmder.vm 
cmder.vm 
cmder.vm 
cmder.vm 
codetrack.vm 
codetrack.vm 
codetrack.vm 
codetrack.vm 
codetrack.vm 
common.vm 
common.vm 
common.vm 
common.vm 
common.vm 
confuserex.vm 
confuserex.vm 
confuserex.vm 
confuserex.vm 
confuserex.vm 
covenant.vm 
covenant.vm 
covenant.vm 
covenant.vm 
covenant.vm 
credninja.vm 
credninja.vm 
credninja.vm 
credninja.vm 
credninja.vm 
cryptotester.vm 
cryptotester.vm GitHub API response not ok: 403
cryptotester.vm 
cryptotester.vm 
cryptotester.vm 
cutter.vm 
cutter.vm GitHub API response not ok: 403
cutter.vm 
cutter.vm 
cutter.vm 
cyberchef.vm 
cyberchef.vm GitHub API response not ok: 403
cyberchef.vm 
cyberchef.vm 
cyberchef.vm 
cygwin.vm 3.6.4

SUCCESS:1
FAILURE:0

Writing success/failure/total and failing packages to success_failure.json
cygwin.vm 
cygwin.vm 
cygwin.vm 
cygwin.vm 
[main 7d1c22d] Update cygwin.vm to 3.6.4
 1 file changed, 2 insertions(+), 2 deletions(-)
dcode.vm 
dcode.vm 
dcode.vm 
dcode.vm 
dcode.vm 
de4dot-cex.vm 
de4dot-cex.vm GitHub API response not ok: 403
de4dot-cex.vm 
de4dot-cex.vm 
de4dot-cex.vm 
debloat.vm 
debloat.vm 
debloat.vm 
debloat.vm 
debloat.vm 
dependencywalker.vm 
dependencywalker.vm 
dependencywalker.vm 
dependencywalker.vm 
dependencywalker.vm 
dex2jar.vm 
dex2jar.vm GitHub API response not ok: 403
dex2jar.vm 
dex2jar.vm 
dex2jar.vm 
didier-stevens-beta.vm 
didier-stevens-beta.vm 
didier-stevens-beta.vm 
didier-stevens-beta.vm 
didier-stevens-beta.vm 
didier-stevens-suite.vm 
didier-stevens-suite.vm 
didier-stevens-suite.vm 
didier-stevens-suite.vm 
didier-stevens-suite.vm 
die.vm 
die.vm GitHub API response not ok: 403
die.vm 
die.vm 
die.vm 
dll-to-exe.vm 
dll-to-exe.vm GitHub API response not ok: 403
dll-to-exe.vm 
dll-to-exe.vm 
dll-to-exe.vm 
dnlib.vm 
dnlib.vm 
dnlib.vm 
dnlib.vm 
dnlib.vm 
dnspyex.vm 
dnspyex.vm GitHub API response not ok: 403
dnspyex.vm 
dnspyex.vm 
dnspyex.vm 
dokan.vm 
dokan.vm GitHub API response not ok: 403
dokan.vm 
dokan.vm 
dokan.vm 
dotdumper.vm 
dotdumper.vm GitHub API response not ok: 403
dotdumper.vm 
dotdumper.vm 
dotdumper.vm 
dotnet-6.vm 
dotnet-6.vm 
dotnet-6.vm 
dotnet-6.vm 
dotnet-6.vm 
dotnet-8.vm 
dotnet-8.vm 
dotnet-8.vm 
dotnet-8.vm 
dotnet-8.vm 
dotnet-9.vm 
dotnet-9.vm 
dotnet-9.vm 
dotnet-9.vm 
dotnet-9.vm 
dotnettojscript.vm 
dotnettojscript.vm 
dotnettojscript.vm 
dotnettojscript.vm 
dotnettojscript.vm 
dumpert.vm 
dumpert.vm 
dumpert.vm 
dumpert.vm 
dumpert.vm 
egress-assess.vm 
egress-assess.vm 
egress-assess.vm 
egress-assess.vm 
egress-assess.vm 
event-log-explorer.vm 
event-log-explorer.vm 
event-log-explorer.vm 
event-log-explorer.vm 
event-log-explorer.vm 
evilclippy.vm 
evilclippy.vm GitHub API response not ok: 403
evilclippy.vm 
evilclippy.vm 
evilclippy.vm 
evtxecmd.vm 
evtxecmd.vm 
evtxecmd.vm 
evtxecmd.vm 
evtxecmd.vm 
exeinfope.vm 
exeinfope.vm 
exeinfope.vm 
exeinfope.vm 
exeinfope.vm 
exiftool.vm 13.32.0

SUCCESS:1
FAILURE:0

Writing success/failure/total and failing packages to success_failure.json
exiftool.vm 
exiftool.vm 
exiftool.vm 
exiftool.vm 
[main db7e0eb] Update exiftool.vm to 13.32.0
 1 file changed, 2 insertions(+), 2 deletions(-)
explorersuite.vm 
explorersuite.vm 
explorersuite.vm 
explorersuite.vm 
explorersuite.vm 
extreme_dumper.vm 
extreme_dumper.vm 
extreme_dumper.vm 
extreme_dumper.vm 
extreme_dumper.vm 
ezviewer.vm 
ezviewer.vm 
ezviewer.vm 
ezviewer.vm 
ezviewer.vm 
fakenet-ng.vm 
fakenet-ng.vm 
fakenet-ng.vm 
fakenet-ng.vm 
fakenet-ng.vm 
fiddler.vm 
fiddler.vm 
fiddler.vm 
fiddler.vm 
fiddler.vm 
file.vm 
file.vm 
file.vm 
file.vm 
file.vm 
floss.vm 
floss.vm 
floss.vm 
floss.vm 
floss.vm 
ftk-imager.vm 
ftk-imager.vm 
ftk-imager.vm 
ftk-imager.vm 
ftk-imager.vm 
fuzzdb.vm 
fuzzdb.vm 
fuzzdb.vm 
fuzzdb.vm 
fuzzdb.vm 
gadgettojscript.vm 
gadgettojscript.vm 
gadgettojscript.vm 
gadgettojscript.vm 
gadgettojscript.vm 
garbageman.vm 
garbageman.vm 
garbageman.vm 
garbageman.vm 
garbageman.vm 
getlapspasswords.vm 
getlapspasswords.vm 
getlapspasswords.vm 
getlapspasswords.vm 
getlapspasswords.vm 
ghidra.vm 11.4.0
Error:  Failed to install ghidra.vm - Try 1

SUCCESS:0
FAILURE:1

Writing success/failure/total and failing packages to success_failure.json
ghidra.vm 11.4.0 FAILED
diff --git a/packages/ghidra.vm/ghidra.vm.nuspec b/packages/ghidra.vm/ghidra.vm.nuspec
index a106405..b08a6a6 100644
--- a/packages/ghidra.vm/ghidra.vm.nuspec
+++ b/packages/ghidra.vm/ghidra.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ghidra.vm</id>
-    <version>11.3.2.20250430</version>
+    <version>11.4.0</version>
     <authors>National Security Agency</authors>
     <description>Ghidra is a software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="ghidra" version="[11.3.2]" />
+      <dependency id="ghidra" version="[11.4.0]" />
       <dependency id="openjdk.vm" />
     </dependencies>
     <tags>Disassemblers</tags>
ghidra.vm 
ghidra.vm 
ghidra.vm 
ghidra.vm 
gobuster.vm 
gobuster.vm GitHub API response not ok: 403
gobuster.vm 
gobuster.vm 
gobuster.vm 
googlechrome.vm 
googlechrome.vm 
googlechrome.vm 
googlechrome.vm 
googlechrome.vm 
goresym.vm 
goresym.vm GitHub API response not ok: 403
goresym.vm 
goresym.vm 
goresym.vm 
gostringungarbler.vm 
gostringungarbler.vm GitHub API response not ok: 403
gostringungarbler.vm 
gostringungarbler.vm 
gostringungarbler.vm 
gowitness.vm 
gowitness.vm GitHub API response not ok: 403
gowitness.vm 
gowitness.vm 
gowitness.vm 
group3r.vm 
group3r.vm GitHub API response not ok: 403
group3r.vm 
group3r.vm 
group3r.vm 
hashcat.vm 
hashcat.vm GitHub API response not ok: 403
hashcat.vm 
hashcat.vm 
hashcat.vm 
hasher.vm 
hasher.vm 
hasher.vm 
hasher.vm 
hasher.vm 
hashmyfiles.vm 
hashmyfiles.vm 
hashmyfiles.vm 
hashmyfiles.vm 
hashmyfiles.vm 
hayabusa.vm 
hayabusa.vm GitHub API response not ok: 403
hayabusa.vm 
hayabusa.vm 
hayabusa.vm 
hollowshunter.vm 
hollowshunter.vm GitHub API response not ok: 403
hollowshunter.vm 
hollowshunter.vm 
hollowshunter.vm 
hxd.vm 
hxd.vm 
hxd.vm 
hxd.vm 
hxd.vm 
ida.plugin.capa.vm 
ida.plugin.capa.vm 
ida.plugin.capa.vm 
ida.plugin.capa.vm 
ida.plugin.capa.vm 
ida.plugin.comida.vm 
ida.plugin.comida.vm 
ida.plugin.comida.vm 
ida.plugin.comida.vm 
ida.plugin.comida.vm 
ida.plugin.dereferencing.vm 
ida.plugin.dereferencing.vm 
ida.plugin.dereferencing.vm 
ida.plugin.dereferencing.vm 
ida.plugin.dereferencing.vm 
ida.plugin.diaphora.vm 
ida.plugin.diaphora.vm GitHub API response not ok: 403
ida.plugin.diaphora.vm 
ida.plugin.diaphora.vm 
ida.plugin.diaphora.vm 
ida.plugin.flare.vm 
ida.plugin.flare.vm 
ida.plugin.flare.vm 
ida.plugin.flare.vm 
ida.plugin.flare.vm 
ida.plugin.hashdb.vm 
ida.plugin.hashdb.vm GitHub API response not ok: 403
ida.plugin.hashdb.vm 
ida.plugin.hashdb.vm 
ida.plugin.hashdb.vm 
ida.plugin.hrtng.vm 
ida.plugin.hrtng.vm GitHub API response not ok: 403
ida.plugin.hrtng.vm 
ida.plugin.hrtng.vm 
ida.plugin.hrtng.vm 
ida.plugin.ifl.vm 
ida.plugin.ifl.vm 
ida.plugin.ifl.vm 
ida.plugin.ifl.vm 
ida.plugin.ifl.vm 
ida.plugin.lighthouse.vm 
ida.plugin.lighthouse.vm 
ida.plugin.lighthouse.vm 
ida.plugin.lighthouse.vm 
ida.plugin.lighthouse.vm 
ida.plugin.xray.vm 
ida.plugin.xray.vm 
ida.plugin.xray.vm 
ida.plugin.xray.vm 
ida.plugin.xray.vm 
ida.plugin.xrefer.vm 
ida.plugin.xrefer.vm GitHub API response not ok: 403
ida.plugin.xrefer.vm 
ida.plugin.xrefer.vm 
ida.plugin.xrefer.vm 
idafree.vm 
idafree.vm 
idafree.vm 
idafree.vm 
idafree.vm 
idapro.vm 
idapro.vm 
idapro.vm 
idapro.vm 
idapro.vm 
```
### After
```
010editor.vm
7zip.vm
adconnectdump.vm
aleapp.vm
amcacheparser.vm
angr.vm
apimonitor.vm
apktool.vm
apktool.vm 2.12.0 SUCCEEDED (GITHUB_URL)
appcompatcacheparser.vm
arsenalimagemounter.vm
asar.vm
asreproast.vm
autoit-ripper.vm
autopsy.vm
azurehound.vm
badassmacros.vm
binaryninja.vm
bindiff.vm
blobrunner.vm
blobrunner64.vm
bloodhound-custom-queries.vm
bloodhound.vm
bstrings.vm
burp-free.vm
bytecodeviewer.vm
c3.vm
capa-explorer-web.vm
capa.vm
capesolo.vm
certify.vm
chainsaw.vm
chrome.extensions.vm
cmder.vm
codetrack.vm
common.vm
confuserex.vm
covenant.vm
credninja.vm
cryptotester.vm
cutter.vm
cyberchef.vm
cygwin.vm
cygwin.vm 3.6.4 SUCCEEDED (DEPENDENCIES)
dcode.vm
de4dot-cex.vm
debloat.vm
dependencywalker.vm
dex2jar.vm
didier-stevens-beta.vm
didier-stevens-suite.vm
die.vm
dll-to-exe.vm
dnlib.vm
dnspyex.vm
dokan.vm
dotdumper.vm
dotnet-6.vm
dotnet-8.vm
dotnet-9.vm
dotnettojscript.vm
dumpert.vm
egress-assess.vm
event-log-explorer.vm
evilclippy.vm
evtxecmd.vm
exeinfope.vm
exiftool.vm
exiftool.vm 13.33.0 SUCCEEDED (DEPENDENCIES)
explorersuite.vm
extreme_dumper.vm
ezviewer.vm
fakenet-ng.vm
fiddler.vm
file.vm
floss.vm
ftk-imager.vm
fuzzdb.vm
gadgettojscript.vm
garbageman.vm
getlapspasswords.vm
ghidra.vm
ghidra.vm 11.4.0 FAILED (DEPENDENCIES)
diff --git a/packages/ghidra.vm/ghidra.vm.nuspec b/packages/ghidra.vm/ghidra.vm.nuspec
index a106405..b08a6a6 100644
--- a/packages/ghidra.vm/ghidra.vm.nuspec
+++ b/packages/ghidra.vm/ghidra.vm.nuspec
@@ -2,12 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ghidra.vm</id>
-    <version>11.3.2.20250430</version>
+    <version>11.4.0</version>
     <authors>National Security Agency</authors>
     <description>Ghidra is a software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission.</description>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
-      <dependency id="ghidra" version="[11.3.2]" />
+      <dependency id="ghidra" version="[11.4.0]" />
       <dependency id="openjdk.vm" />
     </dependencies>
     <tags>Disassemblers</tags>
gobuster.vm
gobuster.vm 3.8.0 SUCCEEDED (GITHUB_URL)
googlechrome.vm
goresym.vm
gostringungarbler.vm
gowitness.vm
group3r.vm
hashcat.vm
hasher.vm
hashmyfiles.vm
hayabusa.vm
hollowshunter.vm
hxd.vm
ida.plugin.capa.vm
ida.plugin.comida.vm
ida.plugin.dereferencing.vm
ida.plugin.diaphora.vm
ida.plugin.flare.vm
ida.plugin.hashdb.vm
ida.plugin.hrtng.vm
ida.plugin.hrtng.vm 2.7.63 FAILED (GITHUB_URL)
diff --git a/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec b/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec
index 8b09a75..ff54e82 100644
--- a/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec
+++ b/packages/ida.plugin.hrtng.vm/ida.plugin.hrtng.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ida.plugin.hrtng.vm</id>
-    <version>2.4.30.20250715</version>
+    <version>2.7.63</version>
     <authors>KasperskyLab</authors>
     <description>hrtng is an IDA Pro plugin with features such as decryption, automation, deobfuscation, patching, lib code recognition and pseudocode transformations.</description>
     <dependencies>
diff --git a/packages/ida.plugin.hrtng.vm/tools/chocolateyinstall.ps1 b/packages/ida.plugin.hrtng.vm/tools/chocolateyinstall.ps1
index 11b3331..80278d4 100644
--- a/packages/ida.plugin.hrtng.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.hrtng.vm/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'
 Import-Module vm.common -Force -DisableNameChecking
 
-$pluginUrl = "https://github.com/KasperskyLab/hrtng/releases/download/v2.4.30/hrtng-2.4.30.7z"
-$pluginSha256 = "34ca57eb236cda6fc46983748e58a4dc3efcfb020107b923416e0d1549905f67"
+$pluginUrl = "https://github.com/KasperskyLab/hrtng/releases/download/v2.7.63/hrtng-2.7.63.7z"
+$pluginSha256 = "5931b12ba1ddc0f8af43e415ccfa9eff4191735ad238ce888b39715d2cf2303d"
 $tempDownloadDir = Join-Path ${Env:TEMP} "temp_$([guid]::NewGuid())"
 
 $packageArgs = @{
ida.plugin.ifl.vm
ida.plugin.lighthouse.vm
ida.plugin.xray.vm
ida.plugin.xrefer.vm
idafree.vm
idapro.vm
```