### PR TITLE
Fix libraries.python3.vm dependency resolution

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20251004</version>
+    <version>0.0.0.20251218</version>
     <description>Python 3 libraries useful for common reverse engineering tasks.</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>


### PR DESCRIPTION
Currently our `libraries.python3.vm` package fails to install on the Github Runner, likely due to silent `pip` things with the OS versions, but I've been unable to confirm the exact reason, but it works fine locally on my Windows 10 VM, so this would be my logical guess.

This fix aims to make it always work and also fixes potential issues that could arise even on a not as up to date VM as it will resolve dependencies across all modules being installed in the list. 

NOTE: We will still potentially fail if we keep the same python version across each tool that installs via `pip` in its own contained package due to `pip` being unable to track dependencies properly. Though if we do go the route of keeping some individually installed tools pinned to an older python version, as somewhat suggested in https://github.com/mandiant/VM-Packages/pull/1547 then we might not have too many problems that arise due to separate interpreters mitigating the issue for us.