### PR TITLE
ignore nodejs.vm on windows 11 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         id: test
         # It runs only if there are modified files
         if: steps.files.outputs.added_modified_renamed != ''
+        env:
+          MATRIX_OS: ${{ matrix.os }}
         run: |
           $os = "${{ matrix.os }}"
           $packages = "${{ steps.files.outputs.added_modified_renamed }}".Split(" ") | Foreach-Object { (Get-Item $_).Directory.Name }

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -46,6 +46,8 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Build and test all packages
         continue-on-error: true
+        env:
+          MATRIX_OS: ${{ matrix.os }}
         run: scripts/test/test_install.ps1 -package_names "${{ matrix.chunk }}" -all -max_tries 3
       - name: Upload logs to artifacts
         uses: ./.github/actions/upload-logs

--- a/scripts/test/test_install.ps1
+++ b/scripts/test/test_install.ps1
@@ -42,14 +42,44 @@ if ($package_names) {
     $packages = Get-ChildItem -Path $packages_dir | Select-Object -ExpandProperty Name
 }
 
+$isWin2025 = $env:MATRIX_OS -eq "windows-2025"
+
 foreach ($package in $packages) {
+    if ($package -eq "nodejs.vm" -and $isWin2025) {
+        Write-Host "[WARN] Skipping packing nodejs.vm in loop on windows-2025. We will handle it separately."
+        continue
+    }
     Set-Location "$packages_dir\$package"
     choco pack -y -out $built_pkgs_dir
     if ($LASTEXITCODE -ne 0) { Exit 1 } # Abort with the first failing build
 }
 
+# Special handling for nodejs.vm on windows-2025
+if ($isWin2025) {
+    Write-Host "Detected Windows Server 2025. Preparing modified nodejs.vm to satisfy dependencies..."
+    $nodejs_dir = "$packages_dir\nodejs.vm"
+    $nuspec_path = "$nodejs_dir\nodejs.vm.nuspec"
+
+    if (Test-Path $nuspec_path) {
+        $nuspec_content = Get-Content $nuspec_path
+        # Remove line with id="nodejs"
+        $new_content = $nuspec_content | Where-Object { $_ -notmatch 'id="nodejs"' }
+
+        $backup_path = "$nuspec_path.bak"
+        Copy-Item $nuspec_path $backup_path -Force
+        $new_content | Out-File -FilePath $nuspec_path -Encoding utf8
+
+        Push-Location $nodejs_dir
+        choco pack -y -out $built_pkgs_dir
+        Pop-Location
+
+        Move-Item $backup_path $nuspec_path -Force
+    }
+}
+
 
 $exclude_tests = @("installer.vm", "idapro.vm")
+
 
 $failures = New-Object Collections.Generic.List[string]
 $failed = 0
@@ -58,35 +88,9 @@ $success = 0
 $built_pkgs = Get-ChildItem $built_pkgs_dir | Foreach-Object { ([regex]::match($_.BaseName, '(.*?[.](?:vm)).*').Groups[1].Value) } | Where-Object { $_ -notin $exclude_tests }
 Set-Location $built_pkgs_dir
 foreach ($package in $built_pkgs) {
-    # Check if the package depends on nodejs.vm by reading its nuspec
-    $nuspecPath = "$packages_dir\$package\$package.nuspec"
-    $dependsOnNode = $false
-    if (Test-Path $nuspecPath) {
-        $dependsOnNode = Get-Content $nuspecPath | Select-String -Pattern "nodejs.vm" -Quiet
-    }
 
     # We try to install the package several times (with a minute interval) to prevent transient failures
     for ($tries = 1; $tries -le $max_tries; $tries += 1) {
-        # On the last try, if it depends on node, repack it without nodejs.vm!
-        if ($tries -eq $max_tries -and $dependsOnNode) {
-            Write-Host -ForegroundColor Yellow "[WARN] Last try for Node tool $package. Repacking without nodejs.vm for testing..."
-
-            $source_dir = "$packages_dir\$package"
-            $nuspec_content = Get-Content $nuspecPath
-
-            # Filter out the nodejs.vm dependency line
-            $new_content = $nuspec_content | Where-Object { $_ -notmatch 'id="nodejs.vm"' }
-
-            $backupPath = "$nuspecPath.bak"
-            Copy-Item $nuspecPath $backupPath -Force
-            $new_content | Out-File -FilePath $nuspecPath -Encoding utf8
-
-            Push-Location $source_dir
-            choco pack -y -out $built_pkgs_dir
-            Pop-Location
-
-            Move-Item $backupPath $nuspecPath -Force
-        }
 
         # install looks for a nuspec with the same version as the installed one
         # upgrade installs the last found version (even if the package is not installed)


### PR DESCRIPTION
`nodejs.vm` still fails on Windows 11 github runner (windows-2025) and is causing an issue in our daily packages failure.

Unfortunately, the error is unable to be caught in testing easily without a brittle string parsing or other not so preferred alternatives. Attempting to just ignore installing `nodejs.vm` also fails due to other packages depending on it being installed, forcing it to run the installer.

This PR allows us to bypass installing `nodejs` (but still allowing completion of installing `nodejs.vm`) on Windows 11 since we know this is a common failure and isn't needed to be installed (for now) due to it already having been installed on the runner.

Confirmation of working run: https://github.com/mandiant/VM-Packages/actions/runs/24363608891