### PR TITLE
[libraries.python3.vm] Fix capstone

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20250716</version>
+    <version>0.0.0.20250730</version>
     <description>Python 3 libraries useful for common reverse engineering tasks.</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/modules.xml
+++ b/packages/libraries.python3.vm/tools/modules.xml
@@ -4,7 +4,7 @@
     <module name="rpyc"/>
     <module name="art"/>
     <module name="binwalk" url="https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.3.zip"/>
-    <module name="capstone-windows"/>
+    <module name="capstone"/>
     <module name="dissect"/>
     <module name="dncil"/>
     <module name="dnfile"/>


### PR DESCRIPTION
Replace `capstone-windows` by `capstone` as the `capstone-windows` library was last updated in 2015 and importing it failed with the following error:
```
PS C:\Users\flare > python
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import capstone
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python310\lib\site-packages\capstone\__init__.py", line 230, in <module>
    raise ImportError("ERROR: fail to load the dynamic library.")
ImportError: ERROR: fail to load the dynamic library.
```

The `capstone` library seems to be working fine:
```
PS C:\Users\flare > python
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import capstone
>>> print(capstone.__version__)
5.0.6
>>>
>>> from capstone import *
>>>
>>> CODE = b"\x55\x48\x8b\x05\xb8\x13\x00\x00"
>>>
>>> md = Cs(CS_ARCH_X86, CS_MODE_64)
>>> for i in md.disasm(CODE, 0x1000):
...     print("0x%x:\t%s\t%s" %(i.address, i.mnemonic, i.op_str))
...
0x1000: push    rbp
0x1001: mov     rax, qword ptr [rip + 0x13b8]
```

I have just installed `libraries.python3.vm` in an [minimal FLARE-VM installation](https://github.com/mandiant/VM-Packages/wiki/Testing#minimal-flare-vm-installation) without doing anything extra. @VinceQu what did you mean with the compilation of the DLL in your issue? Are you sure this is needed with capstone version 5?

Closes https://github.com/mandiant/VM-Packages/issues/1471