### PR TITLE
Fix libraries.python3.vm build failures: batch install and pip downgrade

### DIFF
--- a/packages/libraries.python3.vm/libraries.python3.vm.nuspec
+++ b/packages/libraries.python3.vm/libraries.python3.vm.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>libraries.python3.vm</id>
-    <version>0.0.0.20251004</version>
+    <version>0.0.0.20251222</version>
     <description>Python 3 libraries useful for common reverse engineering tasks.</description>
     <authors>Several, check in pypi.org for every of the libraries</authors>
     <dependencies>

--- a/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
+++ b/packages/libraries.python3.vm/tools/chocolateyinstall.ps1
@@ -6,25 +6,52 @@ try {
     $modulesPath = Join-Path $toolDir "modules.xml" -Resolve
     $modulesXml = [xml](Get-Content $modulesPath)
 
-    # Fix pip version
-    VM-Pip-Install "pip~=23.2.1"
+    # Create output file to log python module installation details
+    $outputFile = VM-New-Install-Log ${Env:VM_COMMON_DIR}
+
+    # Fix pip version (Use --no-deps to prevent crashing on existing environment conflicts)
+    Write-Host "[+] Enforcing pip version..."
+    $pipVersion = "pip~=23.2.1"
+    Invoke-Expression "py -3.10 -W ignore -m pip install $pipVersion --disable-pip-version-check --no-deps --force-reinstall 2>&1 >> $outputFile"
+
 
     $failures = @()
+    $pipArgs = @()
     $modules = $modulesXml.modules.module
+
+    Write-Host "Attempting to install the following Python3 modules:"
     foreach ($module in $modules) {
-        Write-Host "[+] Attempting to install Python3 module: $($module.name)"
+        Write-Host "[+] $($module.name)"
         $installValue = $module.name
         if ($module.url) {
             $installValue = $module.url
         }
+        $pipArgs += $installValue
+    }
 
-        VM-Pip-Install $installValue
+    Write-Host "Batch installing Python modules..."
+    $batchInstallString = $pipArgs -join " "
+    VM-Pip-Install $batchInstallString
 
-        if ($LastExitCode -eq 0) {
-            Write-Host "`t[+] Installed Python 3.10 module: $($module.name)" -ForegroundColor Green
+    foreach ($module in $modules) {
+        $pkgName = $module.name
+
+        # Clean up version pins (e.g., "pywin32==308" -> "pywin32") for install check
+        if ($pkgName -match "==") {
+            $pkgName = $pkgName -split "==" | Select-Object -First 1
+        }
+        if ($pkgName -match ">=") {
+            $pkgName = $pkgName -split ">=" | Select-Object -First 1
+        }
+
+        # 'pip show' returns exit code 0 if found, 1 if missing
+        $null = py -3.10 -m pip show $pkgName 2>&1
+
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "`t[!] Failed to install Python 3.10 module:$pkgName" -ForegroundColor Red
+            $failures += $pkgName
         } else {
-            Write-Host "`t[!] Failed to install Python 3.10 module: $($module.name)" -ForegroundColor Red
-            $failures += $module.Name
+            Write-Host "`t[+] Installed Python 3.10 module: $pkgName" -ForegroundColor Green
         }
     }
 
@@ -32,10 +59,15 @@ try {
         foreach ($module in $failures) {
             VM-Write-Log "ERROR" "Failed to install Python 3.10 module: $module"
         }
-        $outputFile = $outputFile.replace('lib\', 'lib-bad\')
-        VM-Write-Log "ERROR" "Check $outputFile for more information"
-        exit 1
+        throw "Package installation failed. The following modules could not be verified: $($failures -join ', ')"
     }
+
+    # Fix issue with chocolately printing incorrect install directory
+    $pythonPath = py -3.10 -c "import sys; print(sys.prefix)" 2>$null
+    if ($pythonPath) {
+        $env:ChocolateyPackageInstallLocation = $pythonPath
+    }
+
     # Avoid WARNINGs to fail the package install
     exit 0
 } catch {


### PR DESCRIPTION
- Switch to batch installation for Python modules to allow pip to resolve shared dependency conflicts (e.g., cryptography vs pyOpenSSL).
- Add '--no-deps' and '--force-reinstall' when pinning pip version to prevent dependency resolver crashes on existing environments. (attempting to fix install issue in `Daily Failures`): https://github.com/mandiant/VM-Packages/wiki/Daily-Failures
- Add dynamic detection of Python install path to fix incorrect Chocolatey log location (Edge/Application false positive).
- Improve error handling and logging for individual module verification.