### PR TITLE
Add ida.plugin.sigmaker.vm

### DIFF
--- a/packages/ida.plugin.sigmaker.vm/ida.plugin.sigmaker.vm.nuspec
+++ b/packages/ida.plugin.sigmaker.vm/ida.plugin.sigmaker.vm.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>ida.plugin.sigmaker.vm</id>
+    <version>1.0.9</version>
+    <authors>A200K</authors>
+    <description>Signature Maker is an IDA 9+ Pro plugin that generates signatures.</description>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20240424" />
+    </dependencies>
+    <tags>IDA Plugins</tags>
+    <projectUrl>https://github.com/A200K/IDA-Pro-SigMaker</projectUrl>
+  </metadata>
+</package>

--- a/packages/ida.plugin.sigmaker.vm/tools/chocolateyinstall.ps1
+++ b/packages/ida.plugin.sigmaker.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,8 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'SigMaker64.dll'
+$pluginUrl = 'https://github.com/A200K/IDA-Pro-SigMaker/releases/download/v1.0.9/SigMaker9_64.dll'
+$pluginSha256 = 'cec05a96867f51dff686d72384f6be98c763dfda9da2ebbe653510620bfb7070'
+
+VM-Install-IDA-Plugin -pluginName $pluginName -pluginUrl $pluginUrl -pluginSha256 $pluginSha256

--- a/packages/ida.plugin.sigmaker.vm/tools/chocolateyuninstall.ps1
+++ b/packages/ida.plugin.sigmaker.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$pluginName = 'SigMaker9_64.dll'
+VM-Uninstall-IDA-Plugin -pluginName $pluginName


### PR DESCRIPTION
IDA-Pro-SigMaker had been removed by GitHub because it supposedly included code/files that violated Hex-Rays EULA: https://github.com/github/dmca/blob/master/2025/01/2025-01-17-hex-rays.md

But the takedown has been revoked: https://github.com/github/dmca/blob/master/2025/05/2025-05-28-hex-rays-retraction.md :tada: 

Add the latest version of IDA-Pro-SigMake compatible with IDA 9+.

@mandiant/flare-vm do we want to add this package to the default config?. :wink: 

Closes https://github.com/mandiant/VM-Packages/issues/1442