### PR TITLE
Adding uv 0.10.9

### DIFF
--- a/packages/uv.vm/tools/chocolateyinstall.ps1
+++ b/packages/uv.vm/tools/chocolateyinstall.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'uv'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
+
+$zipUrl = "https://github.com/astral-sh/uv/releases/download/0.10.9/uv-x86_64-pc-windows-msvc.zip"
+$zipSha256 = "f58dc40896000229db7c52b8bdd931394040ef2ad59abd1eda841f6d70b13d7a"
+
+VM-Install-From-Zip $toolName $category $zipUrl -zipSha256 $zipSha256 -consoleApp $true -arguments "--help"

--- a/packages/uv.vm/tools/chocolateyuninstall.ps1
+++ b/packages/uv.vm/tools/chocolateyuninstall.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Continue'
+Import-Module vm.common -Force -DisableNameChecking
+
+$toolName = 'uv'
+$category = VM-Get-Category($MyInvocation.MyCommand.Definition)
+
+VM-Uninstall $toolName $category

--- a/packages/uv.vm/uv.vm.nuspec
+++ b/packages/uv.vm/uv.vm.nuspec
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>uv.vm</id>
+    <version>0.10.9</version>
+    <description>uv is an extremely fast Python package and project manager written in Rust.</description>
+    <authors>Astral</authors>
+    <dependencies>
+      <dependency id="common.vm" version="0.0.0.20250206" />
+    </dependencies>
+    <tags>Python</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Adds uv utility, a blazing fast Python manager with excellent dev ergonomics.

Re: https://github.com/mandiant/VM-Packages/issues/1574

Package passes build and test:

<img width="817" height="135" alt="image" src="https://github.com/user-attachments/assets/89e595aa-738f-444c-8127-fb8f421085b2" />

<img width="803" height="454" alt="image" src="https://github.com/user-attachments/assets/f5e3e747-a1f2-4e07-93ce-f2d698cc0997" />

<img width="493" height="374" alt="image" src="https://github.com/user-attachments/assets/712da9f7-0dc1-4d13-b40b-7937fc4ec5d7" />
