### PR TITLE
[doc] Add installer type to new_package.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_package.yml
+++ b/.github/ISSUE_TEMPLATE/new_package.yml
@@ -33,9 +33,9 @@ body:
       label: Package type
       description: |
         - **`ZIP_EXE`** - An executable tool distributed in a ZIP file
-        - **`SINGLE_EXE`** - An executable tool distributed via direct/raw download
+        - **`SINGLE_EXE`** - An executable tool (not an installer for the tool) distributed via direct/raw download
         - **`SINGLE_PS1`** - A PowerShell script distributed via direct/raw download
-        - **`OTHER/UNKNOWN`** - A tool distributed in a different way than the ones described above. It is required that you provide details of how the tool is installed in the `Extra information` section. Note this type does not support automation, a PR would be appreciated!
+        - **`OTHER/UNKNOWN`** - A tool distributed in a different way than the ones described above. For example, an EXE or MSI installer for the tool. It is required that you provide details of how the tool is installed in the `Extra information` section. Note this type does not support automation, a PR would be appreciated!
       options:
         - ZIP_EXE
         - SINGLE_EXE


### PR DESCRIPTION
There is no type for installer as we do not support it in the automation (yet). The current issue template documentation does not mention installers, causing that users select the wrong type (`SINGLE_EXE`) which makes the automation fail when trying to create the package. Improve the documentation to mention installers explicitly until we support this package type (we have an issue for this: https://github.com/mandiant/VM-Packages/issues/354)