### PR TITLE
Update x64dbg

### DIFF
--- a/packages/x64dbg.vm/tools/chocolateyinstall.ps1
+++ b/packages/x64dbg.vm/tools/chocolateyinstall.ps1
@@ -12,8 +12,8 @@ try {
   $packageArgs = @{
     packageName   = ${Env:ChocolateyPackageName}
     unzipLocation = $toolDir
-    url           = "https://sourceforge.net/projects/x64dbg/files/snapshots/snapshot_2025-03-15_15-57.zip/download"
-    checksum      = '490a428d209c0ed87ed050db6e47b5f626ae98a7f69917c9f87f14a7c53afca0'
+    url           = "https://github.com/x64dbg/x64dbg/releases/download/2025.08.19/snapshot_2025-08-19_19-40.zip"
+    checksum      = 'cc614caf34f9fe1ec156f045129db3a513c35593ff1ee647bc819a352dc12271'
     checksumType  = 'sha256'
   }
   Install-ChocolateyZipPackage @packageArgs

--- a/packages/x64dbg.vm/x64dbg.vm.nuspec
+++ b/packages/x64dbg.vm/x64dbg.vm.nuspec
@@ -2,13 +2,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>x64dbg.vm</id>
-    <version>2025.03.15.20250430</version>
-    <description>X64dbg is an open-source x64/x32 debugger for Windows.</description>
+    <version>2025.08.19</version>
+    <description>An open-source user mode debugger for Windows. Optimized for reverse engineering and malware analysis.</description>
     <authors>mrexodia</authors>
     <dependencies>
       <dependency id="common.vm"  version="0.0.0.20250206" />
     </dependencies>
     <tags>Debuggers</tags>
-    <projectUrl>https://sourceforge.net/projects/x64dbg/</projectUrl>
+    <projectUrl>https://github.com/x64dbg/x64dbg</projectUrl>
   </metadata>
 </package>


### PR DESCRIPTION
- Since the previous release we started using CalVer and actual GitHub releases that do not get overwritten
- For a few years it has been possible to create a `userdir` file next to x64dbg.exe (as well as x32dbg.exe). This allows package managers to install x64dbg in a non-writable location and it will put the databases in appdata. I did not implement this here, but might be helpful. Source code: https://github.com/x64dbg/x64dbg/blob/85e0ff85796891ebfd3cc5bb46daedbe7ef6098c/src/bridge/bridgemain.cpp#L113