### PR TITLE
[CI] Fix Version check in linter

### DIFF
--- a/scripts/test/lint.py
+++ b/scripts/test/lint.py
@@ -31,6 +31,8 @@ import sys
 from typing import Dict
 from xml.dom import minidom
 
+from packaging.version import Version
+
 GIT_EXE = "git"
 
 # set log level for debugging here script-wide
@@ -199,11 +201,6 @@ class VersionNotIncreased(Lint):
             return None
         return m.group("version")
 
-    # Convert 1.02.0 to 1.2 to ensure we compare versions consistency
-    def __format_version(self, version):
-        version = re.sub(r"\.0(?P<digit>\d)", lambda x: f".{x.group('digit')}", version)
-        return re.sub(r"(\.0+)+$", "", version)
-
     def check(self, path):
         dom = minidom.parse(str(path))
         metadata = dom.getElementsByTagName("metadata")[0]
@@ -216,7 +213,7 @@ class VersionNotIncreased(Lint):
             print("Package not found in MyGet")
             return False
 
-        if self.__format_version(local_version) < self.__format_version(remote_version):
+        if Version(local_version) < Version(remote_version):
             print(f"{path} package version ({local_version}) must be higher than the one in MyGet ({remote_version})")
             return True
         return False


### PR DESCRIPTION
In https://github.com/mandiant/VM-Packages/pull/1437 I aimed to test that the version is increased, instead I tested that the version is equal or higher than the one in MyGet. We need to test that the version is strictly higher than the ones in MyGet for the packages with modified files. For this we need the logic removed in https://github.com/mandiant/VM-Packages/pull/1437 that obtains the modified files.

In addition, the previous version comparison logic was flawed because it relied on direct string comparison, which caused incorrect behavior with multi-digit version components. For example, it would incorrectly flag `3.10` as not being higher than `3.9.20250219`, since `10` is lexicographically smaller than `9`. This PR replaces the brittle comparison logic with Python's standard `packaging.version.Version` class. This provides a robust, PEP 440-compliant method for comparing versions, ensuring the linter accurately validates version increments.

Closes https://github.com/mandiant/VM-Packages/issues/1466

You can see the changes working in https://github.com/Ana06/VM-Packages/pull/35