### PR TITLE
Correct architecture detection for OS of different languages

### DIFF
--- a/packages/common.vm/common.vm.nuspec
+++ b/packages/common.vm/common.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>common.vm</id>
-    <version>0.0.0.20250814</version>
+    <version>0.0.0.20250828</version>
     <description>Common libraries for VM-packages</description>
     <authors>Mandiant</authors>
   </metadata>

--- a/packages/common.vm/tools/vm.common/vm.common.psm1
+++ b/packages/common.vm/tools/vm.common/vm.common.psm1
@@ -1607,7 +1607,7 @@ function VM-Get-WindowsVersion {
     if ($version -match "10") {
         return "Win10"
     }
-    elseif ($version -match "11" -and $osArchitecture -eq "64-bit") {
+    elseif ($version -match "11" -and $osArchitecture -like "64?bit") {
         return "Win11"
     }
     elseif ($version -match "11" -and $osArchitecture -match "ARM") {


### PR DESCRIPTION
Fixes #1503 by checking [Environment]::Is64BitOperatingSystem to detect the OS architecture.