### PR TITLE
ignore nodejs.vm on windows 11 runner

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test all packages
         continue-on-error: true
+        env:
+          MATRIX_OS: ${{ matrix.os }}
         run: scripts/test/test_install.ps1 -package_names "${{ matrix.chunk }}" -all -max_tries 3
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -50,6 +50,9 @@ foreach ($package in $packages) {
 
 
 $exclude_tests = @("installer.vm", "idapro.vm")
+if ($env:MATRIX_OS -eq "windows-2025") {
+    $exclude_tests += "nodejs.vm"
+}
 
 $failures = New-Object Collections.Generic.List[string]
 $failed = 0


### PR DESCRIPTION
`nodejs.vm` still fails on Windows 11 github runner (`windows-2025`) and is causing an issue in our daily packages failure. 

Unfortunately, the error is unable to be caught in testing easily without a brittle string parsing or other not so preferred alternatives.

This PR allows us to just ignore testing `nodejs.vm` on Windows 11 since we know this is a common failure and isn't needed to be installed (for now) due to it already having been installed on the runner.