### PR TITLE
[CI] Fix new package automation

### DIFF
--- a/.github/workflows/new_package.yml
+++ b/.github/workflows/new_package.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: send PR
+          github_token: ${{ secrets.REPO_TOKEN }}
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Parse issue


### PR DESCRIPTION
The new package automation is not able to remove the `send PR` label. This likely started failing because a change in the workflow permissions in the mandiant organization.  Provide `actions-ecosystem/action-remove-labels` the bot token so that the bot and not `github-actions` removes the label. This ensures that the actions has permissions to remove the label as the bot has write permissions for issues.


### Before

<img width="479" height="64" alt="image" src="https://github.com/user-attachments/assets/0782289c-8056-4417-a5a0-1fb025a799cf" />

### After

<img width="422" height="53" alt="image" src="https://github.com/user-attachments/assets/2d278e0c-5420-4526-88de-a3f09e02ed30" />


Note we could have used the `permissions` tag to give `github-actions` write permissions in issues, but I think it is more robust, nicer in the UI as well as consistent with the other workflows to have the bot removing the label.