### PR TITLE
Fix log upload action

### DIFF
--- a/.github/actions/upload-logs/action.yml
+++ b/.github/actions/upload-logs/action.yml
@@ -1,22 +1,43 @@
 name: Update logs
 description: Update test install logs to artifacts
 
+inputs:
+  os:
+    description: 'The operating system runner'
+    required: true
+
 runs:
   using: "composite"
   steps:
+    - name: Stage VM logs
+      shell: powershell
+      if: always()
+      run: |
+        # Create a directory on the D: drive (the current workspace)
+        New-Item -ItemType Directory -Force -Path "vm_logs_staging"
+        
+        # Copy the log from C: to our D: folder
+        if (Test-Path "C:\ProgramData\_VM\log.txt") {
+          Copy-Item "C:\ProgramData\_VM\log.txt" -Destination "vm_logs_staging\log.txt"
+        }
+        
+        # Copy the workspace file to the same D: folder
+        if (Test-Path "success_failure.json") {
+          Copy-Item "success_failure.json" -Destination "vm_logs_staging\"
+        }
+
     - name: Upload VM logs to artifacts
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: log-VM-${{ matrix.os }}.zip
-        path: |
-          C:\ProgramData\_VM\log.txt
-          success_failure.json
+        name: log-VM-${{ inputs.os }}
+        path: vm_logs_staging/ # Now it only looks at one folder on one drive!
+
     - name: Upload chocolatey logs to artifacts
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: logs-choco-${{ matrix.os }}.zip
+        name: logs-choco-${{ inputs.os }}
         path: |
           C:\ProgramData\chocolatey\logs\chocolatey.log
           C:\ProgramData\chocolatey\lib-bad\**\tools\install_log.txt

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -30,6 +30,9 @@ jobs:
         run: scripts/test/test_install.ps1 -all
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
+        if: always()
+        with:
+          os: ${{ matrix.os }}
       - name: Checkout wiki code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/update_packages.yml
+++ b/.github/workflows/update_packages.yml
@@ -82,6 +82,8 @@ jobs:
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs
         if: always()
+        with:
+          os: windows-2022
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         with:


### PR DESCRIPTION
This fixes the issue that has been ongoing for at least a month where a path was incorrectly formulated, stemming from [this PR](https://github.com/mandiant/VM-Packages/pull/1520).

This also fixes a long standing issue where our logs were not being labeled correctly

Here is the fix running showing that it works: https://github.com/mandiant/VM-Packages/actions/runs/20321370698


Old Logs named incorrectly (See artifacts section):
<img width="1715" height="789" alt="image" src="https://github.com/user-attachments/assets/1eb4ae8f-ee30-4813-a429-a9abfb811cae" />


New logs now named correctly (See artifacts section) - note, they do not need the '.zip' because this labels them as `.zip.zip` when downloaded:
<img width="1715" height="789" alt="image" src="https://github.com/user-attachments/assets/14ca6048-7201-4339-90d1-ed89e0dfb3f2" />
