### PR TITLE
Revert "Fix libraries.python3.vm dependency resolution"

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20251218</version>
+    <version>0.0.0.20251004</version>
     <description>Python 3 libraries useful for common reverse engineering tasks.</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -10,42 +10,21 @@ try {
     VM-Pip-Install "pip~=23.2.1"
 
     $failures = @()
-    $pipArgs = @()
     $modules = $modulesXml.modules.module
-
-    Write-Host "Attempting to install the following Python3 modules:"
     foreach ($module in $modules) {
-        Write-Host "[+] $($module.name)"
+        Write-Host "[+] Attempting to install Python3 module: $($module.name)"
         $installValue = $module.name
         if ($module.url) {
             $installValue = $module.url
         }
-        $pipArgs += $installValue
-    }
 
-    Write-Host "Batch installing Python modules..."
-    $batchInstallString = $pipArgs -join " "
-    VM-Pip-Install $batchInstallString
+        VM-Pip-Install $installValue
 
-    foreach ($module in $modules) {
-        $pkgName = $module.name
-
-        # Clean up version pins (e.g., "pywin32==308" -> "pywin32") for install check
-        if ($pkgName -match "==") {
-            $pkgName = $pkgName -split "==" | Select-Object -First 1
-        }
-        if ($pkgName -match ">=") {
-            $pkgName = $pkgName -split ">=" | Select-Object -First 1
-        }
-
-        # 'pip show' returns exit code 0 if found, 1 if missing
-        $null = py -3.10 -m pip show $pkgName 2>&1
-
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "`t[!] Failed to install Python 3.10 module:$pkgName" -ForegroundColor Red
-            $failures += $pkgName
+        if ($LastExitCode -eq 0) {
+            Write-Host "`t[+] Installed Python 3.10 module: $($module.name)" -ForegroundColor Green
         } else {
-            Write-Host "`t[+] Installed Python 3.10 module: $pkgName" -ForegroundColor Green
+            Write-Host "`t[!] Failed to install Python 3.10 module: $($module.name)" -ForegroundColor Red
+            $failures += $module.Name
         }
     }
 
@@ -53,15 +32,10 @@ try {
         foreach ($module in $failures) {
             VM-Write-Log "ERROR" "Failed to install Python 3.10 module: $module"
         }
-        throw "Package installation failed. The following modules could not be verified: $($failures -join ', ')"
+        $outputFile = $outputFile.replace('lib\', 'lib-bad\')
+        VM-Write-Log "ERROR" "Check $outputFile for more information"
+        exit 1
     }
-
-    # Fix issue with chocolately printing incorrect install directory
-    $pythonPath = py -3.10 -c "import sys; print(sys.prefix)" 2>$null
-    if ($pythonPath) {
-        $env:ChocolateyPackageInstallLocation = $pythonPath
-    }
-
     # Avoid WARNINGs to fail the package install
     exit 0
 } catch {


### PR DESCRIPTION
Reverts mandiant/VM-Packages#1554

This fix didn't seem to fix the issue as expected: https://github.com/mandiant/VM-Packages/wiki/Daily-Failures

Due to the issue not occurring after a single install, it is a bit more complex to test. It's possible that this is a PIP issue due to multiple `VM-Pip-Install "pip~=23.2.1"` likely occurring.