### PR TITLE
[bug] Install vcredist140.vm before python3

### DIFF
--- a/packages/python3.vm/python3.vm.nuspec
+++ b/packages/python3.vm/python3.vm.nuspec
@@ -2,12 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>python3.vm</id>
-    <version>0.0.0.20250716</version>
+    <version>0.0.0.20250801</version>
     <!-- Metapackage for Python 3 to ensure all packages use the same Python version -->
     <description>Python 3.</description>
     <authors>Mandiant</authors>
     <dependencies>
       <dependency id="common.vm" version="0.0.0.20250206" />
+      <dependency id="vcredist140.vm"/>
       <dependency id="python3" version="[3.10.0, 3.11.0)" />
     </dependencies>
     <tags>Python</tags>


### PR DESCRIPTION
`python3.vm` installs a version of `vcredist140` higher than the one specified in `vcredist140.vm` via the following dependencies: `python3.10` -> `python3` -> `vcredist2015` -> `vcredist140`.

Adding `vcredist140.vm` to `python3.vm` as dependency to ensure a compatible version is installed.

Closes https://github.com/mandiant/VM-Packages/issues/1440