### PR TITLE
Fix Win11 internet by moving DNSCache change to only Win10

### DIFF
--- a/packages/debloat.vm/debloat.vm.nuspec
+++ b/packages/debloat.vm/debloat.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>debloat.vm</id>
-    <version>0.0.0.20250615</version>
+    <version>0.0.0.20250729</version>
     <description>Debloat and performance configurations for Windows OS</description>
     <authors>Mandiant</authors>
     <dependencies>

--- a/packages/debloat.vm/tools/win10.xml
+++ b/packages/debloat.vm/tools/win10.xml
@@ -141,6 +141,7 @@
         <registry-item name="Disable Windows Update Automatic Restart" path="HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MusNotification.exe" value="Debugger" type="String" data="cmd.exe" />
         <registry-item name="Disable Microsoft Connectivity Test (msftconnecttest.com)" path="HKLM:\SYSTEM\CurrentControlSet\services\NlaSvc\Parameters\Internet" value="EnableActiveProbing" type="DWord" data="0" />
         <registry-item name="Disable key to open Office application (as it conflicts with Hyper key set)" path="HKCU:\SOFTWARE\Classes\ms-officeapp\Shell\Open\Command" value="(Default)" type="String" data="rundll32" />
+        <registry-item name="Force DNS requests to always come from requesting process" path="HKLM:\SYSTEM\CurrentControlSet\services\Dnscache" value="Start" type="DWord" data="4" />
     </registry-items>
     <path-items>
         <!--


### PR DESCRIPTION
This works in tandem with https://github.com/mandiant/flare-vm/pull/711 to fix the issue of Windows 11 internet not working due to a modification of the DNS cache value in the registry that we made to make internet requests clearer on Windows 10.

This commit will remove the previous change so that we can put the change into the `win10.xml` config for `debloat.vm` so that the change only effects Windows 10.

See https://github.com/mandiant/flare-vm/issues/659 for more details